### PR TITLE
Remove index counter in Holoscan source operators for radar and SDR examples

### DIFF
--- a/applications/sdr_fm_demodulation/sdr_fm_demodulation.py
+++ b/applications/sdr_fm_demodulation/sdr_fm_demodulation.py
@@ -93,7 +93,6 @@ class SignalGeneratorOp(Operator):
 
     def __init__(self, *args, **kwargs):
         # Need to call the base class constructor last
-        self.index = 0
         super().__init__(*args, **kwargs)
 
     def setup(self, spec: OperatorSpec):
@@ -103,7 +102,6 @@ class SignalGeneratorOp(Operator):
         #sig = cp.random.randn(5120) + 1j*cp.random.randn(5120)
         sdr.readStream(rx, [buffer], buffer_size, timeoutUs=int(8e12))
         op_output.emit(cp.asarray(buffer.astype(cp.complex64)), "rx_sig")
-        self.index += 1
 
 
 class DemodulateOp(Operator):

--- a/applications/simple_radar_pipeline/python/simple_radar_pipeline.py
+++ b/applications/simple_radar_pipeline/python/simple_radar_pipeline.py
@@ -76,7 +76,6 @@ class SignalGeneratorOp(Operator):
 
     def __init__(self, *args, **kwargs):
         # Need to call the base class constructor last
-        self.index = 0
         super().__init__(*args, **kwargs)
 
     def setup(self, spec: OperatorSpec):
@@ -91,8 +90,6 @@ class SignalGeneratorOp(Operator):
 
         op_output.emit(x, "x")
         op_output.emit(waveform, "waveform")
-
-        self.index += 1
 
 
 class PulseCompressionOp(Operator):


### PR DESCRIPTION
`self.index = 0` and `self.index += 1` are not needed in the source operators for either the SDR or RADAR example.