### PR TITLE
Advanced network operator

### DIFF
--- a/applications/adv_networking_bench/CMakeLists.txt
+++ b/applications/adv_networking_bench/CMakeLists.txt
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory(cpp)

--- a/applications/adv_networking_bench/cpp/CMakeLists.txt
+++ b/applications/adv_networking_bench/cpp/CMakeLists.txt
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.20)
+project(adv_networking_bench CXX)
+
+find_package(holoscan 0.5 REQUIRED CONFIG
+             PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+
+find_package(PkgConfig REQUIRED)
+        
+add_executable(adv_networking_bench
+  main.cpp
+)
+
+target_link_libraries(adv_networking_bench
+  PRIVATE
+  holoscan::core
+  holoscan::advanced_network
+)
+
+# Copy config file
+add_custom_target(adv_networking_bench_rx_yaml
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/adv_networking_bench_rx.yaml" ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/adv_networking_bench_rx.yaml"
+)
+add_custom_target(adv_networking_bench_tx_yaml
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/adv_networking_bench_tx.yaml" ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/adv_networking_bench_tx.yaml"
+)
+
+add_dependencies(adv_networking_bench adv_networking_bench_rx_yaml adv_networking_bench_tx_yaml)
+
+

--- a/applications/adv_networking_bench/cpp/README.md
+++ b/applications/adv_networking_bench/cpp/README.md
@@ -1,0 +1,80 @@
+# Advanced Networking Benchmark
+
+This is a simple application to measure a lower bound on performance for the advanced networking operator
+by receiving packets, optionally doing work on them, and freeing the buffers. While only freeing the packets is
+an unrealistic workload, it's useful to see at a high level whether the application is able to keep up with
+the bare minimum amount of work to do. The application contains both a transmitter and receiver that are
+designed to run on different systems, and may be configured independently.
+
+The performance of this application depends heavily on a properly-configured system and choosing the best
+tuning parameters that are acceptable for the workload. To configure the system please see the documentation
+for the advanced network operator. With the system tuned, the application performance will be dictated
+by batching size and whether GPUDirect is enabled. 
+
+At this time both the transmitter and receiver are written to handle an Ethernet+IP+UDP packet with a
+configurable payload. Other modes may be added in the future. Also, for simplicity, the transmitter and
+receiver must be configured to a single packet size.
+
+## Transmit
+
+The transmitter sends a UDP packet with an incrementing sequence of bytes after the UDP header. The batch
+size configured dictates how many packets the benchmark operator sends to the advanced network operator
+in each tick. Typically with the same number of CPU cores the transmitter will run faster than the receiver, 
+so this parameter may be used to throttle the sender somewhat by making the batches very small.
+
+## Receiver
+
+The receiver receives the UDP packets in either CPU-only mode or header-data split mode. CPU-only mode
+will receive the packets in CPU memory, copy the payload contents to a host-pinned staging buffer, and
+freed. In header-data split mode the user may configure a split point where the bytes before that point
+are sent to the CPU, and all bytes afterwards are sent to the GPU. Header-data split should achieve higher
+rates than CPU mode since the amount of data to the CPU can be orders of magnitude lower compared to running
+in CPU-only mode. 
+
+### Configuration
+
+The application is configured using a separate transmit and receive file. The transmit file is called
+`adv_networking_bench_tx.yaml` while the receive is named `adv_networking_bench_rx.yaml`. Configure the
+advanced networking operator on both transmit and receive per the instructions for that operator.
+
+#### Receive Configuration
+
+- `header_data_split`: bool
+  Turn on GPUDirect header-data split mode
+- `batch_size`: integer
+  Size in packets for a single batch. This should be a multiple of the advanced network RX operator batch size.
+  A larger batch size consumes more memory since any work will not start unless this batch size is filled. Consider
+  reducing this value if errors are occurring.
+- `max_packet_size`: integer
+  Maximum packet size expected. This value includes all headers up to and including UDP.
+
+#### Transmit Configuration
+
+- `batch_size`: integer
+  Size in packets for a single batch. This batch size is used to send to the advanced network TX operator, and 
+  will loop sending that many packets for each burst.
+- `payload_size`: integer
+  Size of the payload to send after all L2-L4 headers 
+
+### Requirements
+
+This application requires all configuration and requirements from the advanced network operator.
+
+### Build Instructions
+
+Please refer to the top level Holohub README.md file for information on how to build this application.
+
+### Run Instructions
+
+First, go in your `build` or `install` directory, then for the transmitter run:
+
+
+```bash
+./build/applications/adv_networking_bench/cpp/adv_networking_bench adv_networking_bench_tx.yaml
+```
+
+Or for the receiver:
+
+```bash
+./build/applications/adv_networking_bench/cpp/adv_networking_bench adv_networking_bench_tx.yaml
+```

--- a/applications/adv_networking_bench/cpp/adv_networking_bench_rx.yaml
+++ b/applications/adv_networking_bench/cpp/adv_networking_bench_rx.yaml
@@ -1,0 +1,56 @@
+%YAML 1.2
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+extensions:
+  - libgxf_std.so
+
+advanced_network:
+  cfg:
+    version: 1
+    master_core: 5                  # Master CPU core
+    rx:
+      - if_name: 0005:03:00.1       # PCIe BFD of NIC
+        flow_isolation: true
+        queues:
+          - name: "Default"
+            id: 0
+            gpu_direct: false
+            cpu_cores: "7"
+            max_packet_size: 9000        # Maximum payload size
+            num_concurrent_batches: 32767   # Number of batches that can be used at any time
+            batch_size: 1              # Number of packets in a batch               
+          - name: "ADC Samples"
+            id: 1
+            gpu_device: 0
+            gpu_direct: true
+            split_boundary: 42
+            cpu_cores: "6"
+            max_packet_size: 9000     # Maximum payload size
+            num_concurrent_batches: 20   # Number of batches that can be used at any time
+            batch_size: 1000              # Number of packets in a batch      
+        flows:
+          - name: "ADC Samples"
+            action: 
+              type: queue
+              id: 1
+            match:
+              udp_src: 4096
+              udp_dst: 4096    
+
+bench_rx:
+  split_boundary: true
+  batch_size: 10000
+  max_packet_size: 7680

--- a/applications/adv_networking_bench/cpp/adv_networking_bench_tx.yaml
+++ b/applications/adv_networking_bench/cpp/adv_networking_bench_tx.yaml
@@ -1,0 +1,43 @@
+%YAML 1.2
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+extensions:
+  - libgxf_std.so
+
+advanced_network:
+  cfg:
+    version: 1
+    master_core: 5              # Master CPU core
+    tx:
+      - if_name: 03:00.0       # PCIe BFD of NIC  
+        queues:
+          - name: "ADC Samples"
+            id: 0
+            gpu_direct: false
+            max_packet_size: 8000          # Maximum payload size
+            num_concurrent_batches: 5      # Number of batches that can be used at any time
+            batch_size: 10240              # Number of packets in a batch      
+            fill_type: "udp"                    # Highest layer that network operator should populate
+            eth_dst_addr: "48:B0:2D:D9:30:A2"   # Destination MAC to populate
+            ip_src_addr: "192.168.1.2"          # Source IP send from
+            ip_dst_addr: "192.168.10.1"         # Destination IP to send to
+            udp_dst_port: 4096                  # UDP destination port
+            udp_src_port: 4096                  # UDP source port
+            cpu_cores: "7"                      # CPU cores for transmitting          
+
+bench_tx:
+  batch_size: 10000
+  payload_size: 7680                  # + 42 bytes of <= L4 headers to get 1280 max

--- a/applications/adv_networking_bench/cpp/main.cpp
+++ b/applications/adv_networking_bench/cpp/main.cpp
@@ -1,0 +1,282 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "adv_network_rx.h"
+#include "adv_network_tx.h"
+#include "adv_network_kernels.h"
+#include "holoscan/holoscan.hpp"
+#include <linux/if_ether.h>
+#include <linux/ip.h>
+#include <linux/udp.h>
+#include <arpa/inet.h>
+#include <assert.h>
+
+
+namespace holoscan::ops {
+
+// Example IPV4 UDP packet using Linux headers
+struct UDPIPV4Pkt {
+  struct ethhdr eth;
+  struct iphdr ip;
+  struct udphdr udp;
+  uint8_t payload[];
+} __attribute__((packed));
+
+class AdvNetworkingBenchTxOp : public Operator {
+ public:
+  HOLOSCAN_OPERATOR_FORWARD_ARGS(AdvNetworkingBenchTxOp)
+
+  AdvNetworkingBenchTxOp() = default;
+
+  void initialize() override {
+    HOLOSCAN_LOG_INFO("AdvNetworkingBenchTxOp::initialize()");
+    holoscan::Operator::initialize();
+
+    size_t buf_size = batch_size_.get() * payload_size_.get();
+    cudaMallocHost(&full_batch_data_h_, buf_size);
+
+    // Fill in with increasing bytes
+    uint8_t *cptr = static_cast<uint8_t*>(full_batch_data_h_);
+    uint8_t cur = 0;
+    for (int b = 0; b < buf_size; b++) {
+      cptr[b] = cur++;
+    }
+
+    HOLOSCAN_LOG_INFO("AdvNetworkingBenchTxOp::initialize() complete");
+  }
+
+  void setup(OperatorSpec& spec) override {
+    spec.output<AdvNetBurstParams>("burst_out");
+
+    spec.param<uint32_t>(batch_size_, "batch_size", "Batch size",
+      "Batch size for each processing epoch", 1000);
+    spec.param<uint16_t>(payload_size_, "payload_size", "Payload size",
+      "Payload size to send. Does not include <= L4 headers", 1400);
+  }
+
+  void compute(InputContext&, OutputContext& op_output, ExecutionContext&) override {
+    AdvNetStatus ret;
+
+    /**
+     * Spin waiting until a buffer is free. This can be stalled by sending faster than the NIC can handle it. We
+     * expect the transmit operator to operate much faster than the receiver since it's not having to do any work
+     * to construct packets, and just copying from a buffer into memory.
+    */
+    while (!adv_net_tx_burst_available(batch_size_.get())) {}
+
+    auto msg = CreateSharedBurstParams();
+    adv_net_set_hdr(msg, port_id, queue_id, batch_size_);
+
+    if ((ret = adv_net_get_tx_pkt_burst(msg)) != AdvNetStatus::SUCCESS) {
+      HOLOSCAN_LOG_ERROR("Error returned from adv_net_get_tx_pkt_burst: {}", static_cast<int>(ret));
+      return;
+    }
+
+    void *pkt;
+    for (int num_pkt = 0; num_pkt < msg->hdr.num_pkts; num_pkt++) {
+      if ((ret = adv_net_set_cpu_udp_payload( msg,
+                                              num_pkt,
+                                              static_cast<char*>(full_batch_data_h_) +
+                                                    num_pkt * payload_size_.get(),
+                                              payload_size_.get())) != AdvNetStatus::SUCCESS) {
+        HOLOSCAN_LOG_ERROR("Failed to create packet {}", num_pkt);
+      }
+    }
+
+    op_output.emit(msg, "burst_out");
+  };
+
+ private:
+  void *full_batch_data_h_;
+  static constexpr uint16_t port_id = 0;
+  static constexpr uint16_t queue_id = 0;
+  Parameter<uint32_t> batch_size_;
+  Parameter<uint16_t> payload_size_;
+};
+
+class AdvNetworkingBenchRxOp : public Operator {
+ public:
+  HOLOSCAN_OPERATOR_FORWARD_ARGS(AdvNetworkingBenchRxOp)
+
+  AdvNetworkingBenchRxOp() = default;
+
+  ~AdvNetworkingBenchRxOp() {
+    HOLOSCAN_LOG_INFO("Finished receiver with {}/{} bytes/packets received",
+        ttl_bytes_recv_, ttl_pkts_recv_);
+  }
+
+  void initialize() override {
+    HOLOSCAN_LOG_INFO("AdvNetworkingBenchRxOp::initialize()");
+    holoscan::Operator::initialize();
+
+    // For this example assume all packets are the same size, specified in the config
+    nom_payload_size_ = max_packet_size_.get() - sizeof(UDPIPV4Pkt);
+
+    cudaMallocHost(&full_batch_data_h_, batch_size_.get() * nom_payload_size_);
+    cudaMalloc(&full_batch_data_d_,     batch_size_.get() * nom_payload_size_);
+
+    if (hds_.get()) {
+      cudaMallocHost((void**)&h_dev_ptrs_, sizeof(void*) * batch_size_.get());
+    }
+
+    HOLOSCAN_LOG_INFO("AdvNetworkingBenchRxOp::initialize() complete");
+  }
+
+  void setup(OperatorSpec& spec) override {
+    spec.input<AdvNetBurstParams>("burst_in");
+    spec.param<bool>(hds_, "split_boundary", "Header-data split boundary",
+        "Byte boundary where header and data is split", false);
+    spec.param<uint32_t>(batch_size_, "batch_size", "Batch size",
+        "Batch size in packets for each processing epoch", 1000);
+    spec.param<uint16_t>(max_packet_size_, "max_packet_size",
+        "Max packet size", "Maximum packet size expected from sender", 9100);
+  }
+
+  void compute(InputContext& op_input, OutputContext&, ExecutionContext& context) override {
+    int64_t ttl_bytes_in_cur_batch_   = 0;
+    auto burst                        = op_input.receive<AdvNetBurstParams>("burst_in");
+    ttl_pkts_recv_                    += adv_net_get_num_pkts(burst);
+
+    // If packets are coming in from our non-GPUDirect queue, free them and move on
+    if (burst->hdr.q_id == 0) {
+      adv_net_free_cpu_pkts_and_burst(burst);
+      HOLOSCAN_LOG_INFO("Freeing CPU packets on queue 0");
+      return;
+    }
+
+    /* Header data split saves off the GPU pointers into a host-pinned buffer to reassemble later.
+     * Once enough packets are aggregated, a reorder kernel is launched. In CPU-only mode the
+     * entire burst buffer pointer is saved and freed once an entire batch is received.
+     */
+    if (hds_.get()) {
+      int64_t bytes_in_batch = 0;
+      for (int p = 0; p < adv_net_get_num_pkts(burst); p++) {
+        h_dev_ptrs_[aggr_pkts_recv_ + p]   = adv_net_get_gpu_pkt_ptr(burst, p);
+        ttl_bytes_in_cur_batch_           +=
+          adv_net_get_gpu_packet_len(burst, p) + sizeof(UDPIPV4Pkt);
+      }
+
+      ttl_bytes_recv_ += ttl_bytes_in_cur_batch_;
+    } else {
+      auto batch_offset =  aggr_pkts_recv_ * nom_payload_size_;
+      for (int p = 0; p < adv_net_get_num_pkts(burst); p++) {
+        auto pkt = static_cast<UDPIPV4Pkt*>(adv_net_get_cpu_pkt_ptr(burst, p));
+        auto len = ntohs(pkt->udp.len) - 8;
+
+        // assert(len + sizeof(UDPIPV4Pkt) == max_packet_size_.get());
+
+        memcpy((char*)full_batch_data_h_ + batch_offset + p * nom_payload_size_,
+            pkt->payload, len);
+
+        ttl_bytes_recv_ += len + sizeof(UDPIPV4Pkt);
+        ttl_bytes_in_cur_batch_ += len + sizeof(UDPIPV4Pkt);
+      }
+    }
+
+    burst_bufs_[burst_buf_idx_++] = burst;
+    aggr_pkts_recv_ += adv_net_get_num_pkts(burst);
+
+    if (aggr_pkts_recv_ >= batch_size_.get()) {
+      // Do some work on full_batch_data_h_ or full_batch_data_d_
+      aggr_pkts_recv_ = 0;
+
+      if (hds_.get()) {
+        simple_packet_reorder(static_cast<uint8_t*>(full_batch_data_d_), h_dev_ptrs_,
+                      nom_payload_size_, batch_size_.get());
+        if (cudaGetLastError() != cudaSuccess)  {
+          HOLOSCAN_LOG_ERROR("CUDA error with {} packets in batch and {} bytes total",
+                  batch_size_.get(), batch_size_.get()*nom_payload_size_);
+          exit(1);
+        }
+
+        for (int b = 0; b < burst_buf_idx_; b++) {
+          adv_net_free_all_burst_pkts_and_burst(burst_bufs_[b]);
+        }
+      } else {
+        for (int b = 0; b < burst_buf_idx_; b++) {
+          adv_net_free_cpu_pkts_and_burst(burst_bufs_[b]);
+        }
+      }
+
+      burst_buf_idx_ = 0;
+    }
+  }
+
+ private:
+  // Holds burst buffers that cannot be freed yet
+  std::array<std::shared_ptr<AdvNetBurstParams>, 256> burst_bufs_;
+  int     burst_buf_idx_ = 0;                // Index into burst_buf_idx_ of current burst
+  int64_t ttl_bytes_recv_ = 0;               // Total bytes received in operator
+  int64_t ttl_pkts_recv_ = 0;                // Total packets received in operator
+  int64_t aggr_pkts_recv_ = 0;               // Aggregate packets received in processing batch
+  uint16_t nom_payload_size_;                // Nominal payload size (no headers)
+  void **h_dev_ptrs_;                        // Host-pinned list of device pointers
+  void *full_batch_data_h_;                  // Host-pinned aggregated batch
+  void *full_batch_data_d_;                  // Device aggregated batch
+  Parameter<bool> hds_;                      // Header-data split enabled
+  Parameter<uint32_t> batch_size_;           // Batch size for one processing block
+  Parameter<uint16_t> max_packet_size_;      // Maximum size of a single packet
+};
+
+}  // namespace holoscan::ops
+
+class App : public holoscan::Application {
+ public:
+  void compose() override {
+    using namespace holoscan;
+
+    HOLOSCAN_LOG_INFO("Initializing advanced network operator");
+    const auto [rx_en, tx_en] = holoscan::ops::adv_net_get_rx_tx_cfg_en(config());
+
+    if (rx_en) {
+      auto bench_rx     = make_operator<ops::AdvNetworkingBenchRxOp>("bench_rx",
+                                                                      from_config("bench_rx"));
+      auto adv_net_rx   = make_operator<ops::AdvNetworkOpRx>("adv_network_rx",
+                                              from_config("advanced_network"),
+                                              make_condition<BooleanCondition>("is_alive", true));
+      add_flow(adv_net_rx, bench_rx, {{"burst_out", "burst_in"}});
+    }
+    if (tx_en) {
+      auto bench_tx       = make_operator<ops::AdvNetworkingBenchTxOp>("bench_tx",
+                                              from_config("bench_tx"),
+                                              make_condition<BooleanCondition>("is_alive", true));
+      auto adv_net_tx     = make_operator<ops::AdvNetworkOpTx>("adv_network_tx",
+                                                              from_config("advanced_network"));
+      add_flow(bench_tx, adv_net_tx, {{"burst_out", "burst_in"}});
+    }
+  }
+};
+
+int main(int argc, char** argv) {
+  holoscan::load_env_log_level();
+
+  auto app = holoscan::make_application<App>();
+
+  // Get the configuration
+  if (argc < 2) {
+    HOLOSCAN_LOG_ERROR("Usage: {} config_file", argv[0]);
+    return -1;
+  }
+
+  auto config_path = std::filesystem::canonical(argv[0]).parent_path();
+  config_path += "/" + std::string(argv[1]);
+  app->config(config_path);
+
+  app->run();
+
+  return 0;
+}

--- a/applications/adv_networking_bench/cpp/metadata.json
+++ b/applications/adv_networking_bench/cpp/metadata.json
@@ -1,0 +1,35 @@
+{
+	"application": {
+		"name": "Advanced Networking Benchmark",
+		"authors": [
+			{
+				"name": "Cliff Burdick",
+				"affiliation": "NVIDIA"
+			}
+		],
+		"language": "CPP",
+		"version": "1.0",
+		"changelog": {
+			"1.0": "Initial Release"
+		},
+		"platforms": ["amd64", "arm64"],
+		"tags": ["Network", "Networking", "DPDK", "UDP", "Ethernet", "IP", "GPUDirect", "RDMA"],
+		"holoscan_sdk": {
+			"minimum_required_version": "0.5.0",
+			"tested_versions": [
+				"0.5.0"
+			]
+		},
+		"ranking": 1,
+		"dependencies": {
+			"gxf_extensions": [{
+				"name": "advanced_networking_benchmark",
+				"version": "1.0"
+			}]
+		},
+		"run": {
+			"command": "<holohub_app_bin>/adv_networking_bench",
+			"workdir": "holohub_bin"
+		}
+	}
+}

--- a/operators/advanced_network/CMakeLists.txt
+++ b/operators/advanced_network/CMakeLists.txt
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+cmake_minimum_required(VERSION 3.20)
+project(advanced_network)
+
+find_package(holoscan 0.5 REQUIRED CONFIG
+             PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+find_package(PkgConfig)
+
+enable_language(CUDA)
+
+add_library(advanced_network SHARED
+  adv_network_rx.cpp
+  adv_network_tx.cpp
+  adv_network_common.cpp
+  adv_network_kernels.cu
+  adv_network_dpdk_mgr.cpp
+)
+
+add_library(holoscan::advanced_network ALIAS advanced_network)
+
+######## DPDK Configuration ########
+# Set this to wherever your DPDK installation was built if not in a standard location. this
+# can be removed if it was installed globally.
+#set(DPDK_OUTPUT_PATH /tmp/dpdk-22.11/out)
+#set(ENV{PKG_CONFIG_PATH} "${DPDK_OUTPUT_PATH}/lib/aarch64-linux-gnu/pkgconfig")
+
+set(DPDK_EXTRA_LIBS -Wl,--no-whole-archive -lmlx5 -libverbs -pthread -lnuma -ldl)
+
+pkg_check_modules(DPDK REQUIRED libdpdk)
+
+target_include_directories(advanced_network INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_options(advanced_network PUBLIC ${DPDK_CFLAGS})
+target_link_libraries(advanced_network holoscan::core ${DPDK_EXTRA_LIBS} ${DPDK_LIBRARIES})
+
+
+

--- a/operators/advanced_network/Dockerfile
+++ b/operators/advanced_network/Dockerfile
@@ -1,0 +1,42 @@
+FROM nvcr.io/nvidia/clara-holoscan/holoscan:v0.5.0 
+
+ARG HOLOHUB_DIR=/opt/holohub-internal
+ARG OFED_VERSION=5.8-1.0.1.1
+ARG UBUNTU_VERSION=20.04
+ARG ADV_NET_DIR=holohub-internal/operators/advanced_network/
+RUN wget http://www.mellanox.com/downloads/ofed/MLNX_OFED-$OFED_VERSION/MLNX_OFED_LINUX-$OFED_VERSION-ubuntu$UBUNTU_VERSION-aarch64.tgz && \
+        tar xvf MLNX_OFED_LINUX-$OFED_VERSION-ubuntu$UBUNTU_VERSION-aarch64.tgz && \
+        cd MLNX_OFED_LINUX-$OFED_VERSION-ubuntu$UBUNTU_VERSION-aarch64 && \
+        ./mlnxofedinstall --upstream-libs --dpdk --with-mft --upstream-libs --user-space-only --force --without-fw-update && \
+        cd ../ && \
+        rm -fr MLNX_OFED_LINUX-$OFED_VERSION-ubuntu$UBUNTU_VERSION-aarch64 && \
+        rm -rf /var/lib/apt/lists/*
+
+ARG DPDK_VERSION=22.11.1
+RUN apt update && apt install -y python3-pyelftools ninja-build meson 
+
+ADD https://fast.dpdk.org/rel/dpdk-${DPDK_VERSION}.tar.xz /tmp/
+RUN cd /tmp && tar xf dpdk-${DPDK_VERSION}.tar.xz
+COPY ${ADV_NET_DIR}/dpdk_patches/*.patch /tmp/dpdk-stable-${DPDK_VERSION}
+WORKDIR /tmp/dpdk-stable-${DPDK_VERSION}/
+RUN patch --ignore-whitespace --fuzz 3  config/arm/meson.build /tmp/dpdk-stable-${DPDK_VERSION}/dpdk.nvidia.patch 
+RUN patch --ignore-whitespace --fuzz 3  drivers/gpu/cuda/devices.h /tmp/dpdk-stable-${DPDK_VERSION}/devices.h.patch
+RUN patch --ignore-whitespace --fuzz 3  drivers/gpu/cuda/cuda.c /tmp/dpdk-stable-${DPDK_VERSION}/cuda.c.patch
+RUN CFLAGS=-I/usr/local/cuda/include meson build -Dplatform=generic -Dc_args=-I/usr/local/cuda/include \
+          -Ddisabled_drivers=baseband/*,bus/ifpga/*,common/cpt,common/dpaax,common/iavf,common/octeontx,common/octeontx2,crypto/nitrox,net/ark,net/atlantic,net/avp,net/axgbe,net/bnx2x,net/bnxt,net/cxgbe,net/e1000,net/ena,net/enic,net/fm10k,net/hinic,net/hns3,net/i40e,net/ixgbe,vdpa/ifc,net/igc,net/liquidio,net/netvsc,net/nfp,net/qede,net/sfc,net/thunderx,net/vdev_netvsc,net/vmxnet3,regex/octeontx2,
+RUN ninja -C build install
+RUN /tmp/dpdk-${DPDK_VERSION}.tar.xz
+
+ADD holohub-internal ${HOLOHUB_DIR}
+WORKDIR ${HOLOHUB_DIR}
+RUN ls -lart ${HOLOHUB_DIR}
+RUN ./run build advanced_network
+
+WORKDIR /tmp/
+ARG NATS_VER=v2.9.8
+RUN wget https://github.com/nats-io/nats-server/releases/download/${NATS_VER}/nats-server-${NATS_VER}-arm64.deb && \
+        dpkg -i nats-server-${NATS_VER}-arm64.deb
+RUN rm /tmp/nats-server-${NATS_VER}-arm64.deb
+
+RUN pip3 install scipy plotly plotly_express matplotlib dash dash_bootstrap_components nats-py loguru attrs
+

--- a/operators/advanced_network/README
+++ b/operators/advanced_network/README
@@ -1,0 +1,345 @@
+### Advanced Network Operator
+
+The Advanced Network Operator provides a way for users to achieve the highest throughput and lowest latency 
+for transmitting and receiving Ethernet frames out of and into their operators. Direct access to the NIC hardware
+is available in userspace using this operator, thus bypassing the kernel's networking stack entirely. With a 
+properly tuned system the advanced network operator can achieve hundreds of Gbps with latencies in the low 
+microseconds. Performance is highly dependent on system tuning, packet sizes, batch sizes, and other factors. 
+The data may optionally be sent to the GPU using GPUDirect to prevent extra copies to and from the CPU.
+
+Since the kernel's networking stack is bypassed, the user is responsible for defining the protocols used
+over the network. In most cases Ethernet, IP, and UDP are ideal for this type of processing because of their 
+simplicity, but any type of protocol can be implemented or used. The advanced network operator
+gives the option to use several primitives to remove the need for filling out these headers for basic packet types, 
+but raw headers can also be constructed.
+
+#### Requirements
+
+- Linux
+- A DPDK-compatible network card. For GPUDirect only NVIDIA NICs are supported
+- System tuning as described below
+- DPDK 22.11 installed with gpudev support compiled in
+- MOFED 5.8-1.0.1.1 or later
+
+#### Features
+
+- **High Throughput**: Hundreds of gigabits per second is possible with the proper hardware
+- **Low Latency**: With direct access to the NIC's ring buffers, most latency incurred is only PCIe latency
+- **GPUDirect**: Optionally send data directly from the NIC to GPU, or directly from the GPU to NIC. GPUDirect has two modes:
+  - Header-data split: Split the header portion of the packet to the CPU and the rest (payload) to the GPU. The split point is
+    configurable by the user. This option should be the preferred method in most cases since it's easy to use and still
+    gives near peak performance.
+  - Batched GPU: Receive batches of whole packets directly into the GPU memory. This option requires the GPU kernel to inspect
+    and determine how to handle packets. While performance may increase slightly over header-data split, this method
+    requires more effort and should only be used for advanced users.
+- **Flow Configuration**: Configure the NIC's hardware flow engine for configurable patterns. Currently only UDP source
+    and destination are supported.
+
+#### Limitations
+
+The limitations below will be removed in a future release.
+
+- GPUDirect only works in the RX direction. TX will come in a future release
+- GPUDirect only supports header-data split mode
+- Only a single RX and TX DPDK core have been tested
+- Only UDP fill mode is supported
+
+#### Implementation
+
+Internally the advanced network operator is implemented using DPDK. DPDK is an open-source userspace packet processing
+library supported across platforms and vendors. While the DPDK interface is abstracted away from users of the
+advanced network operator, the method in which DPDK integrates with Holoscan is important for understanding 
+how to achieve the highest performance and for debugging. 
+
+When the advanced network operator is compiled/linked against a Holoscan application, an instance of the DPDK manager
+is created, waiting to accept configuration. When either an RX or TX advanced network operator is defined in a 
+Holoscan application, their configuration is sent to the DPDK manager. Once all advanced network operators have initialized,
+the DPDK manager is told to initialize DPDK. At this point the NIC is configured using all parameters given by the operators. 
+This step allocates all packet buffers, initializes the queues on the NIC, and starts the appropriate number of internal 
+threads. The job of the internal threads is to take packets off or put packets onto the NIC as fast as possible. They
+act as a proxy between the advanced network operators and DPDK by handling packets faster than the operators may be
+able to.
+
+To achieve zero copy throughout the whole pipeline only pointers are passed between each entity above. When the user
+receives the packets from the network operator it's using the same buffers that the NIC wrote to either CPU or GPU 
+memory. This architecture also implies that the user must explicitly decide when to free any buffers it's owning.
+Failure to free buffers will result in errors in the advanced network operators not being able to allocate buffers.
+
+#### System Tuning
+
+From a high level, tuning the system for a low latency workload prevents latency spikes large enough to cause anomalies
+in the application. This section details how to perform the basic tuning steps needed on both a Clara AGX and Orin IGX systems.
+
+##### Create Hugepages
+
+Hugepages give the kernel access to a larger page size than the default (usually 4K) which reduces the number of memory 
+translations that have to be actively maintained in MMUs. 1GB hugepages are ideal, but 2MB may be used as well if 1GB is not
+available. To configure 1GB hugepages:
+
+```
+mkdir /mnt/huge
+mount -t hugetlbfs nodev /mnt/huge
+sudo sh -c "echo nodev /mnt/huge hugetlbfs pagesize=1GB 0 0 >> /etc/fstab"
+```
+
+##### Linux Boot Command Line
+
+The Linux boot command line allows configuration to be injected into Linux before booting. Some configuration options are
+only available at the boot command since they must be provided before the kernel has started. On the Clara AGX and Orin IGX
+editing the boot command can be done with the following configuration:
+
+```
+vim /boot/extlinux/extlinux.conf
+# Find the line starting with APPEND and add the following
+
+# For Orin IGX:
+isolcpus=6-11 nohz_full=6-11 irqaffinity=0-5 rcu_nocbs=6-11 rcu_nocb_poll tsc=reliable audit=0 nosoftlockup default_hugepagesz=1G hugepagesz=2M hugepages=2
+
+# For Clara AGX:
+isolcpus=4-7 nohz_full=4=7 irqaffinity=0-3 rcu_nocbs=4-7 rcu_nocb_poll tsc=reliable audit=0 nosoftlockup default_hugepagesz=1G hugepagesz=1G hugepages=2
+```
+
+The settings above isolate CPU cores 6-11 on the Orin and 4-7 on the Clara, and turn 1GB hugepages on.
+
+##### Setting the CPU governor
+
+The CPU governor reduces power consumption by decreasing the clock frequency of the CPU when cores are idle. While this is useful
+in most environments, increasing the clocks from an idle period can cause long latency stalls. To disable frequency scaling:
+
+```
+sudo apt install cpufrequtils
+sudo sed -i 's/^GOVERNOR=.*/GOVERNOR="performance"/' /etc/init.d/cpufrequtils
+```
+
+Reboot the system after these changes.
+
+##### Permissions
+
+DPDK typically requires running as a root user. If you wish to run as a non-root user, you may follow the directions here:
+http://doc.dpdk.org/guides/linux_gsg/enable_func.html
+
+If running in a container, you will need to run in privileged container, and mount your hugepages mount point from above into the container. This
+can be done as part of the `docker run` command by adding the following flags:
+
+```
+-v /mnt/huge:/mnt/huge \
+--privileged \
+```        
+
+#### Configuration Parameters
+
+The advanced network operator contains a separate operator for both transmit and receive. This allows applications to choose
+whether they need to handle bidirectional traffic or only unidirectional. Transmit and receive are configured separately in
+a YAML file, and a common configuration contains items used by both directions. Each configuration section is described below.
+
+##### Common Configuration
+
+The common configuration container parameters are used by both TX and RX:
+
+- **`version`**: Version of the config. Only 1 is valid currently.
+  - type: `integer`
+- **`master_core`**: Master core used to fork and join network threads. This core is not used for packet processing and can be
+bound to a non-isolated core
+  - type: `integer`  
+
+##### Receive Configuration
+
+- **`if_name`**: Name of the interface or PCIe BDF to use
+  - type: `string`
+- **`queues`**: Array of queues
+  - type: `array`
+- **`name`**: Name of queue
+  - type: `string`
+- **`gpu_direct`**: GPUDirect is enabled on the queue
+  - type: `boolean`  
+- **`batch_size`**: Number of packets in a batch that is passed between the advanced network operator and the user's operator. A
+larger number increases throughput and latency by requiring fewer messages between operators, but takes longer to populate a single
+buffer. A smaller number reduces latency and bandwidth by passing more messages.
+- **`num_concurrent_batches`**: Number of batches that can be outstanding (not freed) at any given time. This value directly affects
+the amount of memory needed for receiving packets. A value too small and packets will be dropped, while a value too large will
+unnecessarily use excess CPU and/or GPU memory.
+  - type: `integer`
+- **`max_packet_size`**: Largest packet size expected
+  - type: `integer`
+- **`split_boundary`**: Split point in bytes where any byte before this value is sent to CPU, and anything after to GPU
+  - type: `integer` 
+- **`gpu_device`**: GPU device number if using GPUDirect
+  - type: `integer` 
+- **`cpu_cores`**: List of CPU cores from the isolated set used by the operator for receiving
+  - type: `string`
+- **`flows`**: Array of flows
+  - type: `array`
+- **`name`**: Name of queue
+  - type: `string`
+- **`action`**: Action section of flow
+  - type: `sequence`
+- **`type`**: Type of action. Only "queue" is supported currently.
+  - type: `string`
+- **`id`**: ID of queue to steer to
+  - type: `integer`
+- **`match`**: Match section of flow
+  - type: `sequence`
+- **`udp_src`**: UDP source port
+  - type: `integer`
+- **`udp_dst`**: UDP destination port
+  - type: `integer`    
+  
+##### Transmit Configuration
+
+- **`if_name`**: Name of the interface or PCIe BDF to use
+  - type: `string`
+- **`queues`**: Array of queues
+  - type: `array`
+- **`name`**: Name of queue
+  - type: `string`  
+- **`id`**: ID of queue to steer to
+  - type: `integer`  
+- **`gpu_direct`**: GPUDirect is enabled on the queue
+  - type: `boolean`    
+- **`batch_size`**: Number of packets in a batch that is passed between the advanced network operator and the user's operator. A
+larger number increases throughput and latency by requiring fewer messages between operators, but takes longer to populate a single
+buffer. A smaller number reduces latency and bandwidth by passing more messages.
+  - type: `integer`
+- **`max_payload_size`**: Largest payload size expected
+  - type: `integer`
+- **`layer_fill`**: Layer(s) that the advanced network operator should populate in the packet. Anything higher than the layer
+specified must be populated by the user. For example, if `ethernet` is specified, the user is responsible for populating values of
+any item above that layer (IP, UDP, etc...). Valid values are `raw`, `ethernet`, `ip`, and `udp`
+  - type: `string` 
+- **`eth_dst_addr`**: Destination ethernet MAC address. Only used for `ethernet` layer_fill mode or above
+  - type: `string` 
+- **`ip_src_addr`**: Source IP address to send packets from. Only used for `ip` layer_fill and above
+  - type: `string`
+- **`ip_dst_addr`**: Destination IP address to send packets to. Only used for `ip` layer_fill and above
+  - type: `string`  
+- **`udp_dst_port`**: UDP destination port. Only used for `udp` layer_fill and above
+  - type: `integer`
+- **`udp_src_port`**: UDP source port. Only used for `udp` layer_fill and above
+  - type: `integer`
+- **`cpu_cores`**: List of CPU cores for transmitting
+  - type: `string`
+
+  #### API Structures
+
+  Both the transmit and receive operators use a common structure named `AdvNetBurstParams` to pass data to/from other operators. 
+  `AdvNetBurstParams` provides pointers to all packets on the CPU and GPU, and contains metadata needed by the operator to track
+  allocations. Since the advanced network operator utilizes a generic interface that does not expose the underlying low-level network
+  card library, interacting with the `AdvNetBurstParams` is mostly done with the helper functions described below. A user should
+  never modify any members of `AdvNetBurstParams` directly as this may break in future versions. The `AdvNetBurstParams` is described
+  below:
+
+  ```
+  struct AdvNetBurstParams {
+    union {
+        AdvNetBurstParamsHdr hdr;
+        uint8_t buf[HS_NETWORK_HEADER_SIZE_BYTES];
+    };
+
+    void **cpu_pkts;
+    void **gpu_pkts;
+};
+```
+
+Starting from the top, the `hdr` field contains metadata about the batch of packets. `buf` is a placeholder for future expansion
+of fields. `cpu_pkts` contains pointers to CPU packets, while `gpu_pkts` contains pointers to the GPU packets. As mentioned above, 
+the `cpu_pkts` and `gpu_pkts` are opaque pointers and should not be access directly. See the next section for information on interacting
+with these fields.
+
+#### Example API Usage
+
+For an entire list of API functions, please see the `adv_network_common.h` header file. 
+
+##### Receive
+
+The section below describes a workflowusing GPUDirect to receive packets using header-data split. The job of the user's operator(s)
+is to process and free the buffers as quickly as possible. This might be copying to interim buffers or freeing before the entire 
+pipeline is done processing. This allows the networking piece to use relatively few buffers while still achieving very high rates.
+
+The first step in receiving from the advanced network operator is to tie your operator's input port to the output port of the RX
+network operator's `burst_out` port. 
+
+```
+auto adv_net_rx    = make_operator<ops::AdvNetworkOpRx>("adv_network_rx", from_config("adv_network_common"), from_config("adv_network_rx"), make_condition<BooleanCondition>("is_alive", true));
+auto my_receiver   = make_operator<ops::MyReceiver>("my_receiver", from_config("my_receiver"));
+add_flow(adv_net_rx, my_receiver, {{"burst_out", "burst_in"}});   
+```
+
+Once the ports are connected, inside the `compute()` function of your operator you will receive a `AdvNetBurstParams` structure
+when a batch is complete:
+
+```
+auto burst = op_input.receive<AdvNetBurstParams>("burst_in");
+```
+
+The packets arrive in scattered packet buffers. Depending on the application, you may need to iterate through the packets to
+aggregate them into a single buffer. Alternatively the operator handling the packet data can operate on a list of packet
+pointers rather than a contiguous buffer. Below is an example of aggregating separate GPU packet buffers into a single GPU
+buffer:
+
+```
+  for (int p = 0; p < adv_net_get_num_pkts(burst); p++) {
+    h_dev_ptrs_[aggr_pkts_recv_ + p]   = adv_net_get_cpu_pkt_ptr(burst, p);
+    ttl_bytes_in_cur_batch_           += adv_net_get_gpu_packet_len(burst, p) + sizeof(UDPPkt);
+  }
+
+  simple_packet_reorder(buffer, h_dev_ptrs, packet_len, burst->hdr.num_pkts); 
+```
+
+For this example we are tossing the header portion (CPU), so we don't need to examine the packets. Since we launched a reorder
+kernel to aggregate the packets in GPU memory, we are also done with the GPU pointers. All buffers may be freed to the
+advanced network operator at this point:
+
+```
+adv_net_free_all_burst_pkts_and_burst(burst_bufs_[b]);
+```
+
+##### Transmit 
+
+Transmitting packets works similar to the receive side, except the user is tasked with filling out the packets as much as it
+needs to. As mentioned above, helper functions are available to fill in most boilerplate header information if that doesn't 
+change often. 
+
+Similar to the receive, the transmit operator needs to connect to `burst_in` on the advanced network operator transmitter:
+
+```
+auto my_transmitter  = make_operator<ops::MyTransmitter>("my_transmitter", from_config("my_transmitter"), make_condition<BooleanCondition>("is_alive", true));      
+auto adv_net_tx       = make_operator<ops::AdvNetworkOpTx>("adv_network_tx", from_config("adv_network_common"), from_config("adv_network_tx"));
+add_flow(my_transmitter, adv_net_tx, {{"burst_out", "burst_in"}});
+```
+
+Before sending packets, the user's transmit operator must request a buffer from the advanced network operator pool:
+
+```
+auto msg = std::make_shared<AdvNetBurstParams>();
+msg->hdr.num_pkts = num_pkts;
+if ((ret = adv_net_get_tx_pkt_burst(msg.get())) != AdvNetStatus::SUCCESS) {
+  HOLOSCAN_LOG_ERROR("Error returned from adv_net_get_tx_pkt_burst: {}", static_cast<int>(ret));
+  return;
+}
+```      
+
+The code above creates a shared `AdvNetBurstParams` that will be passed to the advanced network operator, and uses 
+`adv_net_get_tx_pkt_burst` to populate the burst buffers with valid packet buffers. On success, the buffers inside the
+burst structure will be allocate and are ready to be filled in. Each packet must be filled in by the user. In this
+example we loop through each packet and populate a buffer:
+
+```
+for (int num_pkt = 0; num_pkt < msg->hdr.num_pkts; num_pkt++) {
+  void *payload_src = data_buf + num_pkt * nom_pkt_size;
+  if (adv_net_set_udp_payload(msg->cpu_pkts[num_pkt], payload_src, nom_pkt_size) != AdvNetStatus::SUCCESS) {
+    HOLOSCAN_LOG_ERROR("Failed to create packet {}", num_pkt);
+  }
+}
+```
+
+The code iterates over `msg->hdr.num_pkts` (defined by the user) and passes a pointer to the payload and the packet
+size to `adv_net_set_udp_payload`. In this example our configuration is using `fill_mode` "udp" on the transmitter, so
+`adv_net_set_udp_payload` will populate the Ethernet, IP, and UDP headers. The payload pointer passed by the user
+is also copied into the buffer. Alternatively a user could use the packet buffers directly as output from a previous stage
+to avoid this extra copy.
+
+With the `AdvNetBurstParams` populated, the burst can be sent off to the advanced network operator for transmission:
+
+```
+op_output.emit(msg, "burst_out");
+```

--- a/operators/advanced_network/adv_network_common.cpp
+++ b/operators/advanced_network/adv_network_common.cpp
@@ -1,0 +1,252 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "adv_network_common.h"
+#include "holoscan/holoscan.hpp"
+#include <rte_mbuf.h>
+#include <rte_memcpy.h>
+#include <rte_ethdev.h>
+
+namespace holoscan::ops {
+
+/**
+ * @brief Structure for passing packets to/from advanced network operator
+ *
+ * AdvNetBurstParams is populated by the RX advanced network operator before arriving at the user's
+ * operator, and the user populates it prior to sending to the TX advanced network operator. The
+ * structure describes metadata about a packet batch and its packet pointers.
+ *
+ */
+
+/**
+ * @brief Generic UDP packet structure
+ *
+ */
+struct UDPPkt {
+  struct rte_ether_hdr eth;
+  struct rte_ipv4_hdr ip;
+  struct rte_udp_hdr udp;
+  uint8_t payload[];
+} __attribute__((packed));
+
+
+void adv_net_free_pkt(void *pkt) {
+  rte_pktmbuf_free_seg(static_cast<rte_mbuf*>(pkt));
+}
+
+
+uint16_t adv_net_get_cpu_packet_len(AdvNetBurstParams *burst, int idx) {
+  return reinterpret_cast<rte_mbuf*>(burst->cpu_pkts[idx])->data_len;
+}
+
+uint16_t adv_net_get_cpu_packet_len(std::shared_ptr<AdvNetBurstParams> &burst, int idx) {
+  return adv_net_get_cpu_packet_len(burst.get(), idx);
+}
+
+uint16_t adv_net_get_gpu_packet_len(AdvNetBurstParams *burst, int idx) {
+  return reinterpret_cast<rte_mbuf*>(burst->gpu_pkts[idx])->data_len;
+}
+
+uint16_t adv_net_get_gpu_packet_len(std::shared_ptr<AdvNetBurstParams> &burst, int idx) {
+  return adv_net_get_gpu_packet_len(burst.get(), idx);
+}
+
+void adv_net_free_pkts(void **pkts, int num_pkts) {
+  for (int p = 0; p < num_pkts; p++) {
+    rte_pktmbuf_free_seg(reinterpret_cast<rte_mbuf**>(pkts)[p]);
+  }
+}
+
+
+void adv_net_free_all_burst_pkts(AdvNetBurstParams *burst) {
+  adv_net_free_pkts(burst->cpu_pkts, burst->hdr.num_pkts);
+  adv_net_free_pkts(burst->gpu_pkts, burst->hdr.num_pkts);
+}
+
+void adv_net_free_all_burst_pkts(std::shared_ptr<AdvNetBurstParams> &burst) {
+  return adv_net_free_all_burst_pkts(burst.get());
+}
+
+
+void adv_net_free_all_burst_pkts_and_burst(AdvNetBurstParams *burst) {
+  adv_net_free_pkts(burst->cpu_pkts, burst->hdr.num_pkts);
+  adv_net_free_pkts(burst->gpu_pkts, burst->hdr.num_pkts);
+  adv_net_free_rx_burst(burst);
+}
+
+void adv_net_free_all_burst_pkts_and_burst(std::shared_ptr<AdvNetBurstParams> &burst) {
+  adv_net_free_all_burst_pkts_and_burst(burst.get());
+}
+
+
+void adv_net_free_cpu_pkts_and_burst(AdvNetBurstParams *burst) {
+  adv_net_free_pkts(burst->cpu_pkts, burst->hdr.num_pkts);
+  adv_net_free_rx_burst(burst);
+}
+
+void adv_net_free_cpu_pkts_and_burst(std::shared_ptr<AdvNetBurstParams> &burst) {
+  adv_net_free_cpu_pkts_and_burst(burst.get());
+}
+
+
+bool adv_net_tx_burst_available(int num_pkts) {
+  auto burst_pool = rte_mempool_lookup("TX_BURST_POOL");
+  auto pkt_pool   = rte_mempool_lookup("TX_POOL");
+  if (burst_pool == nullptr || pkt_pool == nullptr) {
+    return false;
+  }
+
+  if (rte_mempool_empty(burst_pool)) {
+    return false;
+  }
+
+  if (rte_mempool_avail_count(pkt_pool) < num_pkts) {
+    return false;
+  }
+
+  return true;
+}
+
+
+AdvNetStatus adv_net_get_tx_pkt_burst(AdvNetBurstParams *burst) {
+  auto burst_pool = rte_mempool_lookup("TX_BURST_POOL");
+  auto pkt_pool   = rte_mempool_lookup("TX_POOL");
+  if (burst_pool == nullptr || pkt_pool == nullptr) {
+    return AdvNetStatus::NULL_PTR;
+  }
+
+  if (rte_mempool_get(burst_pool, reinterpret_cast<void**>(&burst->cpu_pkts)) != 0) {
+    return AdvNetStatus::NO_FREE_BURST_BUFFERS;
+  }
+
+  if (rte_pktmbuf_alloc_bulk(pkt_pool, reinterpret_cast<rte_mbuf**>(burst->cpu_pkts),
+              static_cast<int>(burst->hdr.num_pkts)) != 0) {
+    rte_mempool_put(burst_pool, reinterpret_cast<void*>(burst->cpu_pkts));
+    return AdvNetStatus::NO_FREE_CPU_PACKET_BUFFERS;
+  }
+
+  return AdvNetStatus::SUCCESS;
+}
+
+AdvNetStatus adv_net_get_tx_pkt_burst(std::shared_ptr<AdvNetBurstParams> &burst) {
+  return adv_net_get_tx_pkt_burst(burst.get());
+}
+
+
+AdvNetStatus adv_net_set_cpu_udp_payload(AdvNetBurstParams *burst, int idx, void *data, int len) {
+  auto mbuf = reinterpret_cast<rte_mbuf*>(burst->cpu_pkts[idx]);
+  auto mbuf_data = rte_pktmbuf_mtod(mbuf, UDPPkt*);
+
+  rte_memcpy(mbuf_data->payload, data, len);
+  mbuf_data->eth.ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
+  mbuf_data->udp.dgram_cksum = 0;
+  mbuf_data->udp.dgram_len = htons(len + sizeof(mbuf_data->udp));
+  mbuf_data->ip.next_proto_id = IPPROTO_UDP;
+  mbuf_data->ip.ihl = 5;
+  mbuf_data->ip.total_length =
+        rte_cpu_to_be_16(sizeof(mbuf_data->ip) + sizeof(mbuf_data->udp) + len);
+  mbuf_data->ip.version = 4;
+
+  mbuf->data_len = len + sizeof(UDPPkt);
+  mbuf->pkt_len  = mbuf->data_len;
+
+  return AdvNetStatus::SUCCESS;
+}
+
+AdvNetStatus adv_net_set_cpu_udp_payload(std::shared_ptr<AdvNetBurstParams> &burst,
+              int idx, void *data, int len) {
+  return adv_net_set_cpu_udp_payload(burst.get(), idx, data, len);
+}
+
+int64_t adv_net_get_num_pkts(AdvNetBurstParams *burst) {
+  return burst->hdr.num_pkts;
+}
+
+int64_t adv_net_get_num_pkts(std::shared_ptr<AdvNetBurstParams> &burst) {
+  return adv_net_get_num_pkts(burst.get());
+}
+
+void adv_net_set_num_pkts(AdvNetBurstParams *burst, int64_t num) {
+  burst->hdr.num_pkts = num;
+}
+
+void adv_net_set_num_pkts(std::shared_ptr<AdvNetBurstParams> &burst, int64_t num) {
+  return adv_net_set_num_pkts(burst.get(), num);
+}
+
+void adv_net_set_hdr(AdvNetBurstParams *burst, uint16_t port, uint16_t q, int64_t num) {
+  burst->hdr.num_pkts = num;
+  burst->hdr.port_id = port;
+  burst->hdr.q_id = q;
+}
+
+void adv_net_set_hdr(std::shared_ptr<AdvNetBurstParams> &burst,
+          uint16_t port, uint16_t q, int64_t num) {
+  return adv_net_set_hdr(burst.get(), port, q, num);
+}
+
+
+void adv_net_free_tx_burst(AdvNetBurstParams *burst) {
+  auto burst_pool = rte_mempool_lookup("TX_BURST_POOL");
+  rte_mempool_put(burst_pool, (void *)burst->cpu_pkts);
+}
+
+void adv_net_free_tx_burst(std::shared_ptr<AdvNetBurstParams> &burst) {
+  return adv_net_free_tx_burst(burst.get());
+}
+
+void adv_net_free_rx_burst(AdvNetBurstParams *burst) {
+  auto burst_pool = rte_mempool_lookup("RX_BURST_POOL");
+  rte_mempool_put(burst_pool, (void *)burst->cpu_pkts);
+  if (burst->gpu_pkts != nullptr) {
+    rte_mempool_put(burst_pool, (void *)burst->gpu_pkts);
+  }
+}
+
+void adv_net_free_rx_burst(std::shared_ptr<AdvNetBurstParams> &burst) {
+  return adv_net_free_rx_burst(burst.get());
+}
+
+void *adv_net_get_cpu_pkt_ptr(AdvNetBurstParams *burst, int idx)   {
+  return rte_pktmbuf_mtod(reinterpret_cast<rte_mbuf*>(burst->cpu_pkts[idx]), void*);
+}
+
+void *adv_net_get_cpu_pkt_ptr(std::shared_ptr<AdvNetBurstParams> &burst, int idx) {
+  return rte_pktmbuf_mtod(reinterpret_cast<rte_mbuf*>(burst->cpu_pkts[idx]), void*);
+}
+
+void *adv_net_get_gpu_pkt_ptr(AdvNetBurstParams *burst, int idx)   {
+  return rte_pktmbuf_mtod(reinterpret_cast<rte_mbuf*>(burst->gpu_pkts[idx]), void*);
+}
+
+void *adv_net_get_gpu_pkt_ptr(std::shared_ptr<AdvNetBurstParams> &burst, int idx) {
+  return rte_pktmbuf_mtod(reinterpret_cast<rte_mbuf*>(burst->gpu_pkts[idx]), void*);
+}
+
+std::optional<uint16_t> adv_net_get_port_from_ifname(const std::string &name) {
+  uint16_t port;
+  auto ret = rte_eth_dev_get_port_by_name(name.c_str(), &port);
+  if (ret < 0) {
+    return {};
+  }
+
+  return port;
+}
+
+
+
+};  // namespace holoscan::ops

--- a/operators/advanced_network/adv_network_common.h
+++ b/operators/advanced_network/adv_network_common.h
@@ -1,0 +1,570 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <vector>
+#include <string>
+#include <memory>
+#include <optional>
+#include <tuple>
+#include <stdint.h>
+#include "holoscan/holoscan.hpp"
+
+namespace holoscan::ops {
+
+/**
+ * @brief Reserved header bytes for burst structure
+ *
+ */
+static inline constexpr uint32_t ADV_NETWORK_HEADER_SIZE_BYTES = 256;
+static inline constexpr uint32_t MAX_NUM_RX_QUEUES = 32;
+static inline constexpr uint32_t MAX_NUM_TX_QUEUES = 32;
+static inline constexpr uint32_t MAX_INTERFACES = 4;
+
+/**
+ * @brief Header of AdvNetBurstParams
+ *
+ */
+struct AdvNetBurstParamsHdr {
+  size_t        num_pkts;
+  uint16_t       port_id;
+  uint16_t      q_id;
+};
+
+struct AdvNetBurstParams {
+  union {
+    AdvNetBurstParamsHdr hdr;
+    uint8_t buf[ADV_NETWORK_HEADER_SIZE_BYTES];
+  };
+
+  void **cpu_pkts;
+  void **gpu_pkts;
+};
+
+// this part is purely optional, just a helper for the user
+inline auto CreateSharedBurstParams() {
+  return std::make_shared<AdvNetBurstParams>();
+}
+
+
+/**
+ * @brief Return status codes from advanced network operators
+ *
+ */
+enum class AdvNetStatus {
+  SUCCESS,
+  NULL_PTR,
+  NO_FREE_BURST_BUFFERS,
+  NO_FREE_CPU_PACKET_BUFFERS,
+  NO_FREE_GPU_PACKET_BUFFERS,
+};
+
+/**
+ * @brief Location of packet buffers
+ *
+ */
+enum class AdvNetBufferLocation : uint8_t {
+  CPU = 0,
+  GPU = 1,
+  CPU_GPU_SPLIT = 2,
+};
+
+/**
+ * @brief Direction of operator
+ *
+ */
+enum class AdvNetDirection : uint8_t {
+  RX = 0,
+  TX = 1,
+  TX_RX = 2,
+};
+
+namespace detail {
+  inline AdvNetDirection DirectionStringToType(const std::string &dir) {
+    if (dir == "rx") {
+      return AdvNetDirection::RX;
+    } else if (dir == "tx") {
+      return AdvNetDirection::TX;
+    }
+
+    return AdvNetDirection::TX_RX;
+  }
+};  // namespace detail
+
+
+
+/**
+ * @brief Parameters to configure advanced network operators
+ *
+ */
+struct AdvNetConfig {
+  AdvNetBufferLocation rx_loc;
+  uint16_t max_packet_size = 0;
+  size_t batch_size = 0;
+  uint32_t num_concurrent_batches;
+  std::vector<std::string> if_names;
+  std::string cpu_cores = "";
+  std::string master_core = "";
+  int hds = 0;
+  int gpu_dev = -1;
+  bool use_network = false;
+  bool enabled = false;
+};
+
+
+/**
+ * @brief Determine which directions are enabled
+ *
+ * @param dir Direction from config. Either "rx", "tx", or "tx/rx"
+ * @return int Number of directions enabled
+ */
+inline int EnabledDirections(const std::string &dir) {
+  if (dir == "rx" || dir == "tx") {
+    return 1;
+  }
+
+  return 0;
+}
+
+
+/**
+ * @brief Returns a raw CPU packet pointer from a pointer in AdvNetBurstParams
+ *
+ * The AdvNetBurstParams structure contains pointers to opaque packets which are not accessible
+ * directly by the user. This function fetches the CPU packet pointer at index idx
+ * from the burst.
+ *
+ * @param burst Burst structure containing packets
+ * @param idx Index of packet
+ * @return Pointer to packet data
+ */
+void *adv_net_get_cpu_pkt_ptr(AdvNetBurstParams *burst, int idx);
+void *adv_net_get_cpu_pkt_ptr(std::shared_ptr<AdvNetBurstParams> &burst, int idx);
+
+/**
+ * @brief Returns a raw GPU packet pointer from a pointer in AdvNetBurstParams
+ *
+ * The AdvNetBurstParams structure contains pointers to opaque packets which are not accessible
+ * directly by the user. This function fetches the GPU packet pointer at index idx
+ * from the burst.
+ *
+ * @param burst Burst structure containing packets
+ * @param idx Index of packet
+ * @return Pointer to packet data
+ */
+void *adv_net_get_gpu_pkt_ptr(AdvNetBurstParams *burst, int idx);
+void *adv_net_get_gpu_pkt_ptr(std::shared_ptr<AdvNetBurstParams> &burst, int idx);
+
+
+/**
+ * @brief Get packet length of a CPU packet
+ *
+ * Returns the length of an individual CPU packet
+ *
+ * @param burst Burst structure containing packets
+ * @param idx Index of packet
+ * @return uint16_t Length of packet
+ */
+uint16_t adv_net_get_cpu_packet_len(AdvNetBurstParams *burst, int idx);
+uint16_t adv_net_get_cpu_packet_len(std::shared_ptr<AdvNetBurstParams> &burst, int idx);
+
+/**
+ * @brief Get packet length of a GPU packet
+ *
+ * Returns the length of an individual GPU packet
+ *
+ * @param pkt Packet to get length of
+ * @param burst Burst structure containing packets
+ * @return uint16_t Length of packet
+ */
+uint16_t adv_net_get_gpu_packet_len(AdvNetBurstParams *burst, int idx);
+uint16_t adv_net_get_gpu_packet_len(std::shared_ptr<AdvNetBurstParams> &burst, int idx);
+
+/**
+ * @brief Populate a TX packet burst buffer
+ *
+ * Populates a transmit packet burst buffer with allocated packets. The user can take these
+ * allocated packets and fill with the desired data/headers.
+ *
+ * @param burst Burst structure to populate
+ * @return AdvNetStatus indicating status. Valid values are:
+ *    SUCCESS: Packets allocated
+ *    NULL_PTR: Burst or packet pools uninitialized
+ *    NO_FREE_BURST_BUFFERS: No burst buffers to allocate
+ *    NO_FREE_CPU_PACKET_BUFFERS: Not enough CPU packet buffers available
+ */
+AdvNetStatus adv_net_get_tx_pkt_burst(AdvNetBurstParams *burst);
+AdvNetStatus adv_net_get_tx_pkt_burst(std::shared_ptr<AdvNetBurstParams> &burst);
+
+/**
+ * @brief Set UDP payload parameters in packet
+ *
+ * @param pkt Pointer to packet to fill parameters
+ * @param idx Index of packet
+ * @param data Payload data after UDP header
+ * @param len Length of payload
+ * @return AdvNetStatus indicating status. Valid values are:
+ *    SUCCESS: Packet populated successfully
+ */
+AdvNetStatus adv_net_set_cpu_udp_payload(AdvNetBurstParams *burst, int idx, void *data, int len);
+AdvNetStatus adv_net_set_cpu_udp_payload(std::shared_ptr<AdvNetBurstParams> &burst,
+                int idx, void *data, int len);
+
+/**
+ * @brief Test if a TX burst is available
+ *
+ * Checks whether a TX burst for a given size can be allocated. This is useful for an
+ * application to throttle its transmissions if the NIC and/or advanced network operator
+ * is not keeping up with the desired rate. Rather than returning an error, the user can
+ * use this function to loop or return later to try again.
+ *
+ * @param num_pkts Number of packets to test allocation for
+ * @return true Burst is available
+ * @return false Burst is not available
+ */
+bool adv_net_tx_burst_available(int num_pkts);
+
+/**
+ * @brief Free all CPU packets and burst
+ *
+ * Frees every allocated CPU packets in the burst and the burst metadata. After this
+ * call completes the CPU pointers are no longer valid.
+ *
+ * @param burst Burst to free
+ */
+void adv_net_free_cpu_pkts_and_burst(AdvNetBurstParams *burst);
+void adv_net_free_cpu_pkts_and_burst(std::shared_ptr<AdvNetBurstParams> &burst);
+
+/**
+ * @brief Free all packets and a burst
+ *
+ * Frees all packets in a burst of packets and the associated burst buffer
+ *
+ * @param burst Burst structure containing packet lists
+ */
+void adv_net_free_all_burst_pkts_and_burst(AdvNetBurstParams *burst);
+void adv_net_free_all_burst_pkts_and_burst(std::shared_ptr<AdvNetBurstParams> &burst);
+
+/**
+ * @brief Frees a single packet
+ *
+ * Frees a single packet from either the CPU or GPU buffer list. This function is extremely
+ * inefficient since it frees a single packet, and bulk methods should be preferred instead.
+ *
+ * @param pkt Pointer to packet to free
+ */
+void adv_net_free_pkt(void *pkt);
+
+/**
+ * @brief Free all packets in a single list (CPU or GPU)
+ *
+ * Frees all packets in a single list. This function can be used when one type of packet
+ * should be freed while the other is used for a longer period of time. For example, the
+ * GPU buffers may be needed for pipeline processing, but the CPU buffers can be freed immediately
+ * after sorting the packets in header-data spit mode.
+ *
+ * @param pkts List of packets
+ * @param len Number of packets to free
+ */
+void adv_net_free_pkts(void **pkts, int len);
+
+/**
+ * @brief Free all packets in a burst
+ *
+ * Frees all packets in a burst of packets. After completion, all CPU and GPU packets will
+ * be released back to the free pool.
+ *
+ * @param burst Burst structure containing packet lists
+ */
+void adv_net_free_all_burst_pkts(AdvNetBurstParams *burst);
+void adv_net_free_all_burst_pkts(std::shared_ptr<AdvNetBurstParams> &burst);
+
+/**
+ * @brief Free a receive burst
+ *
+ * Frees the buffer containing a receive burst buffer. This function does not free packets;
+ * packets must be freed prior to calling this.
+ *
+ * @param burst
+ */
+void adv_net_free_rx_burst(AdvNetBurstParams *burst);
+void adv_net_free_rx_burst(std::shared_ptr<AdvNetBurstParams> &burst);
+
+/**
+ * @brief Free a transmit burst buffer
+ *
+ * Frees the buffer containing a transmit burst buffer. This function does not free packets;
+ * packets must be freed prior to calling this.
+ *
+ * @param burst Burst structure to free
+ */
+void adv_net_free_tx_burst(AdvNetBurstParams *burst);
+void adv_net_free_tx_burst(std::shared_ptr<AdvNetBurstParams> &burst);
+
+/**
+ * @brief Get the number of packets in a burst
+ *
+ * @param burst Burst structure with packets
+ */
+int64_t adv_net_get_num_pkts(AdvNetBurstParams *burst);
+int64_t adv_net_get_num_pkts(std::shared_ptr<AdvNetBurstParams> &burst);
+
+/**
+ * @brief Set the number of packets in a burst
+ *
+ * @param burst Burst structure
+ * @param num Number of packets
+ */
+void adv_net_set_num_pkts(AdvNetBurstParams *burst, int64_t num);
+void adv_net_set_num_pkts(std::shared_ptr<AdvNetBurstParams> &burst, int64_t num);
+
+/**
+ * @brief Set the header fields in a burst
+ *
+ * @param burst Burst structure
+ * @param port Port ID of interface
+ * @param q Queue ID of interface
+ * @param num Number of packets
+ */
+void adv_net_set_hdr(AdvNetBurstParams *burst, uint16_t port, uint16_t q, int64_t num);
+void adv_net_set_hdr(std::shared_ptr<AdvNetBurstParams> &burst,
+          uint16_t port, uint16_t q, int64_t num);
+
+std::optional<uint16_t> adv_net_get_port_from_ifname(const std::string &name);
+
+struct CommonQueueConfig {
+  std::string name_;
+  int id_;
+  int gpu_dev_;
+  bool gpu_direct_;
+  int hds_;
+  std::string cpu_cores_;
+  int max_packet_size_;
+  int num_concurrent_batches_;
+  int batch_size_;
+  void *backend_config_;  // Filled in by operator
+};
+
+struct RxQueueConfig {
+  CommonQueueConfig common_;
+};
+
+struct TxQueueConfig {
+  CommonQueueConfig common_;
+  std::string eth_dst_;
+  std::string ip_src_;
+  std::string ip_dst_;
+  std::string fill_type_;
+  uint16_t udp_src_port_;
+  uint16_t udp_dst_port_;
+};
+
+// struct FlowConfig {
+//   FlowConfig() = default;
+//   std::string name_;
+//   std::string pattern_;
+// };
+
+enum class FlowType {
+  QUEUE
+};
+
+struct FlowAction {
+  FlowType type_;
+  uint16_t id_;
+};
+
+struct FlowMatch {
+  uint16_t udp_src_;
+  uint16_t udp_dst_;
+};
+struct FlowConfig {
+  std::string name_;
+  FlowAction action_;
+  FlowMatch  match_;
+};
+
+struct CommonConfig {
+  int version;
+  int master_core_;
+  AdvNetDirection dir;
+};
+
+struct AdvNetRxConfig {
+    std::string if_name_;
+    uint16_t port_id_;
+    bool flow_isolation_;
+    bool empty;
+    std::vector<RxQueueConfig> queues_;
+    std::vector<FlowConfig> flows_;
+};
+
+struct AdvNetTxConfig {
+    std::string if_name_;
+    uint16_t port_id_;
+    bool empty;
+    std::vector<TxQueueConfig> queues_;
+    std::vector<FlowConfig> flows_;
+};
+
+struct AdvNetConfigYaml {
+    CommonConfig common_;
+    std::vector<AdvNetRxConfig> rx_;
+    std::vector<AdvNetTxConfig> tx_;
+};
+
+template <typename Config>
+auto adv_net_get_rx_tx_cfg_en(const Config &config) {
+  bool rx = false;
+  bool tx = false;
+
+  auto& yaml_nodes = config.yaml_nodes();
+  for (const auto &yaml_node : yaml_nodes) {
+    auto node = yaml_node["advanced_network"]["cfg"];
+    rx = node["rx"].IsSequence();
+    tx = node["tx"].IsSequence();
+  }
+
+  return std::make_tuple(rx, tx);
+}
+};  // namespace holoscan::ops
+
+
+template <>
+struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
+  static Node encode(const holoscan::ops::AdvNetConfigYaml& input_spec) {
+    Node node;
+    // node["type"] = inputTypeToString(input_spec.type_);
+    // node["name"] = input_spec.tensor_name_;
+    // node["opacity"] = std::to_string(input_spec.opacity_);
+    // node["priority"] = std::to_string(input_spec.priority_);
+    // node["color"] = input_spec.color_;
+    // node["line_width"] = std::to_string(input_spec.line_width_);
+    // node["point_size"] = std::to_string(input_spec.point_size_);
+    // node["text"] = input_spec.text_;
+    // node["depth_map_render_mode"] =
+    //      depthMapRenderModeToString(input_spec.depth_map_render_mode_);
+    return node;
+  }
+
+  static bool decode(const Node& node, holoscan::ops::AdvNetConfigYaml& input_spec) {
+    if (!node.IsMap()) {
+      GXF_LOG_ERROR("InputSpec: expected a map");
+      return false;
+    }
+
+    // YAML is using exceptions, catch them
+    try {
+      input_spec.common_.version        = node["version"].as<int32_t>();
+      input_spec.common_.master_core_   = node["master_core"].as<int32_t>();
+
+      try {
+        const auto &rx = node["rx"];
+        for (const auto &rx_item : rx) {
+          holoscan::ops::AdvNetRxConfig rx_cfg;
+          rx_cfg.if_name_ = rx_item["if_name"].as<std::string>();
+          rx_cfg.flow_isolation_ = rx_item["flow_isolation"].as<bool>();
+
+          for (const auto &q_item :  rx_item["queues"]) {
+            holoscan::ops::RxQueueConfig q;
+            q.common_.name_             = q_item["name"].as<std::string>();
+            q.common_.id_               = q_item["id"].as<int>();
+            q.common_.gpu_direct_       = q_item["gpu_direct"].as<bool>();
+            if (q.common_.gpu_direct_) {
+              q.common_.gpu_dev_          = q_item["gpu_device"].as<int>();
+              q.common_.hds_              = q_item["split_boundary"].as<int>();
+            }
+
+            q.common_.cpu_cores_        = q_item["cpu_cores"].as<std::string>();
+            q.common_.max_packet_size_  = q_item["max_packet_size"].as<int>();
+            q.common_.num_concurrent_batches_  = q_item["num_concurrent_batches"].as<int>();
+            q.common_.max_packet_size_  = q_item["max_packet_size"].as<int>();
+            q.common_.batch_size_       = q_item["batch_size"].as<int>();
+
+            rx_cfg.queues_.emplace_back(q);
+          }
+
+          for (const auto &flow_item :  rx_item["flows"]) {
+            holoscan::ops::FlowConfig flow;
+            flow.name_          = flow_item["name"].as<std::string>();
+
+            flow.action_.type_     = holoscan::ops::FlowType::QUEUE;
+            flow.action_.id_       = flow_item["action"]["id"].as<int>();
+            flow.match_.udp_src_   = flow_item["match"]["udp_src"].as<uint16_t>();
+            flow.match_.udp_dst_   = flow_item["match"]["udp_dst"].as<uint16_t>();
+
+            rx_cfg.flows_.emplace_back(flow);
+          }
+
+          input_spec.rx_.emplace_back(rx_cfg);
+        }
+
+        const auto &tx = node["tx"];
+        for (const auto &tx_item : tx) {
+          holoscan::ops::AdvNetTxConfig tx_cfg;
+          tx_cfg.if_name_ = tx_item["if_name"].as<std::string>();
+
+          for (const auto &q_item :  tx_item["queues"]) {
+            holoscan::ops::TxQueueConfig q;
+            q.common_.name_             = q_item["name"].as<std::string>();
+            q.common_.id_               = q_item["id"].as<int>();
+            q.common_.gpu_direct_       = q_item["gpu_direct"].as<bool>();
+            if (q.common_.gpu_direct_) {
+              q.common_.gpu_dev_          = q_item["gpu_device"].as<int>();
+              q.common_.hds_              = q_item["split_boundary"].as<int>();
+            }
+
+            q.common_.cpu_cores_        = q_item["cpu_cores"].as<std::string>();
+            q.common_.max_packet_size_  = q_item["max_packet_size"].as<int>();
+            q.common_.num_concurrent_batches_  = q_item["num_concurrent_batches"].as<int>();
+            q.common_.max_packet_size_  = q_item["max_packet_size"].as<int>();
+            q.common_.batch_size_       = q_item["batch_size"].as<int>();
+
+            q.eth_dst_      = q_item["eth_dst_addr"].as<std::string>();
+            q.ip_src_       = q_item["ip_src_addr"].as<std::string>();
+            q.ip_dst_       = q_item["ip_dst_addr"].as<std::string>();
+            q.fill_type_    = q_item["fill_type"].as<std::string>();
+            q.udp_src_port_ = q_item["udp_src_port"].as<uint16_t>();
+            q.udp_dst_port_ = q_item["udp_dst_port"].as<uint16_t>();
+
+            tx_cfg.queues_.emplace_back(q);
+          }
+
+          // for (const auto &flow_item:  tx_item["flows"]) {
+          //   holoscan::ops::FlowConfig flow;
+          //   flow.name_          = flow_item["name"].as<std::string>();
+          //   flow.pattern_       = flow_item["pattern"].as<std::string>();
+
+          //   tx_cfg.flows_.emplace_back(flow);
+          // }
+
+          input_spec.tx_.emplace_back(tx_cfg);
+        }
+      } catch (const std::exception& e) {
+        GXF_LOG_ERROR(e.what());
+        return false;
+      }
+
+      HOLOSCAN_LOG_INFO("Finished reading advanced network operator config");
+
+      return true;
+    } catch (const std::exception& e) {
+      GXF_LOG_ERROR(e.what());
+      return false;
+    }
+  }
+};

--- a/operators/advanced_network/adv_network_dpdk_mgr.cpp
+++ b/operators/advanced_network/adv_network_dpdk_mgr.cpp
@@ -1,0 +1,1072 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <atomic>
+#include <cmath>
+#include <complex>
+#include <chrono>
+#include <iostream>
+#include <map>
+#include <set>
+
+#include "adv_network_dpdk_mgr.h"
+#include "holoscan/holoscan.hpp"
+
+
+using namespace std::chrono;
+
+namespace holoscan::ops {
+
+DpdkMgr dpdk_mgr{};
+
+std::atomic<bool> force_quit = false;
+
+struct TxWorkerParams {
+  int port;
+  int queue;
+  uint32_t batch_size;
+  struct rte_ring *ring;
+  struct rte_mempool *meta_pool;
+  struct rte_mempool *burst_pool;
+  struct rte_ether_addr mac_addr;
+};
+
+struct RxWorkerParams {
+  int port;
+  int queue;
+  uint32_t batch_size;
+  struct rte_ring *ring;
+  struct rte_mempool *burst_pool;
+  struct rte_mempool *meta_pool;
+  uint64_t rx_pkts = 0;
+  bool hds;
+};
+
+
+struct DPDKQueueConfig {
+  struct rte_mempool *pools[DpdkMgr::BUFFER_SPLIT_SEGS];
+  struct rte_eth_rxconf rxconf_qsplit;
+  union  rte_eth_rxseg  rx_useg[DpdkMgr::BUFFER_SPLIT_SEGS] = {};
+};
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+///
+///  \brief Init
+///
+////////////////////////////////////////////////////////////////////////////////
+void DpdkMgr::SetConfigAndInitialize(const AdvNetConfigYaml &cfg) {
+  if (!initialized) {
+    cfg_ = cfg;
+    Initialize();
+    Run();
+  }
+}
+
+
+void DpdkMgr::Initialize() {
+  int ret;
+  uint16_t portid;
+
+  struct rte_pktmbuf_extmem ext_mem;
+
+  static struct rte_eth_conf conf_eth_port = {
+    .rxmode = {
+      .mq_mode = RTE_ETH_MQ_RX_RSS,
+      .offloads = RTE_ETH_RX_OFFLOAD_BUFFER_SPLIT,  // Required by buffer split feature
+    },
+    .txmode = {
+      .mq_mode = RTE_ETH_MQ_TX_NONE,
+      .offloads = RTE_ETH_TX_OFFLOAD_MULTI_SEGS,
+    },
+    .rx_adv_conf = {
+      .rss_conf = {
+        .rss_key = NULL,
+        .rss_hf = RTE_ETH_RSS_IP
+      },
+    },
+  };
+
+  for (auto &conf : local_port_conf) {
+    conf = conf_eth_port;
+  }
+
+  /* Initialize DPDK params */
+  constexpr int max_nargs = 32;
+  constexpr int max_arg_size = 64;
+  char **_argv;
+  _argv = (char**)malloc(sizeof(char*) * max_nargs);
+  for (int i = 0; i < max_nargs; i++) {
+    _argv[i] = (char*)malloc(max_arg_size);
+  }
+
+  int arg = 0;
+  std::string cores = std::to_string(cfg_.common_.master_core_) + ",";
+  std::set<std::string> ifs;
+  std::set<std::string> gpu_bdfs;
+  std::unordered_map<uint16_t, std::pair<uint16_t, uint16_t>> port_q_num;
+  std::unordered_map<uint16_t, std::string> port_id_to_name;
+
+  // Get GPU PCIe BDFs since they're needed to pass to DPDK
+  for (const auto &rx : cfg_.rx_) {
+    ifs.emplace(rx.if_name_);
+    for (const auto &q : rx.queues_) {
+      cores += q.common_.cpu_cores_ + ",";
+
+      if (q.common_.gpu_direct_) {
+        char gpu_bdf[32];
+        if (cudaDeviceGetPCIBusId(gpu_bdf, sizeof(gpu_bdf), q.common_.gpu_dev_) != cudaSuccess) {
+          HOLOSCAN_LOG_CRITICAL("Cannot get GPU BDF for device ID {}", q.common_.gpu_dev_);
+          return;
+        }
+
+        gpu_bdfs.insert(std::string(gpu_bdf));
+        HOLOSCAN_LOG_INFO("Found GPU BDF {} for device ID {}", gpu_bdf, q.common_.gpu_dev_);
+      }
+    }
+  }
+
+  for (const auto &tx : cfg_.tx_) {
+    ifs.emplace(tx.if_name_);
+    for (const auto &q : tx.queues_) {
+      cores += q.common_.cpu_cores_ + ",";
+
+      if (q.common_.gpu_direct_) {
+        char gpu_bdf[32];
+        if (cudaDeviceGetPCIBusId(gpu_bdf, sizeof(gpu_bdf), q.common_.gpu_dev_) != cudaSuccess) {
+          HOLOSCAN_LOG_CRITICAL("Cannot get GPU BDF for device ID {}", q.common_.gpu_dev_);
+          return;
+        }
+
+        gpu_bdfs.insert(std::string(gpu_bdf));
+        HOLOSCAN_LOG_INFO("Found GPU BDF {} for device ID {}", gpu_bdf, q.common_.gpu_dev_);
+      }
+    }
+  }
+
+  cores = cores.substr(0, cores.size()-1);
+  // Get a unique set of interfaces
+  num_ports = ifs.size();
+  HOLOSCAN_LOG_INFO("Attempting to use {} ports for high-speed network", num_ports);
+
+  if (num_ports > 1) {
+    HOLOSCAN_LOG_CRITICAL("Only single NIC interface supported at this time!");
+    return;
+  }
+
+  strncpy(_argv[arg++], "adv_net_operator", max_arg_size - 1);
+  strncpy(_argv[arg++], "-l", max_arg_size - 1);
+  strncpy(_argv[arg++], cores.c_str(), max_arg_size - 1);
+  //  strncpy(_argv[arg++], "--log-level=99", max_arg_size - 1);
+  //  strncpy(_argv[arg++], "--log-level=pmd.net.mlx5:8", max_arg_size - 1);
+  for (const auto &name : ifs) {
+    strncpy(_argv[arg++], "-a", max_arg_size - 1);
+    strncpy(_argv[arg++], name.c_str(), max_arg_size - 1);
+    //  strncpy(_argv[arg++],
+    //  (name + std::string(",txq_inline_max=0,dv_flow_en=1")).c_str(), max_arg_size - 1);
+  }
+
+  for (const auto &gpu : gpu_bdfs) {
+    strncpy(_argv[arg++], "-a", max_arg_size - 1);
+    strncpy(_argv[arg++], gpu.c_str(), max_arg_size - 1);
+  }
+
+  _argv[arg] = nullptr;
+  std::string dpdk_args = "";
+  for (int ac = 0; ac < arg; ac++) {
+    dpdk_args += std::string(_argv[ac]) + " ";
+  }
+
+  HOLOSCAN_LOG_INFO("DPDK EAL arguments: {}", dpdk_args);
+
+  ret = rte_eal_init(arg, _argv);
+  if (ret < 0) {
+    HOLOSCAN_LOG_CRITICAL("Invalid EAL arguments: {}", rte_errno);
+    return;
+  }
+
+  for (int i = 0; i < num_ports; i++) {
+    rte_eth_macaddr_get(i, &mac_addrs[i]);
+  }
+
+  // Build name to id mapping
+  for (auto &rx : cfg_.rx_) {
+    ret = rte_eth_dev_get_port_by_name(rx.if_name_.c_str(), &rx.port_id_);
+    if (ret < 0) {
+      HOLOSCAN_LOG_CRITICAL("Failed to get port number for {}", rx.if_name_.c_str());
+      return;
+    }
+
+    port_q_num[rx.port_id_] = {rx.queues_.size(), 0};
+    port_id_to_name[rx.port_id_] = rx.if_name_;
+    rx.empty = false;
+  }
+
+  for (auto &tx : cfg_.tx_) {
+    ret = rte_eth_dev_get_port_by_name(tx.if_name_.c_str(), &tx.port_id_);
+    if (ret < 0) {
+      HOLOSCAN_LOG_CRITICAL("Failed to get port number for {}", tx.if_name_.c_str());
+      return;
+    }
+
+    if (port_q_num.find(tx.port_id_) == port_q_num.end()) {
+      port_q_num[tx.port_id_] = {0, tx.queues_.size()};
+    } else {
+      port_q_num[tx.port_id_].second = tx.queues_.size();
+    }
+    port_id_to_name[tx.port_id_] = tx.if_name_;
+    tx.empty = false;
+  }
+
+  HOLOSCAN_LOG_INFO("DPDK init -- RX: {} TX: {}", cfg_.rx_.size() > 0 ? "ENABLED" : "DISABLED",
+                                                  cfg_.tx_.size() > 0 ? "ENABLED" : "DISABLED");
+
+  // Create any missing queues default queues
+  for (const auto &[port, queues] : port_q_num) {
+    if (queues.first == 0) {
+      HOLOSCAN_LOG_INFO("Creating default queue for port {} receive", port);
+      RxQueueConfig q = {.common_ = {"Default", 0, 0, false, 0, "0", 1518, 32767, 1, nullptr}};
+      AdvNetRxConfig rxcfg;
+      rxcfg.if_name_ = port_id_to_name[port];
+      rxcfg.port_id_ = port;
+      rxcfg.empty = true;
+      rxcfg.queues_.emplace_back(q);
+      cfg_.rx_.emplace_back(rxcfg);
+      port_q_num[port].first = 1;
+    } else if (queues.second == 0) {
+      HOLOSCAN_LOG_INFO("Creating default queue for port {} transmit", port);
+      TxQueueConfig q = {.common_ = {"Default", 0, 0, false, 0, "0", 1518, 32767, 1, nullptr},
+                        .eth_dst_ = "", .ip_src_ = "", .ip_dst_ = "", .fill_type_ = "udp",
+                        .udp_src_port_ = 0, .udp_dst_port_ = 0};
+      AdvNetTxConfig txcfg;
+      txcfg.if_name_ = port_id_to_name[port];
+      txcfg.port_id_ = port;
+      txcfg.empty = true;
+      txcfg.queues_.emplace_back(q);
+      cfg_.tx_.emplace_back(txcfg);
+      port_q_num[port].second = 1;
+    }
+  }
+
+  // Queue setup
+  int max_batch_size = 0;
+  for (auto &rx : cfg_.rx_) {
+    int max_pkt_size = 0;
+    ret = rte_eth_dev_get_port_by_name(rx.if_name_.c_str(), &rx.port_id_);
+    if (ret < 0) {
+      HOLOSCAN_LOG_CRITICAL("Failed to get port number for {}", rx.if_name_.c_str());
+      return;
+    }
+
+    for (auto &q : rx.queues_) {
+      HOLOSCAN_LOG_INFO("Configuring queue: {} ({})", q.common_.name_, q.common_.id_);
+      q.common_.backend_config_ = new DPDKQueueConfig;
+      auto q_backend = static_cast<DPDKQueueConfig *>(q.common_.backend_config_);
+
+      std::string append = "_P" + std::to_string(rx.port_id_) + "_Q" +
+          std::to_string(q.common_.id_);
+      auto rx_mbufs = q.common_.num_concurrent_batches_* q.common_.batch_size_;
+      max_batch_size = std::max(max_batch_size, q.common_.batch_size_);
+      max_pkt_size   = std::max(max_pkt_size, q.common_.max_packet_size_);
+
+      if (q.common_.gpu_direct_ && q.common_.hds_ > 0) {
+        auto target_el_size = (q.common_.max_packet_size_ - q.common_.hds_) + RTE_PKTMBUF_HEADROOM;
+        ext_mem.elt_size = ((target_el_size + 3) / 4) * 4;
+        HOLOSCAN_LOG_INFO(
+            "Enabling header-data split on RX with split point of {} and GPU payload size {}",
+              q.common_.hds_, ext_mem.elt_size);
+
+        struct rte_eth_dev_info dev_info;
+        ret = rte_eth_dev_info_get(rx.port_id_, &dev_info);
+        if (ret != 0) {
+          HOLOSCAN_LOG_CRITICAL("Failed to get device info for port {}", rx.port_id_);
+          return;
+        }
+
+        ext_mem.buf_len = RTE_ALIGN_CEIL(rx_mbufs * ext_mem.elt_size, GPU_PAGE_SIZE);
+        HOLOSCAN_LOG_DEBUG("Allocated {} buffers totalling {} bytes of GPU memory for packets",
+              rx_mbufs, ext_mem.buf_len);
+        ext_mem.buf_iova = RTE_BAD_IOVA;
+
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        ext_mem.buf_ptr = rte_gpu_mem_alloc(q.common_.gpu_dev_, ext_mem.buf_len, CPU_PAGE_SIZE);
+  #pragma GCC diagnostic pop
+        if (ext_mem.buf_ptr == NULL) {
+          HOLOSCAN_LOG_CRITICAL("Could not allocate GPU device memory");
+          return;
+        } else {
+          HOLOSCAN_LOG_INFO("Allocated {:.2f}MB on GPU", ext_mem.buf_len/1e6);
+        }
+
+        ret = rte_extmem_register(ext_mem.buf_ptr, ext_mem.buf_len, NULL, ext_mem.buf_iova,
+              GPU_PAGE_SIZE);
+        if (ret) {
+          HOLOSCAN_LOG_CRITICAL("Unable to register addr {}, ret {}", ext_mem.buf_ptr, ret);
+          return;
+        } else {
+          HOLOSCAN_LOG_INFO("Successfully registered external memory");
+        }
+
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        ret = rte_dev_dma_map(dev_info.device, ext_mem.buf_ptr, ext_mem.buf_iova, ext_mem.buf_len);
+  #pragma GCC diagnostic pop
+        if (ret) {
+          HOLOSCAN_LOG_CRITICAL("Could not DMA map EXT memory: {} err={}", ret, rte_errno);
+          return;
+        }
+
+        std::string gpu_name = std::string("RX_GPU_POOL") + append;
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+        q_backend->pools[1] = rte_pktmbuf_pool_create_extbuf(gpu_name.c_str(), rx_mbufs,
+            0, 0, ext_mem.elt_size, rte_socket_id(), &ext_mem, 1);
+  #pragma GCC diagnostic pop
+        if (q_backend->pools[1] == NULL) {
+          HOLOSCAN_LOG_CRITICAL("Could not create EXT memory mempool");
+          return;
+        }
+
+        HOLOSCAN_LOG_INFO("Created GPU mempool for HDS: {} mbufs={} elsize={} ptr={}",
+            gpu_name, rx_mbufs, ext_mem.elt_size, (void*)q_backend->pools[1]);
+
+        auto cpu_name = std::string("RX_CPU_POOL") + append;
+        q_backend->pools[0] = rte_pktmbuf_pool_create(cpu_name.c_str(),
+            rx_mbufs,  MEMPOOL_CACHE_SIZE, 0, q.common_.hds_ + RTE_PKTMBUF_HEADROOM,
+                rte_socket_id());
+        if (!q_backend->pools[0]) {
+          HOLOSCAN_LOG_CRITICAL("Could not create sysmem mempool {} buffer split: {}",
+              cpu_name, rte_errno);
+          return;
+        }
+
+        HOLOSCAN_LOG_INFO("Created CPU mempool for HDS: {} mbufs={} elsize={} ptr={}",
+          cpu_name, rx_mbufs, q.common_.hds_ + RTE_PKTMBUF_HEADROOM, (void*)q_backend->pools[0]);
+
+        memcpy(&q_backend->rxconf_qsplit, &dev_info.default_rxconf,
+            sizeof(q_backend->rxconf_qsplit));
+
+        q_backend->rxconf_qsplit.offloads =
+            RTE_ETH_RX_OFFLOAD_SCATTER | RTE_ETH_RX_OFFLOAD_BUFFER_SPLIT;
+        q_backend->rxconf_qsplit.rx_nseg  = BUFFER_SPLIT_SEGS;
+        q_backend->rxconf_qsplit.rx_seg   = q_backend->rx_useg;
+
+        struct rte_eth_rxseg_split *rx_seg;
+        rx_seg = &q_backend->rx_useg[0].split;
+        rx_seg->mp = q_backend->pools[0];
+        rx_seg->length = q.common_.hds_;
+        rx_seg->offset = 0;
+
+        rx_seg = &q_backend->rx_useg[1].split;
+        rx_seg->mp = q_backend->pools[1];
+        rx_seg->length = 0;
+        rx_seg->offset = 0;
+
+        local_port_conf[rx.port_id_].rxmode.offloads |=
+            RTE_ETH_RX_OFFLOAD_SCATTER | RTE_ETH_RX_OFFLOAD_BUFFER_SPLIT;
+      } else {
+        /* Create the mbuf pools. */
+        auto pkt_size = q.common_.max_packet_size_ + RTE_PKTMBUF_HEADROOM + MAX_ETH_HDR_SIZE;
+        auto name = std::string("RX_CPU_POOL") + append;
+        q_backend->pools[0] = rte_pktmbuf_pool_create(name.c_str(),
+            rx_mbufs, MEMPOOL_CACHE_SIZE, 0, pkt_size, rte_socket_id());
+        if (q_backend->pools[0] == NULL) {
+          HOLOSCAN_LOG_CRITICAL("Cannot init mbuf pool");
+          return;
+        }
+
+        HOLOSCAN_LOG_INFO("Created RX pool {} with packet size {} bytes and {} mbufs at {}",
+            name, pkt_size, rx_mbufs, (void*)q_backend->pools[0]);
+      }
+    }
+
+    local_port_conf[rx.port_id_].rxmode.offloads |= RTE_ETH_RX_OFFLOAD_CHECKSUM;
+    local_port_conf[rx.port_id_].rxmode.mtu = max_pkt_size;
+    local_port_conf[rx.port_id_].rxmode.max_lro_pkt_size = max_pkt_size;
+  }
+
+  HOLOSCAN_LOG_INFO("Setting up RX ring");
+  rx_ring = rte_ring_create("RX_RING", 2048, rte_socket_id(),
+      RING_F_MC_RTS_DEQ | RING_F_MP_RTS_ENQ);
+  if (rx_ring == nullptr) {
+    HOLOSCAN_LOG_CRITICAL("Failed to allocate ring!");
+    return;
+  }
+
+  auto num_rx_ptrs_bufs = (1UL << 12) - 1;
+  HOLOSCAN_LOG_INFO("Setting up RX burst pool with {} batches",  num_rx_ptrs_bufs);
+  rx_burst_buffer = rte_mempool_create("RX_BURST_POOL",
+                    num_rx_ptrs_bufs,
+                    sizeof(void *) * max_batch_size * 2,  // 2 If HDR is enabled
+                    0,
+                    0,
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    rte_socket_id(),
+                    0);
+  if (rx_burst_buffer == nullptr) {
+    HOLOSCAN_LOG_CRITICAL("Failed to allocate RX burst pool!");
+    return;
+  }
+
+  HOLOSCAN_LOG_INFO("Setting up RX meta pool");
+  rx_meta = rte_mempool_create("RX_META_POOL",
+                    (1U << 6) - 1U,
+                    sizeof(AdvNetBurstParams),
+                    0,
+                    0,
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    rte_socket_id(),
+                    0);
+  if (rx_meta == nullptr) {
+    HOLOSCAN_LOG_CRITICAL("Failed to allocate RX meta pool!");
+    return;
+  }
+
+  // For now make a single queue. Support more sophisticated TX on next release
+  max_batch_size = 0;
+  for (auto &tx : cfg_.tx_) {
+    ret = rte_eth_dev_get_port_by_name(tx.if_name_.c_str(), &tx.port_id_);
+    if (ret < 0) {
+      HOLOSCAN_LOG_CRITICAL("Failed to get port number for {}", tx.if_name_.c_str());
+      return;
+    }
+
+    for (auto &q : tx.queues_) {
+      ret = rte_eth_dev_get_port_by_name(tx.if_name_.c_str(), &portid);
+      if (ret < 0) {
+        HOLOSCAN_LOG_CRITICAL("Failed to get port number for {}", tx.if_name_);
+        return;
+      }
+
+      if (q.common_.gpu_direct_ && q.common_.hds_ > 0) {
+        HOLOSCAN_LOG_CRITICAL("Header data split not supported on TX yet");
+        return;
+      }
+
+      q.common_.backend_config_ = new DPDKQueueConfig;
+      auto q_backend = static_cast<DPDKQueueConfig *>(q.common_.backend_config_);
+
+      max_batch_size = std::max(max_batch_size, q.common_.batch_size_);
+      auto tx_mbufs = q.common_.num_concurrent_batches_* q.common_.batch_size_;
+      auto pkt_size = q.common_.max_packet_size_ + RTE_PKTMBUF_HEADROOM;
+      q_backend->pools[0] = rte_pktmbuf_pool_create("TX_POOL",
+          tx_mbufs, MEMPOOL_CACHE_SIZE, 0, pkt_size, rte_socket_id());
+      if (q_backend->pools[0] == NULL) {
+        HOLOSCAN_LOG_CRITICAL("Cannot init TX mbuf pool");
+        return;
+      }
+
+      HOLOSCAN_LOG_INFO("Created TX pool with packet size {} bytes and {} mbufs",
+            pkt_size, tx_mbufs);
+    }
+
+    local_port_conf[tx.port_id_].txmode.mq_mode  =  RTE_ETH_MQ_TX_NONE;
+    local_port_conf[tx.port_id_].txmode.offloads =  RTE_ETH_TX_OFFLOAD_IPV4_CKSUM  |
+                                                    RTE_ETH_TX_OFFLOAD_UDP_CKSUM   |
+                                                    RTE_ETH_TX_OFFLOAD_TCP_CKSUM;
+    // Add multi-seg offload when TX GPUDirect is supported
+  }
+
+  HOLOSCAN_LOG_INFO("Setting up TX ring");
+  tx_ring = rte_ring_create("TX_RING", 2048, rte_socket_id(),
+        RING_F_MC_RTS_DEQ | RING_F_MP_RTS_ENQ);
+  if (tx_ring == nullptr) {
+    HOLOSCAN_LOG_CRITICAL("Failed to allocate ring!");
+    return;
+  }
+
+  HOLOSCAN_LOG_INFO("Setting up TX meta pool");
+  tx_meta = rte_mempool_create("TX_META_POOL",
+                    (1U << 6) - 1U,
+                    sizeof(AdvNetBurstParams),
+                    0,
+                    0,
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    rte_socket_id(),
+                    0);
+  if (tx_meta == nullptr) {
+    HOLOSCAN_LOG_CRITICAL("Failed to allocate TX meta pool!");
+    return;
+  }
+
+  HOLOSCAN_LOG_INFO("Setting up TX burst pool with {} pointers", max_batch_size);
+  tx_burst_buffer = rte_mempool_create("TX_BURST_POOL",
+                    (1U << 5) - 1U,
+                    sizeof(void *) * max_batch_size * 2,
+                    0,
+                    0,
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    rte_socket_id(),
+                    0);
+  if (tx_burst_buffer == nullptr) {
+    HOLOSCAN_LOG_CRITICAL("Failed to allocate TX message pool!");
+    return;
+  }
+
+  for (const auto &[port, queues] : port_q_num) {
+    HOLOSCAN_LOG_INFO("Initializing port {} with {} RX queues and {} TX queues...",
+        port, queues.first, queues.second);
+
+    ret = rte_eth_dev_configure(port, queues.first, queues.second, &local_port_conf[port]);
+    if (ret < 0) {
+      HOLOSCAN_LOG_CRITICAL("Cannot configure device: err={}, str={}, port={}",
+            ret, rte_strerror(ret), port);
+      return;
+    } else {
+      HOLOSCAN_LOG_INFO("Successfully configured ethdev");
+    }
+
+    ret = rte_eth_dev_adjust_nb_rx_tx_desc(port, &default_num_rx_desc, &default_num_tx_desc);
+    if (ret < 0) {
+      HOLOSCAN_LOG_CRITICAL("Cannot adjust number of descriptors: err={}, port={}", ret, port);
+      return;
+    } else {
+      HOLOSCAN_LOG_INFO("Successfully set descriptors");
+    }
+
+    rte_eth_macaddr_get(port, &conf_ports_eth_addr[port]);
+
+    for (const auto &rx : cfg_.rx_) {
+      if (port != rx.port_id_) {
+        continue;
+      }
+
+      if (rx.flow_isolation_) {
+        struct rte_flow_error error;
+        ret = rte_flow_isolate(rx.port_id_, 1, &error);
+        if (ret < 0) {
+          HOLOSCAN_LOG_CRITICAL("Failed to set flow isolation");
+        }
+      }
+
+      for (const auto &q : rx.queues_) {
+        // Assume one core for now
+        auto socketid = rte_lcore_to_socket_id(strtol(q.common_.cpu_cores_.c_str(), nullptr, 10));
+        auto qinfo    = static_cast<DPDKQueueConfig *>(q.common_.backend_config_);
+
+        if (q.common_.gpu_direct_ && q.common_.hds_ > 0) {
+          ret = rte_eth_rx_queue_setup(rx.port_id_, q.common_.id_,
+                default_num_rx_desc, socketid, &qinfo->rxconf_qsplit, NULL);
+        } else {
+          ret = rte_eth_rx_queue_setup(rx.port_id_, q.common_.id_,
+                default_num_rx_desc, socketid, NULL, qinfo->pools[0]);
+        }
+
+        if (ret < 0) {
+          HOLOSCAN_LOG_CRITICAL("rte_eth_rx_queue_setup: err={}, port={}", ret, rx.port_id_);
+          return;
+        } else {
+          HOLOSCAN_LOG_INFO("Successfully setup RX port {} queue {} pools: {} {}",
+                rx.port_id_, q.common_.id_, (void*)qinfo->pools[0], (void*)qinfo->pools[1]);
+        }
+      }
+
+      break;
+    }
+
+
+    struct rte_eth_txconf txq_conf;
+    struct rte_eth_dev_info dev_info;
+
+    ret = rte_eth_dev_info_get(port, &dev_info);
+    if (ret != 0) {
+      HOLOSCAN_LOG_CRITICAL("Failed to get device info for port {}", port);
+      return;
+    }
+
+    for (const auto &tx : cfg_.tx_) {
+      if (port != tx.port_id_) {
+        continue;
+      }
+
+      for (const auto &q : tx.queues_) {
+        txq_conf = dev_info.default_txconf;
+        txq_conf.offloads = local_port_conf[tx.port_id_].txmode.offloads;
+        ret = rte_eth_tx_queue_setup(tx.port_id_, q.common_.id_, default_num_tx_desc,
+            rte_eth_dev_socket_id(tx.port_id_), &txq_conf);
+        if (ret < 0) {
+          HOLOSCAN_LOG_CRITICAL("Queue setup error {}:{}, port={} caps={:x} set={:x}",
+            ret, rte_strerror(ret), tx.port_id_, dev_info.tx_offload_capa,
+              local_port_conf[tx.port_id_].txmode.offloads);
+          return;
+        } else {
+          HOLOSCAN_LOG_INFO("Successfully setup TX queue");
+        }
+      }
+
+      break;
+    }
+  }
+
+  for (const auto &[port, queues] : port_q_num) {
+    ret = rte_eth_dev_start(port);
+    if (ret != 0) {
+      HOLOSCAN_LOG_CRITICAL("Cannot start device err={}, port={}", ret, port);
+      return;
+    } else {
+      HOLOSCAN_LOG_INFO("Successfully started port {}", port);
+    }
+
+    rte_eth_promiscuous_enable(port);
+    HOLOSCAN_LOG_INFO("Port {}, MAC address: {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+      port,
+      conf_ports_eth_addr[port].addr_bytes[0],
+      conf_ports_eth_addr[port].addr_bytes[1],
+      conf_ports_eth_addr[port].addr_bytes[2],
+      conf_ports_eth_addr[port].addr_bytes[3],
+      conf_ports_eth_addr[port].addr_bytes[4],
+      conf_ports_eth_addr[port].addr_bytes[5]);
+  }
+
+  int flow_num = 0;
+  for (const auto &rx : cfg_.rx_) {
+    for (const auto &flow : rx.flows_) {
+      HOLOSCAN_LOG_INFO("Adding RX flow {}", flow.name_);
+      AddFlow(rx.port_id_, flow);
+    }
+  }
+
+  initialized = true;
+}
+
+#define MAX_PATTERN_NUM    4
+#define MAX_ACTION_NUM    2
+
+// Taken from flow_block.c DPDK example */
+struct rte_flow *DpdkMgr::AddFlow(int port, const FlowConfig &cfg) {
+  /* Declaring structs being used. 8< */
+  struct rte_flow_attr attr;
+  struct rte_flow_item pattern[MAX_PATTERN_NUM];
+  struct rte_flow_action action[MAX_ACTION_NUM];
+  struct rte_flow *flow = NULL;
+  struct rte_flow_action_queue queue = { .index = cfg.action_.id_ };
+  struct rte_flow_error error;
+  struct rte_flow_item_udp udp_spec;
+  struct rte_flow_item_udp udp_mask;
+  struct rte_flow_item udp_item;
+  /* >8 End of declaring structs being used. */
+  int res;
+
+  memset(pattern, 0, sizeof(pattern));
+  memset(action, 0, sizeof(action));
+
+  /* Set the rule attribute, only ingress packets will be checked. 8< */
+  memset(&attr, 0, sizeof(struct rte_flow_attr));
+  attr.ingress = 1;
+  /* >8 End of setting the rule attribute. */
+
+  /*
+   * create the action sequence.
+   * one action only,  move packet to queue
+   */
+  action[0].type = RTE_FLOW_ACTION_TYPE_QUEUE;
+  action[0].conf = &queue;
+  action[1].type = RTE_FLOW_ACTION_TYPE_END;
+
+  /*
+   * set the first level of the pattern (ETH).
+   * since in this example we just want to get the
+   * ipv4 we set this level to allow all.
+   */
+
+  /* Set this level to allow all. 8< */
+  pattern[0].type = RTE_FLOW_ITEM_TYPE_ETH;
+  pattern[1].type = RTE_FLOW_ITEM_TYPE_IPV4;
+
+  /* >8 End of setting the first level of the pattern. */
+  udp_spec.hdr.src_port = htons(cfg.match_.udp_src_);
+  udp_spec.hdr.dst_port = htons(cfg.match_.udp_dst_);
+  udp_spec.hdr.dgram_len = 0;
+  udp_spec.hdr.dgram_cksum = 0;
+
+  udp_mask.hdr.src_port = 0xffff;
+  udp_mask.hdr.dst_port = 0xffff;
+  udp_mask.hdr.dgram_len = 0;
+  udp_mask.hdr.dgram_cksum = 0;
+
+  udp_item.type = RTE_FLOW_ITEM_TYPE_UDP;
+  udp_item.spec = &udp_spec;
+  udp_item.mask = &udp_mask;
+  udp_item.last = NULL;
+
+  pattern[2] = udp_item;
+
+  attr.priority = 0;
+
+  /* The final level must be always type end. 8< */
+  pattern[3].type = RTE_FLOW_ITEM_TYPE_END;
+  /* >8 End of final level must be always type end. */
+
+  /* Validate the rule and create it. 8< */
+  res = rte_flow_validate(port, &attr, pattern, action, &error);
+  if (!res) {
+    flow = rte_flow_create(port, &attr, pattern, action, &error);
+    return flow;
+  }
+
+  return nullptr;
+}
+
+int DpdkMgr::GetRxPkts(void **pkts, int num) {
+  return rte_ring_dequeue_bulk(rx_ring, pkts, num, nullptr);
+}
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+///
+///  \brief
+///
+////////////////////////////////////////////////////////////////////////////////
+void PrintDpdkStats() {
+    struct rte_eth_stats eth_stats;
+    int len, ret, i;
+    RTE_ETH_FOREACH_DEV(i) {
+      rte_eth_stats_get(i, &eth_stats);
+      printf("\n\nPort %u:\n", i);
+
+      printf(" - Received packets:    %lu\n", eth_stats.ipackets);
+      printf(" - Transmit packets:    %lu\n", eth_stats.opackets);
+      printf(" - Received bytes:      %lu\n", eth_stats.ibytes);
+      printf(" - Transmit bytes:      %lu\n", eth_stats.obytes);
+      printf(" - Missed packets:      %lu\n", eth_stats.imissed);
+      printf(" - Errored packets:     %lu\n", eth_stats.ierrors);
+      printf(" - RX no mbufs:         %lu\n", eth_stats.rx_nombuf);
+
+      printf("\nXStats\n");
+
+      struct rte_eth_xstat *xstats;
+      struct rte_eth_xstat_name *xstats_names;
+      static const char *stats_border = "_______";
+
+      /* Clear screen and move to top left */
+
+      printf("PORT STATISTICS:\n================\n");
+      len = rte_eth_xstats_get(i, NULL, 0);
+      if (len < 0)
+          rte_exit(EXIT_FAILURE,
+                  "rte_eth_xstats_get(%u) failed: %d", 0,
+                  len);
+      xstats = (struct rte_eth_xstat *)calloc(len, sizeof(*xstats));
+      if (xstats == NULL)
+          rte_exit(EXIT_FAILURE,
+                  "Failed to calloc memory for xstats");
+      ret = rte_eth_xstats_get(i, xstats, len);
+      if (ret < 0 || ret > len) {
+          free(xstats);
+          rte_exit(EXIT_FAILURE,
+                  "rte_eth_xstats_get(%u) len%i failed: %d",
+                  0, len, ret);
+      }
+      xstats_names = (struct rte_eth_xstat_name *)calloc(len, sizeof(*xstats_names));
+      if (xstats_names == NULL) {
+          free(xstats);
+          rte_exit(EXIT_FAILURE,
+                  "Failed to calloc memory for xstats_names");
+      }
+      ret = rte_eth_xstats_get_names(i, xstats_names, len);
+      if (ret < 0 || ret > len) {
+          free(xstats);
+          free(xstats_names);
+          rte_exit(EXIT_FAILURE,
+                  "rte_eth_xstats_get_names(%u) len%i failed: %d",
+                  0, len, ret);
+      }
+      for (i = 0; i < len; i++) {
+          if (xstats[i].value > 0)
+              printf("Port %u: %s %s:\t\t%lu\n",
+                      0, stats_border,
+                      xstats_names[i].name,
+                      xstats[i].value);
+      }
+      fflush(stdout);
+      free(xstats);
+      free(xstats_names);
+  }
+}
+
+DpdkMgr::~DpdkMgr() {
+  PrintDpdkStats();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+///
+///  \brief
+///
+////////////////////////////////////////////////////////////////////////////////
+void DpdkMgr::Run() {
+  int secondary_id = 0;
+  int icore;
+
+  HOLOSCAN_LOG_INFO("Starting advanced network workers");
+  // determine the correct process types for input/output
+  int (*rx_worker)(void*) = rx_core;
+  int (*tx_worker)(void*) = tx_core;
+
+  for (auto &rx : cfg_.rx_) {
+    if (rx.empty) {
+      continue;
+    }
+    for (auto &q : rx.queues_) {
+      auto qinfo = static_cast<DPDKQueueConfig *>(q.common_.backend_config_);
+      auto params = new RxWorkerParams;
+      params->hds    = q.common_.hds_ > 0;
+      params->port   = rx.port_id_;
+      params->ring   = rx_ring;
+      params->queue  = q.common_.id_;
+      params->burst_pool   = rx_burst_buffer;
+      params->meta_pool  = rx_meta;
+      params->batch_size = q.common_.batch_size_;
+      rte_eal_remote_launch(rx_worker, (void*)params,
+          strtol(q.common_.cpu_cores_.c_str(), NULL, 10));
+    }
+  }
+
+  for (auto &tx : cfg_.tx_) {
+    if (tx.empty) {
+      continue;
+    }
+    for (auto &q : tx.queues_) {
+      auto qinfo = static_cast<DPDKQueueConfig *>(q.common_.backend_config_);
+      auto params = new TxWorkerParams;
+      //  params->hds    = q.common_.hds_ > 0;
+      params->port   = tx.port_id_;
+      params->ring   = tx_ring;
+      params->queue  = q.common_.id_;
+      params->burst_pool  = tx_burst_buffer;
+      params->meta_pool   = tx_meta;
+      params->batch_size  = q.common_.batch_size_;
+      rte_eth_macaddr_get(tx.port_id_, &params->mac_addr);
+      rte_eal_remote_launch(tx_worker, (void*)params,
+          strtol(q.common_.cpu_cores_.c_str(), NULL, 10));
+    }
+  }
+
+  HOLOSCAN_LOG_INFO("Done starting workers");
+}
+
+void DpdkMgr::wait() {
+  int icore = 0;
+
+  HOLOSCAN_LOG_INFO("Stopping all workers");
+  force_quit.store(true);
+  RTE_LCORE_FOREACH_WORKER(icore) {
+    if (rte_eal_wait_lcore(icore) < 0) {
+      fprintf(stderr, "bad exit for coreid: %d\n", icore);
+      break;
+    }
+  }
+
+  PrintDpdkStats();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+///  \brief
+///
+////////////////////////////////////////////////////////////////////////////////
+void DpdkMgr::flush_packets(int port) {
+  struct rte_mbuf * rx_mbuf;
+  HOLOSCAN_LOG_INFO("Flushing packet on port {}", port);
+  while (rte_eth_rx_burst(port, 0, &rx_mbuf, 1) != 0) {
+    rte_pktmbuf_free(rx_mbuf);
+  }
+}
+
+void DpdkMgr::check_pkts_to_free(rte_ring *msg_ring,
+    rte_mempool *burst_pool, rte_mempool *meta_pool) {
+    AdvNetBurstParams *msg;
+    if (rte_ring_dequeue(msg_ring, reinterpret_cast<void**>(&msg)) == 0) {
+      for (int p = 0; p < msg->hdr.num_pkts; p++) {
+        rte_pktmbuf_free_seg(reinterpret_cast<rte_mbuf*>(msg->cpu_pkts[p]));
+      }
+      rte_mempool_put(burst_pool, msg->cpu_pkts);
+      rte_mempool_put(meta_pool, msg);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///
+///  \brief
+///
+////////////////////////////////////////////////////////////////////////////////
+int DpdkMgr::rx_core(void *arg) {
+  RxWorkerParams *tparams = (RxWorkerParams*)arg;
+  struct rte_mbuf * rx_mbufs[DEFAULT_NUM_RX_BURST];
+  int ret = 0;
+
+  uint64_t freq = rte_get_tsc_hz();
+  uint64_t timeout_ticks = freq * 0.02;  // expect all packets within 20ms
+
+  uint64_t total_pkts = 0;
+
+  flush_packets(tparams->port);
+  struct rte_mbuf* mbuf_arr[DEFAULT_NUM_RX_BURST];
+
+  HOLOSCAN_LOG_INFO("Starting RX Core {}, port {}, queue {}, socket {}",
+      rte_lcore_id(), tparams->port, tparams->queue, rte_socket_id());
+  int nb_rx = 0;
+  int to_copy = 0;
+  //
+  //  run loop
+  //
+  while (!force_quit.load()) {
+    AdvNetBurstParams *burst;
+    if (rte_mempool_get(tparams->meta_pool, reinterpret_cast<void **>(&burst)) < 0) {
+      HOLOSCAN_LOG_ERROR("Processing function falling behind. No free buffers for metadata!");
+      exit(1);
+    }
+
+    if (rte_mempool_get(tparams->burst_pool, reinterpret_cast<void **>(&burst->cpu_pkts)) < 0) {
+      HOLOSCAN_LOG_ERROR("Processing function falling behind. No free CPU buffers for packets!");
+      continue;
+    }
+
+    //  Queue ID for receiver to differentiate
+    burst->hdr.q_id = tparams->queue;
+
+    if (tparams->hds) {
+      if (rte_mempool_get(tparams->burst_pool, reinterpret_cast<void **>(&burst->gpu_pkts)) < 0) {
+        HOLOSCAN_LOG_ERROR("Processing function falling behind. No free GPU buffers for packets!");
+        rte_mempool_put(tparams->burst_pool, burst->cpu_pkts);
+        continue;
+      }
+    } else {
+      burst->gpu_pkts = nullptr;
+    }
+
+    if (nb_rx > 0) {
+      memcpy(&burst->cpu_pkts[0], &mbuf_arr[to_copy], sizeof(rte_mbuf*) * nb_rx);
+      burst->hdr.num_pkts = nb_rx;
+
+      if (tparams->hds) {
+        for (int p = 0; p < nb_rx; p++) {
+          burst->gpu_pkts[p] = mbuf_arr[to_copy + p]->next;
+        }
+      }
+
+      nb_rx = 0;
+    } else {
+      burst->hdr.num_pkts = 0;
+    }
+
+    // DPDK on some ARM platforms requires that you always pass nb_pkts as a number divisible
+    // by 4. If you pass something other than that, you get undefined results and will end up
+    // running out of buffers.
+    do {
+      int burst_size = std::min((uint32_t)DEFAULT_NUM_RX_BURST,
+          (uint32_t)(tparams->batch_size - burst->hdr.num_pkts));
+      nb_rx  = rte_eth_rx_burst(tparams->port, tparams->queue,
+          reinterpret_cast<rte_mbuf**>(&mbuf_arr[0]), DEFAULT_NUM_RX_BURST);
+
+      if (nb_rx == 0) {
+        continue;
+      }
+
+      to_copy       = std::min(nb_rx, (int)(tparams->batch_size - burst->hdr.num_pkts));
+      memcpy(&burst->cpu_pkts[burst->hdr.num_pkts], mbuf_arr, sizeof(rte_mbuf*) * to_copy);
+      if (tparams->hds) {
+        for (int p = 0; p < to_copy; p++) {
+          burst->gpu_pkts[burst->hdr.num_pkts + p] = mbuf_arr[p]->next;
+        }
+      }
+
+      burst->hdr.num_pkts += to_copy;
+      nb_rx               -= to_copy;
+      total_pkts          += nb_rx;
+
+      if (burst->hdr.num_pkts == tparams->batch_size) {
+        rte_ring_enqueue(tparams->ring, reinterpret_cast<void *>(burst));
+        break;
+      }
+    } while (!force_quit.load());
+  }
+
+  HOLOSCAN_LOG_ERROR("Total packets received by application (port/queue {}/{}): {}\n",
+        tparams->port, tparams->queue, total_pkts);
+  return 0;
+}
+
+
+
+int DpdkMgr::tx_core(void *arg) {
+  TxWorkerParams *tparams = (TxWorkerParams*)arg;
+  uint64_t seq;
+  uint64_t pkts_tx = 0;
+  AdvNetBurstParams *msg;
+  int64_t bursts = 0;
+
+  HOLOSCAN_LOG_INFO("Starting TX Core {}, port {}, queue {} socket {}", rte_lcore_id(),
+        tparams->port, tparams->queue, rte_socket_id());
+
+  while (!force_quit.load()) {
+    if (rte_ring_dequeue(tparams->ring, reinterpret_cast<void**>(&msg)) != 0) {
+      continue;
+    }
+
+    HOLOSCAN_LOG_DEBUG("Got burst in TX");
+
+    for (size_t p = 0; p < msg->hdr.num_pkts; p++) {
+      auto *mbuf = reinterpret_cast<rte_mbuf*>(msg->cpu_pkts[p]);
+      auto *pkt  = rte_pktmbuf_mtod(mbuf, uint8_t*);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+      rte_ether_addr_copy(&tparams->mac_addr, reinterpret_cast<rte_ether_addr *>(pkt + 6));
+#pragma GCC diagnostic pop
+
+      mbuf->ol_flags = RTE_MBUF_F_TX_IPV4 | RTE_MBUF_F_TX_IP_CKSUM | RTE_MBUF_F_TX_UDP_CKSUM;
+    }
+
+    auto pkts_to_transmit = static_cast<int64_t>(msg->hdr.num_pkts);
+
+    size_t pkts_tx = 0;
+    while (pkts_tx != msg->hdr.num_pkts && !force_quit.load()) {
+      auto to_send = static_cast<uint16_t>(
+            std::min(static_cast<size_t>(DEFAULT_NUM_TX_BURST), msg->hdr.num_pkts - pkts_tx));
+      int tx = rte_eth_tx_burst(tparams->port,
+            tparams->queue, reinterpret_cast<rte_mbuf**>(&msg->cpu_pkts[pkts_tx]), to_send);
+
+      pkts_tx += tx;
+    }
+
+    rte_mempool_put(tparams->burst_pool, static_cast<void*>(msg->cpu_pkts));
+    rte_mempool_put(tparams->meta_pool, msg);
+
+    HOLOSCAN_LOG_DEBUG("Sent {} packets\n", pkts_tx);
+
+    bursts++;
+  }
+  printf("TX thread exiting\n");
+
+  return 0;
+}
+};  // namespace holoscan::ops

--- a/operators/advanced_network/adv_network_dpdk_mgr.h
+++ b/operators/advanced_network/adv_network_dpdk_mgr.h
@@ -1,0 +1,111 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <vector>
+#include <string>
+#include <tuple>
+#include <rte_common.h>
+#include <rte_log.h>
+#include <rte_malloc.h>
+#include <rte_memory.h>
+#include <rte_memcpy.h>
+#include <rte_eal.h>
+#include <rte_launch.h>
+#include <rte_atomic.h>
+#include <rte_cycles.h>
+#include <rte_prefetch.h>
+#include <rte_lcore.h>
+#include <rte_per_lcore.h>
+#include <rte_branch_prediction.h>
+#include <rte_interrupts.h>
+#include <rte_random.h>
+#include <rte_debug.h>
+#include <rte_ether.h>
+#include <rte_ethdev.h>
+#include <rte_mempool.h>
+#include <rte_mbuf.h>
+#include <rte_metrics.h>
+#include <rte_bitrate.h>
+#include <rte_latencystats.h>
+#include <rte_flow.h>
+#include <rte_gpudev.h>
+#include <atomic>
+#include "adv_network_common.h"
+
+namespace holoscan::ops {
+
+class DpdkMgr {
+ public:
+    DpdkMgr() {
+      static_assert(MAX_INTERFACES <= RTE_MAX_ETHPORTS, "Too many interfaces configured");
+    }
+    ~DpdkMgr();
+    void SetConfigAndInitialize(const AdvNetConfigYaml &cfg);
+    int GetRxPkts(void **pkts, int num);
+    void Initialize();
+    void Run();
+    void wait();
+    static int rx_core(void *arg);
+    static int tx_core(void *arg);
+    static void check_pkts_to_free(rte_ring *msg_ring,
+          rte_mempool *burst_pool, rte_mempool *meta_pool);
+    static constexpr int JUMBFRAME_SIZE = 9100;
+    static constexpr int DEFAULT_NUM_TX_BURST = 256;
+    static constexpr int DEFAULT_NUM_RX_BURST = 1024;
+    uint16_t default_num_rx_desc = 8192;
+    uint16_t default_num_tx_desc = 8192;
+    int num_ports = 0;
+    static constexpr int MAX_IFS = 4;
+    static constexpr int num_lcores = 2;
+    static constexpr int MEMPOOL_CACHE_SIZE = 32;
+    static constexpr int MAX_PKT_BURST = 64;
+    static constexpr uint32_t GPU_PAGE_SHIFT = 16;
+    static constexpr uint32_t GPU_PAGE_SIZE = (1UL << GPU_PAGE_SHIFT);
+    static constexpr uint32_t GPU_PAGE_OFFSET = (GPU_PAGE_SIZE - 1);
+    static constexpr uint32_t GPU_PAGE_MASK = (~GPU_PAGE_OFFSET);
+    static constexpr uint32_t CPU_PAGE_SIZE = 4096;
+    static constexpr int BUFFER_SPLIT_SEGS = 2;
+    static constexpr int MAX_ETH_HDR_SIZE = 18;
+
+
+ private:
+    static void flush_packets(int port);
+    struct rte_flow *AddFlow(int port, const FlowConfig &cfg);
+    std::string GetQueueName(int port, int q, AdvNetDirection dir);
+
+    AdvNetConfigYaml cfg_;
+    std::array<std::string, MAX_IFS> if_names;
+    std::array<std::string, MAX_IFS> pcie_addrs;
+    std::array<struct rte_ether_addr, MAX_IFS> mac_addrs;
+    struct rte_ether_addr conf_ports_eth_addr[RTE_MAX_ETHPORTS];
+    struct rte_pktmbuf_extmem ext_mem;
+    struct rte_ring *rx_ring;
+    struct rte_ring *tx_ring;
+    struct rte_mempool *rx_burst_buffer;
+    struct rte_mempool *rx_meta;
+    struct rte_mempool *tx_meta;
+    struct rte_mempool *tx_burst_buffer;
+    std::array<struct rte_eth_conf, MAX_INTERFACES> local_port_conf;
+
+    bool initialized = false;
+    int num_init = 0;
+};
+
+extern DpdkMgr dpdk_mgr;
+};  // namespace holoscan::ops

--- a/operators/advanced_network/adv_network_kernels.cu
+++ b/operators/advanced_network/adv_network_kernels.cu
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "adv_network_kernels.h"
+
+/**
+ * @brief Simple packet reorder kernel to demonstrate reordering a batch of packets into 
+ *        contiguous memory
+ *
+ * @param out Output buffer
+ * @param in Pointer to list of input packet pointers
+ * @param pkt_len Length of each packet. All packets must be same length for this example
+ * @param num_pkts Number of packets
+ */
+__global__ void simple_packet_reorder_kernel(void * __restrict__ out,
+                                            const void *const *const __restrict__ in,
+                                            uint16_t pkt_len,
+                                            uint32_t num_pkts) {
+  const int pkt_idx = blockIdx.x;
+  const int len = pkt_len;
+  const void *in_pkt = in[pkt_idx];
+
+  if (pkt_idx < num_pkts) {
+    for (int pos = threadIdx.x; pos < len / 4; pos += blockDim.x) {
+      const uint32_t *in_ptr  = static_cast<const uint32_t*>(in_pkt) + pos;
+      uint32_t *out_ptr       = static_cast<uint32_t*>(out)    + pos;
+      out_ptr[pos]            = in_ptr[pos];
+    }
+  }
+}
+
+/**
+ * @brief Wrapper to launch packet reorder kernel
+ *
+ * @param out Output buffer
+ * @param in Pointer to list of input packet pointers
+ * @param pkt_len Length of each packet. All packets must be same length for this example
+ * @param num_pkts Number of packets
+ */
+void simple_packet_reorder(void *out, const void *const *const in,
+          uint16_t pkt_len, uint32_t num_pkts) {
+  simple_packet_reorder_kernel<<<num_pkts, 128>>>(out, in, pkt_len, num_pkts);
+}

--- a/operators/advanced_network/adv_network_kernels.h
+++ b/operators/advanced_network/adv_network_kernels.h
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <stdint.h>
+
+void simple_packet_reorder(void *out,
+                           const void *const *const in,
+                           uint16_t pkt_len,
+                           uint32_t num_pkts);

--- a/operators/advanced_network/adv_network_rx.cpp
+++ b/operators/advanced_network/adv_network_rx.cpp
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "adv_network_rx.h"
+#include "adv_network_dpdk_mgr.h"
+#include <memory>
+
+namespace holoscan::ops {
+
+struct AdvNetworkOpRx::AdvNetworkOpRxImpl {
+  DpdkMgr *dpdk_mgr;
+  struct rte_ring *rx_ring;
+  struct rte_mempool *rx_desc_pool;
+  struct rte_mempool *rx_meta_pool;
+  AdvNetConfigYaml cfg;
+};
+
+
+void AdvNetworkOpRx::setup(OperatorSpec& spec) {
+  spec.output<AdvNetBurstParams *>("burst_out");
+
+  spec.param(
+      cfg_,
+      "cfg",
+      "Configuration",
+      "Configuration for the advanced network operator",
+      AdvNetConfigYaml());
+}
+
+void AdvNetworkOpRx::initialize() {
+  HOLOSCAN_LOG_INFO("AdvNetworkOpRx::initialize()");
+  register_converter<holoscan::ops::AdvNetConfigYaml>();
+
+  holoscan::Operator::initialize();
+  Init();
+}
+
+int AdvNetworkOpRx::Init() {
+  impl = new AdvNetworkOpRxImpl();
+  impl->cfg = cfg_.get();
+  impl->dpdk_mgr = &dpdk_mgr;
+  impl->dpdk_mgr->SetConfigAndInitialize(impl->cfg);
+  impl->rx_desc_pool = nullptr;
+  impl->rx_ring = nullptr;
+
+  return 0;
+}
+
+
+
+void AdvNetworkOpRx::compute([[maybe_unused]] InputContext&, OutputContext& op_output,
+      [[maybe_unused]] ExecutionContext&) {
+  int n;
+  AdvNetBurstParams *burst;
+
+  if (unlikely(impl->rx_ring == nullptr)) {
+    impl->rx_ring = rte_ring_lookup("RX_RING");
+  }
+
+  if (unlikely(impl->rx_desc_pool == nullptr)) {
+    impl->rx_desc_pool = rte_mempool_lookup("RX_BURST_POOL");
+  }
+
+  if (unlikely(impl->rx_meta_pool == nullptr)) {
+    impl->rx_meta_pool = rte_mempool_lookup("RX_META_POOL");
+  }
+
+  if (rte_ring_dequeue(impl->rx_ring, reinterpret_cast<void**>(&burst)) < 0) {
+    return;
+  }
+
+  auto adv_burst = std::make_shared<AdvNetBurstParams>();
+  memcpy(adv_burst.get(), burst, sizeof(*burst));
+  rte_mempool_put(impl->rx_meta_pool, burst);
+
+  op_output.emit(adv_burst, "burst_out");
+}
+
+};  // namespace holoscan::ops

--- a/operators/advanced_network/adv_network_rx.h
+++ b/operators/advanced_network/adv_network_rx.h
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include "adv_network_common.h"
+#include "holoscan/holoscan.hpp"
+#include <experimental/propagate_const>
+
+
+
+namespace holoscan::ops {
+/*
+  Class for handling data from a high-speed network. This can be used for low-speed networks too,
+  but requires more configuration that's not necessarily needed with low-speed networks.
+*/
+
+class AdvNetworkOpRx : public Operator {
+  class AdvNetworkOpRxImpl;
+
+ public:
+    HOLOSCAN_OPERATOR_FORWARD_ARGS(AdvNetworkOpRx);
+    AdvNetworkOpRx() = default;
+    ~AdvNetworkOpRx() = default;
+
+    void initialize() override;
+    int Init();
+    int FreeBurst(AdvNetBurstParams *burst);
+
+    // Holoscan functions
+    void setup(OperatorSpec& spec) override;
+    void compute(InputContext&, OutputContext& op_output, ExecutionContext&) override;
+
+
+ private:
+    static constexpr int RX_BURST_SIZE = 128;
+    AdvNetworkOpRxImpl *impl;
+    Parameter<std::string> if_name_;
+    Parameter<std::string> cpu_cores_;
+    Parameter<std::string> master_core_;
+    Parameter<std::string> direction_;
+    Parameter<int> hds_split_;
+    Parameter<int> gpu_device_;
+    Parameter<int> batch_size_;
+    Parameter<int> max_packet_size_;
+    Parameter<uint32_t> num_concurrent_batches_;
+    Parameter<AdvNetConfigYaml> cfg_;
+};
+
+};  // namespace holoscan::ops

--- a/operators/advanced_network/adv_network_tx.cpp
+++ b/operators/advanced_network/adv_network_tx.cpp
@@ -1,0 +1,162 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "adv_network_tx.h"
+#include "adv_network_dpdk_mgr.h"
+#include <rte_ether.h>
+#include <rte_ip.h>
+#include <rte_udp.h>
+#include <memory>
+
+namespace holoscan::ops {
+
+struct AdvNetworkOpTx::AdvNetworkOpTxImpl {
+  DpdkMgr *dpdk_mgr;
+  struct rte_ring *tx_ring;
+  struct rte_mempool *tx_meta_pool;
+  AdvNetConfigYaml cfg;
+};
+
+struct UDPPkt {
+  struct rte_ether_hdr eth;
+  struct rte_ipv4_hdr ip;
+  struct rte_udp_hdr udp;
+  uint8_t payload[];
+} __attribute__((packed));
+
+void AdvNetworkOpTx::setup(OperatorSpec& spec)  {
+  spec.input<AdvNetBurstParams *>("burst_in");
+
+  spec.param(
+      cfg_,
+      "cfg",
+      "Configuration",
+      "Configuration for the advanced network operator",
+      AdvNetConfigYaml());
+}
+
+void AdvNetworkOpTx::initialize() {
+  HOLOSCAN_LOG_INFO("AdvNetworkOpTx::initialize()");
+  register_converter<holoscan::ops::AdvNetConfigYaml>();
+
+  holoscan::Operator::initialize();
+  Init();
+}
+
+int AdvNetworkOpTx::Init() {
+  impl = new AdvNetworkOpTxImpl();
+  impl->cfg = cfg_.get();;
+  impl->dpdk_mgr = &dpdk_mgr;
+  impl->tx_ring = nullptr;
+  impl->dpdk_mgr->SetConfigAndInitialize(impl->cfg);
+
+  // Set up all LUTs for speed
+  for (auto &tx : cfg_.get().tx_) {
+    auto port_opt = adv_net_get_port_from_ifname(tx.if_name_);
+    if (!port_opt) {
+      HOLOSCAN_LOG_CRITICAL("Failed to get port ID from interface {}", tx.if_name_);
+      return -1;
+    }
+
+    auto port = port_opt.value();
+
+    for (auto &q : tx.queues_) {
+      auto q_id       = q.common_.id_;
+      auto fill_type  = q.fill_type_;
+      if (fill_type == "eth") {
+        fill[port][q_id] = FILL_ETH;
+      } else if (fill_type == "ip") {
+        fill[port][q_id] = FILL_IP;
+      } else if (fill_type == "udp") {
+        fill[port][q_id] = FILL_UDP;
+      } else {
+        fill[port][q_id] = FILL_NONE;
+      }
+
+      if (fill[port][q_id] >= FILL_ETH) {
+        rte_ether_unformat_addr(q.eth_dst_.c_str(),
+          reinterpret_cast<rte_ether_addr*>(&raw_eth_dst_[port][q_id][0]));
+      }
+      if (fill[port][q_id] >= FILL_IP) {
+        inet_pton(AF_INET, q.ip_src_.c_str(), &(raw_ip_src_[port][q_id]));
+        inet_pton(AF_INET, q.ip_dst_.c_str(), &(raw_ip_dst_[port][q_id]));
+      }
+      if (fill[port][q_id] >= FILL_UDP) {
+        raw_udp_src_port_[port][q_id] = htons(q.udp_src_port_);
+        raw_udp_dst_port_[port][q_id] = htons(q.udp_dst_port_);
+      }
+    }
+  }
+
+  return 0;
+}
+
+void AdvNetworkOpTx::compute(InputContext& op_input, [[maybe_unused]] OutputContext& op_output,
+      [[maybe_unused]] ExecutionContext&) {
+  int n;
+
+  if (unlikely(impl->tx_ring == nullptr)) {
+    impl->tx_ring = rte_ring_lookup("TX_RING");
+  }
+
+  if (unlikely(impl->tx_meta_pool == nullptr)) {
+    impl->tx_meta_pool = rte_mempool_lookup("TX_META_POOL");
+  }
+
+  auto burst = op_input.receive<AdvNetBurstParams>("burst_in");
+  auto port_id = burst->hdr.port_id;
+  auto q_id    = burst->hdr.q_id;
+
+  if (fill[port_id][q_id] >= FILL_ETH) {
+    for (size_t p = 0; p < burst->hdr.num_pkts; p++) {
+      auto *pkt = rte_pktmbuf_mtod((rte_mbuf*)burst->cpu_pkts[p], UDPPkt*);
+      memcpy(reinterpret_cast<void*>(&pkt->eth.dst_addr),
+             reinterpret_cast<void*>(&raw_eth_dst_[port_id][q_id][0]),
+             sizeof(raw_eth_dst_[port_id][q_id]));
+    }
+  }
+  if (fill[port_id][q_id] >= FILL_IP) {
+    for (size_t p = 0; p < burst->hdr.num_pkts; p++) {
+      auto *pkt = rte_pktmbuf_mtod((rte_mbuf*)burst->cpu_pkts[p], UDPPkt*);
+      pkt->ip.src_addr = raw_ip_src_[port_id][q_id];
+      pkt->ip.dst_addr = raw_ip_dst_[port_id][q_id];
+    }
+  }
+
+  if (fill[port_id][q_id] >= FILL_UDP) {
+    for (size_t p = 0; p < burst->hdr.num_pkts; p++) {
+      auto *pkt = rte_pktmbuf_mtod((rte_mbuf*)burst->cpu_pkts[p], UDPPkt*);
+      pkt->udp.src_port = raw_udp_src_port_[port_id][q_id];
+      pkt->udp.dst_port = raw_udp_dst_port_[port_id][q_id];
+    }
+  }
+
+  AdvNetBurstParams *d_params;
+  if (rte_mempool_get(impl->tx_meta_pool, reinterpret_cast<void**>(&d_params)) != 0) {
+    HOLOSCAN_LOG_CRITICAL("Failed to get TX meta descriptor");
+    return;
+  }
+
+  rte_memcpy(static_cast<void*>(d_params), burst.get(), sizeof(*burst));
+  if (rte_ring_enqueue(impl->tx_ring, reinterpret_cast<void *>(d_params)) != 0) {
+    adv_net_free_tx_burst(burst.get());
+    rte_mempool_put(impl->tx_meta_pool, d_params);
+    HOLOSCAN_LOG_CRITICAL("Failed to enqueue TX work");
+    return;
+  }
+}
+};  // namespace holoscan::ops

--- a/operators/advanced_network/adv_network_tx.h
+++ b/operators/advanced_network/adv_network_tx.h
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include "adv_network_common.h"
+#include "holoscan/holoscan.hpp"
+
+namespace holoscan::ops {
+/*
+  Class for handling data from a high-speed network. This can be used for low-speed networks too,
+  but requires more configuration that's not necessarily needed with low-speed networks.
+*/
+
+enum PacketLayerFill {
+  FILL_NONE = 0,
+  FILL_ETH = 1,
+  FILL_IP = 2,
+  FILL_UDP = 3
+};
+
+class AdvNetworkOpTx : public Operator {
+  class AdvNetworkOpTxImpl;
+
+ public:
+    HOLOSCAN_OPERATOR_FORWARD_ARGS(AdvNetworkOpTx);
+
+    AdvNetworkOpTx() = default;
+    ~AdvNetworkOpTx() = default;
+    void initialize() override;
+    int Init();
+    int FreeBurst(AdvNetBurstParams *burst);
+
+    // Holoscan functions
+    void setup(OperatorSpec& spec) override;
+    void compute(InputContext&, OutputContext& op_output, ExecutionContext&) override;
+
+ private:
+    void SetFillInfo();
+    Parameter<AdvNetConfigYaml> cfg_;
+    AdvNetworkOpTxImpl *impl;
+
+    PacketLayerFill fill[MAX_INTERFACES][MAX_NUM_TX_QUEUES] = {FILL_NONE};
+    uint8_t  raw_eth_dst_[MAX_INTERFACES][MAX_NUM_TX_QUEUES][6];
+    uint32_t raw_ip_src_[MAX_INTERFACES][MAX_NUM_TX_QUEUES];
+    uint32_t raw_ip_dst_[MAX_INTERFACES][MAX_NUM_TX_QUEUES];
+    uint16_t raw_udp_src_port_[MAX_INTERFACES][MAX_NUM_TX_QUEUES];
+    uint16_t raw_udp_dst_port_[MAX_INTERFACES][MAX_NUM_TX_QUEUES];
+};
+};  // namespace holoscan::ops

--- a/operators/advanced_network/dpdk_patches/cuda.c.patch
+++ b/operators/advanced_network/dpdk_patches/cuda.c.patch
@@ -1,0 +1,13 @@
+--- drivers/gpu/cuda/cuda.c	2022-11-27 02:36:36.000000000 -0800
++++ drivers/gpu/cuda/cuda.patch.c	2023-01-30 20:29:35.337900000 -0800
+@@ -201,6 +201,10 @@
+ 	},
+ 	{
+ 		RTE_PCI_DEVICE(NVIDIA_GPU_VENDOR_ID,
++				NVIDIA_GPU_QUADRO_RTX_6000_TURING)
++	},	
++	{
++		RTE_PCI_DEVICE(NVIDIA_GPU_VENDOR_ID,
+ 				NVIDIA_GPU_QUADRO_RTX_8000)
+ 	},
+ 	{

--- a/operators/advanced_network/dpdk_patches/devices.h.patch
+++ b/operators/advanced_network/dpdk_patches/devices.h.patch
@@ -1,0 +1,10 @@
+--- drivers/gpu/cuda/devices.h	2023-01-30 20:29:47.279884000 -0800
++++ drivers/gpu/cuda/devices.patch.hh	2023-01-30 20:30:02.370920000 -0800
+@@ -53,6 +53,7 @@
+ #define NVIDIA_GPU_QUADRO_RTX_4000 (0x1eb1)
+ #define NVIDIA_GPU_QUADRO_RTX_5000 (0x1eb0)
+ #define NVIDIA_GPU_QUADRO_RTX_6000 (0x13d9)
++#define NVIDIA_GPU_QUADRO_RTX_6000_TURING (0x1e30)
+ #define NVIDIA_GPU_QUADRO_RTX_8000 (0x13d8)
+ #define NVIDIA_GPU_QUADRO_RTX_A4000 (0x24b0)
+ #define NVIDIA_GPU_QUADRO_RTX_A6000 (0x2230)

--- a/operators/advanced_network/dpdk_patches/dpdk.nvidia.patch
+++ b/operators/advanced_network/dpdk_patches/dpdk.nvidia.patch
@@ -1,0 +1,35 @@
+--- config/arm/meson.build	2023-01-30 15:18:49.413204000 -0800
++++ config/arm/arm_new.build	2023-01-30 15:20:36.110169000 -0800
+@@ -234,6 +234,24 @@
+     }
+ }
+ 
++implementer_nvidia = {
++    'description': 'NVIDIA',
++    'flags': [
++        ['RTE_MACHINE', '"armv8a"'],
++        ['RTE_USE_C11_MEM_MODEL', true],
++        ['RTE_MAX_LCORE', 256],
++        ['RTE_MAX_NUMA_NODES', 4]
++    ],
++    'part_number_config': {
++        '0x4': {
++            'march': 'armv8-a',
++            'march_features': ['crc'],
++            'compiler_options': ['-moutline-atomics']
++        }
++    }
++}
++
++
+ 
+ implementer_qualcomm = {
+     'description': 'Qualcomm',
+@@ -262,6 +280,7 @@
+     '0x41': implementer_arm,
+     '0x43': implementer_cavium,
+     '0x48': implementer_hisilicon,
++    '0x4e': implementer_nvidia,
+     '0x50': implementer_ampere,
+     '0x51': implementer_qualcomm,
+     '0x70': implementer_phytium,

--- a/operators/advanced_network/metadata.json
+++ b/operators/advanced_network/metadata.json
@@ -1,0 +1,31 @@
+{
+	"operator": {
+		"name": "advanced_network",
+		"authors": [
+			{
+				"name": "Cliff Burdick",
+				"affiliation": "NVIDIA"
+			}
+		],
+		"version": "1.0",
+		"changelog": {
+			"1.0": "Initial Release"
+		},
+		"platforms": ["amd64", "arm64"],
+		"tags": ["Network", "Networking", "DPDK", "UDP", "Ethernet", "IP", "GPUDirect", "RDMA"],
+		"holoscan_sdk": {
+			"minimum_required_version": "0.5.0",
+			"tested_versions": [
+				"0.5.0"
+			]
+		},
+		"ranking": 1,
+		"dependencies": {
+				"gxf_extensions": [{
+					"name": "advanced_network",
+					"version": "1.0"
+				}
+			   ]
+			}
+		}
+}


### PR DESCRIPTION
First commit of the advanced network operator. This operator is being used in a partnership with Analog devices in their 5G signal analyzer workflow. At the moment it's missing a lot of useful features, but this will allow a basic, high-speed UDP pipeline to be implemented in Holoscan using DPDK.
Features includes

- GPUDirect + header-data split
- Packet buffering on isolated cores to absorb Holoscan operator jitter
- Configurable from YAML
- Documentation with example code
- Example application