### PR TITLE
Dev container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+# syntax=docker/dockerfile:1
+
+# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+############################################################
+# Base image
+############################################################
+
+ARG BASE_IMAGE=ngc_dgpu
+# Holoscan SDK 0.5.1 dGPU container from NGC (x86, Clara AGX and IGX Orin Dev Kits)
+FROM nvcr.io/nvidia/clara-holoscan/holoscan:v0.5.1-dgpu AS ngc_dgpu
+# Holoscan SDK 0.5.1 ARM64 iGPU container from NGC (AGX Orin and IGX Orin (iGPU mode) Dev Kits)
+FROM nvcr.io/nvidia/clara-holoscan/holoscan:v0.5.1-igpu  AS ngc_igpu
+# Holoscan SDK container built from source
+FROM holoscan-sdk-dev:latest as from_source
+
+FROM ${BASE_IMAGE} as base
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && \ 
+    apt install --no-install-recommends -y \
+    ffmpeg=7:4.2.7-0ubuntu0.1 \
+    libv4l-dev=1.18.0-2build1
+
+# --------------------------------------------------------------------------
+#
+# Holohub run setup 
+#
+
+RUN mkdir -p /tmp/scripts
+COPY run /tmp/scripts/
+RUN chmod +x /tmp/scripts/run
+RUN /tmp/scripts/run setup
+
+
+# - This variable is consumed by all dependencies below as an environment variable (CMake 3.22+)
+# - We use ARG to only set it at docker build time, so it does not affect cmake builds
+#   performed at docker run time in case users want to use a different BUILD_TYPE
+ARG CMAKE_BUILD_TYPE=Release
+
+

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ HoloHub has been tested and is known to run on Ubuntu 20.04. Other versions of U
 
 1. Clone this repository.
 
-2. Choose to build Holohub sample apps using development container or bare metal.
+2. Choose to build Holohub using development container or using a local environment.
 
 **Container build**
 
@@ -51,9 +51,9 @@ The launch script will also inspect for available video devices (V4L2, AJA captu
 (2) When building Holoscan SDK on AGX Orin Dev Kit from source please add the option  ```--cudaarchs all``` to the ```./run build``` command to include support for AGX Orin's iGPU.
 
 
-**Bare metal build** 
+**Local build** 
 
-Refer to the [Holoscan SDK README](https://github.com/nvidia-holoscan/holoscan-sdk/blob/main/README.md) for ways to install Holoscan SDK bare metal: Debian package, Python wheels or from source.
+Refer to the [Holoscan SDK README](https://github.com/nvidia-holoscan/holoscan-sdk/blob/main/README.md) for ways to install Holoscan SDK in local environemnt: Debian package, Python wheels or from source.
 
 Install the package dependencies for Holohub on your host system. The easiest way to make sure the minimal package dependencies is to use the run script from the top level directory.
 

--- a/README.md
+++ b/README.md
@@ -13,16 +13,53 @@ Holohub is a central repository for users and developers of extensions and appli
 HoloHub is based on [Holoscan SDK](https://github.com/nvidia-holoscan/holoscan-sdk).
 HoloHub has been tested and is known to run on Ubuntu 20.04. Other versions of Ubuntu or OS distributions may result in build and/or runtime issues.
 
-1. Refer to the [Holoscan SDK README](https://github.com/nvidia-holoscan/holoscan-sdk/blob/main/README.md) for ways to install Holoscan SDK: Debian package, Python wheels, container or from source.
 
-2. Clone this repository.
+1. Clone this repository.
 
-3. Install the package dependencies. The easiest way to make sure the minimal package dependencies is to use the run script from the top level directory.
+2. Choose to build Holohub sample apps using development container or bare metal.
+
+**Container build**
+
+***Build container:*** Run the following command from the holohub directory to build the development container.
+
+```bash
+  ./dev_container build_image
+```
+
+***Note:*** The development container script ```dev_container``` will by default use [NGC's Holoscan SDK container](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/clara-holoscan/containers/holoscan) for the local GPU configuration by detecting if the system is using an iGPU (integrated GPU) or a dGPU (discrete GPU). 
+
+
+It is possible to configure a locally built Holoscan SDK container by passing the option ```--base_image from_source``` to the build_image or launch command. When using the ```--base_image from_source```  option please make sure that you have checked out holoscan-sdk into the same directory as holohub and that you have built holoscan SDK as described in the [Holoscan SDK README: Build using the run script](https://github.com/nvidia-holoscan/holoscan-sdk/blob/main/README.md#recommended-using-the-run-script).
+
+
+***Launch container:***  Run the following command from the holohub directory to launch the development container.
+
+```bash
+  ./dev_container launch
+```
+
+From within the container build the Holohub apps as explained in section [Building HoloHub](#building-holohub).
+
+The development container has been tested on the following platforms: x86_x64 workstation with multiple RTX GPUs, Clara AGX Dev Kit (dGPU mode), IGX Orin Dev Kit (dGPU mode), AGX Orin Dev Kit (iGPU).
+
+The launch script will also inspect for available video devices (V4L2, AJA capture boards, Deltacast capture boards) and presence of Deltacast's Videomaster SDK and map it into the development container.
+
+***Notes for AGX Orin Dev Kit***: 
+
+(1) On AGX Orin Dev Kit the launch script will add ```--privileged``` and ```--group-add video``` to the docker run command for the Holohub sample apps to work. Please also make sure that the current user is member of the group video.  
+
+(2) When building Holoscan SDK on AGX Orin Dev Kit from source please add the option  ```--cudaarchs all``` to the ```./run build``` command to include support for AGX Orin's iGPU.
+
+
+**Bare metal build** 
+
+Refer to the [Holoscan SDK README](https://github.com/nvidia-holoscan/holoscan-sdk/blob/main/README.md) for ways to install Holoscan SDK bare metal: Debian package, Python wheels or from source.
+
+Install the package dependencies for Holohub on your host system. The easiest way to make sure the minimal package dependencies is to use the run script from the top level directory.
+
 ```bash
   # if sudo is available
   sudo ./run setup
-  # if sudo is not available (container)
-  ./run setup
 ```
 
 If you prefer you can also install the dependencies manually:
@@ -41,7 +78,8 @@ If you prefer you can also install the dependencies manually:
 
 *Note: the run script setup installs the minimal set of dependencies required to run the sample applications. Other applications might require more dependencies. Please refer to the README of each application for more information.*
 
-# Building HoloHub
+# Building HoloHub 
+
 While not all applications requires building HoloHub, the current build system automatically manages dependencies (applications/operators) and also downloads and convert datasets at build time. HoloHub provides a convenient run script to build and run applications (you can run `./run -h` for information about the available commands).
 
 You can refer to the README of each application/operator if you prefer to build/run them manually.

--- a/dev_container
+++ b/dev_container
@@ -1,0 +1,724 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Error out if a command fails
+set -e
+
+#===============================================================================
+# Default values for environment variables.
+#===============================================================================
+
+init_globals() {
+    if [ "$0" != "/bin/bash" ] && [ "$0" != "bash" ]; then
+        SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+        export RUN_SCRIPT_FILE="$(readlink -f "$0")"
+    else
+        export RUN_SCRIPT_FILE="$(readlink -f "${BASH_SOURCE[0]}")"
+    fi
+
+    export HOLOHUB_ROOT=$(dirname "${RUN_SCRIPT_FILE}")
+
+    HOLOSCAN_PY_EXE=${HOLOSCAN_PY_EXE:-"python3"}
+    export HOLOSCAN_PY_EXE
+    HOLOSCAN_DOCKER_EXE=${HOLOSCAN_DOCKER_EXE:-"docker"}
+    export HOLOSCAN_DOCKER_EXE
+
+    HOLOSCAN_SDK_VERSION="latest"
+    export HOLOSCAN_SDK_VERSION
+    HOLOHUB_CONTAINER_NAME=holohub:${HOLOSCAN_SDK_VERSION}
+    export HOLOHUB_CONTAINER_NAME
+
+
+    DO_DRY_RUN="false"  # print commands but do not execute them. Used by run_command
+}
+
+################################################################################
+# Utility functions
+################################################################################
+
+
+#######################################
+# Check if current architecture is x86_64.
+#
+# Returns:
+#   Exit code:
+#     0 if $(uname -m) == "x86_64".
+#     1 otherwise.
+#######################################
+checkif_x86_64() {
+    if [ $(uname -m) == "x86_64" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+#######################################
+# Check if current architecture is aarch64.
+#
+# Returns:
+#   Exit code:
+#     0 if $(uname -m) == "aarch64".
+#     1 otherwise.
+#######################################
+checkif_aarch64() {
+    if [ $(uname -m) == "aarch64" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+#######################################
+# Get list of available commands from a given input file.
+#
+# Available commands and command summary are extracted by checking a pattern
+# "_desc() { c_echo '".
+# Section title is extracted by checking a pattern "# Section: ".
+# This command is used for listing available commands in CLI.
+#
+# e.g.)
+#   "# Section: String/IO functions"
+#     => "# String/IO functions"
+#   "to_lower_desc() { c_echo 'Convert to lower case"
+#     => "to_lower ----------------- Convert to lower case"
+#
+# Arguments:
+#   $1 - input file that defines commands
+# Returns:
+#   Print list of available commands from $1
+#######################################
+get_list_of_available_commands() {
+    local mode="color"
+    if [ "${1:-}" = "color" ]; then
+        mode="color"
+        shift
+    elif [ "${1:-}" = "nocolor" ]; then
+        mode="nocolor"
+        shift
+    fi
+
+    local file_name="$1"
+    if [ ! -e "$1" ]; then
+        echo "$1 doesn't exist!"
+    fi
+
+    local line_str='--------------------------------'
+    local IFS= cmd_lines="$(IFS= cat "$1" | grep -E -e "^(([[:alpha:]_[:digit:]]+)_desc\(\)|# Section: )" | sed "s/_desc() *{ *c_echo '/ : /")"
+    local line
+    while IFS= read -r line; do
+        local cmd=$(echo "$line" | cut -d":" -f1)
+        local desc=$(echo "$line" | cut -d":" -f2-)
+        if [ "$cmd" = "# Section" ]; then
+            c_echo ${mode} B "${desc}"
+        else
+            # there is no substring operation in 'sh' so use 'cut'
+            local dash_line="$(echo "${line_str}" | cut -c ${#cmd}-)"  #  = "${line_str:${#cmd}}"
+             c_echo ${mode} Y "   ${cmd}" w " ${dash_line} ${desc}"
+        fi
+        # use <<EOF, not '<<<"$cmd_lines"' to be executable in sh
+    done <<EOF
+$cmd_lines
+EOF
+}
+
+my_cat_prefix() {
+    local IFS
+    local prefix="$1"
+    local line
+    while IFS= read -r line; do
+        echo "${prefix}${line}" # -e option doesn't work in 'sh' so disallow escaped characters
+    done <&0
+}
+
+c_str() {
+    local old_color=39
+    local old_attr=0
+    local color=39
+    local attr=0
+    local text=""
+    local mode="color"
+    if [ "${1:-}" = "color" ]; then
+        mode="color"
+        shift
+    elif [ "${1:-}" = "nocolor" ]; then
+        mode="nocolor"
+        shift
+    fi
+
+    for i in "$@"; do
+        case "$i" in
+            r|R)
+                color=31
+                ;;
+            g|G)
+                color=32
+                ;;
+            y|Y)
+                color=33
+                ;;
+            b|B)
+                color=34
+                ;;
+            p|P)
+                color=35
+                ;;
+            c|C)
+                color=36
+                ;;
+            w|W)
+                color=37
+                ;;
+
+            z|Z)
+                color=0
+                ;;
+        esac
+        case "$i" in
+            l|L|R|G|Y|B|P|C|W)
+                attr=1
+                ;;
+            n|N|r|g|y|b|p|c|w)
+                attr=0
+                ;;
+            z|Z)
+                attr=0
+                ;;
+            *)
+                text="${text}$i"
+        esac
+        if [ "${mode}" = "color" ]; then
+            if [ ${old_color} -ne ${color} ] || [ ${old_attr} -ne ${attr} ]; then
+                text="${text}\033[${attr};${color}m"
+                old_color=$color
+                old_attr=$attr
+            fi
+        fi
+    done
+    /bin/echo -en "$text"
+}
+
+c_echo() {
+    # Select color/nocolor based on the first argument
+    local mode="color"
+    if [ "${1:-}" = "color" ]; then
+        mode="color"
+        shift
+    elif [ "${1:-}" = "nocolor" ]; then
+        mode="nocolor"
+        shift
+    else
+        if [ ! -t 1 ]; then
+            mode="nocolor"
+        fi
+    fi
+
+    local old_opt="$(shopt -op xtrace)" # save old xtrace option
+    set +x # unset xtrace
+
+    if [ "${mode}" = "color" ]; then
+        local text="$(c_str color "$@")"
+        /bin/echo -e "$text\033[0m"
+    else
+        local text="$(c_str nocolor "$@")"
+        /bin/echo -e "$text"
+    fi
+    eval "${old_opt}" # restore old xtrace option
+}
+
+echo_err() {
+    >&2 echo "$@"
+}
+
+c_echo_err() {
+    >&2 c_echo "$@"
+}
+
+printf_err() {
+    >&2 printf "$@"
+}
+
+get_unused_ports() {
+    local num_of_ports=${1:-1}
+    local start=${2:-49152}
+    local end=${3:-61000}
+    comm -23 \
+    <(seq ${start} ${end} | sort) \
+    <(ss -tan | awk '{print $4}' | while read line; do echo ${line##*\:}; done | grep '[0-9]\{1,5\}' | sort -u) \
+    | shuf | tail -n ${num_of_ports} # use tail instead head to avoid broken pipe in VSCode terminal
+}
+
+newline() {
+    echo
+}
+
+info() {
+    c_echo_err W "$(date -u '+%Y-%m-%d %H:%M:%S') [INFO] " Z "$@"
+}
+
+error() {
+    c_echo_err R "$(date -u '+%Y-%m-%d %H:%M:%S') [ERROR] " Z "$@"
+}
+
+fatal() {
+    if [ -n "$*" ]; then
+        c_echo_err R "$(date -u '+%Y-%m-%d %H:%M:%S') [FATAL] " Z "$@"
+        echo_err
+    fi
+    if [ -n "${SCRIPT_DIR}" ]; then
+        exit 1
+    else
+        kill -INT $$  # kill the current process instead of exit in shell environment.
+    fi
+}
+
+run_command() {
+    local status=0
+    local cmd="$*"
+
+    if [ "${DO_DRY_RUN}" != "true" ]; then
+        c_echo_err B "$(date -u '+%Y-%m-%d %H:%M:%S') " W "\$ " G "${cmd}"
+    else
+        c_echo_err B "$(date -u '+%Y-%m-%d %H:%M:%S') " C "[dryrun] " W "\$ " G "${cmd}"
+    fi
+
+    [ "$(echo -n "$@")" = "" ] && return 1 # return 1 if there is no command available
+
+    if [ "${DO_DRY_RUN}" != "true" ]; then
+        "$@"
+        status=$?
+    fi
+
+    return $status
+}
+
+run_docker() {
+    $(./run docker_cmd "-u $(id -u):$(id -g)") "$@"
+}
+
+
+#===============================================================================
+# Section: Build
+#===============================================================================
+
+get_buildtype_str() {
+    local build_type="${1:-}"
+    local build_type_str
+
+    case "${build_type}" in
+        debug|Debug)
+            build_type_str="Debug"
+            ;;
+        release|Release)
+            build_type_str="Release"
+            ;;
+        rel-debug|RelWithDebInfo)
+            build_type_str="RelWithDebInfo"
+            ;;
+        *)
+            build_type_str="${CMAKE_BUILD_TYPE:-Release}"
+            ;;
+    esac
+
+    echo -n "${build_type_str}"
+}
+
+get_platform_str() {
+    local platform="${1:-}"
+    local platform_str
+
+    case "${platform}" in
+        amd64|x86_64|x86|linux/amd64)
+            platform_str="linux/amd64"
+            ;;
+        arm64|aarch64|arm|linux/arm64)
+            platform_str="linux/arm64"
+            ;;
+    esac
+
+    echo -n "${platform_str}"
+}
+
+get_gpu_str() {
+    local gpu="${1:-}"
+    local gpu_str=$gpu
+
+    case "${gpu}" in
+        igpu|iGPU|integrated|Jetson)
+            gpu_str="igpu"
+            ;;
+        dgpu|dGPU|discrete|RTX)
+            gpu_str="dgpu"
+            ;;
+    esac
+
+    echo -n "${gpu_str}"
+}
+
+get_host_gpu() {
+    if lsmod | grep -q nvidia_drm && command -v nvidia-smi > /dev/null; then
+        echo -n "dgpu"
+    elif lsmod | grep -q nvgpu ; then
+        echo -n "igpu"
+    else
+        c_echo_err Y "Could not find any GPU drivers on host. Defaulting build to target dGPU/CPU stack."
+        echo -n "dgpu"
+    fi
+}
+
+get_cuda_archs() {
+    local cuda_archs="${1:-}"
+
+    case "${cuda_archs}" in
+        native|NATIVE)
+            cuda_archs_str="NATIVE"
+            ;;
+        all|ALL)
+            cuda_archs_str="ALL"
+            ;;
+        *)
+            cuda_archs_str="${1:-}"
+            ;;
+    esac
+
+    echo -n "${cuda_archs_str}"
+}
+
+build_image_desc() { c_echo 'Build dev image
+  --base_image [ngc | from_source : Specify base for holohub container
+        Default: Holoscan SDK 0.5.1 container from NGC
+    '
+}
+build_image() {
+
+    # Choose NGC Holoscan SDK base image based on local platform, default is dGPU
+    local base_image="ngc"
+
+    # Parse CLI arguments next
+    ARGS=("$@")
+    local i
+    local arg
+    for i in "${!ARGS[@]}"; do
+        arg="${ARGS[i]}"
+        if [ "$arg" = "--base_image" ]; then
+           base_image="${ARGS[i+1]}"
+        fi
+    done
+
+    if [[ "$base_image" == "ngc" ]]; then
+        if lsmod | grep -q nvgpu 
+        then 
+            base_image="ngc_igpu"
+        else 
+            base_image="ngc_dgpu"
+        fi
+    fi
+
+
+    # Docker build
+    run_command export DOCKER_BUILDKIT=1
+    run_command docker build \
+        --build-arg BUILDKIT_INLINE_CACHE=1 \
+        --build-arg BASE_IMAGE=${base_image} \
+        --network=host \
+        -t ${HOLOHUB_CONTAINER_NAME}-${base_image} \
+        ${HOLOHUB_ROOT}
+}
+
+#===============================================================================
+# Section: Launch
+#===============================================================================
+
+launch_desc() { c_echo 'Launch Docker container
+    --base_image [ngc | from_source : Specify base for holohub container
+        Default: Holoscan SDK 0.5.1 container from NGC
+    '
+}
+launch() {
+    local build_path="${CMAKE_BUILD_PATH:-build}"
+    local working_dir=${1:-${build_path}}
+    local mount_device_opt=""
+    local conditional_opt=""
+
+    # Choose NGC Holoscan SDK base image based on local platform, default is dGPU
+    local base_image="ngc"
+
+    # Parse CLI arguments next
+    ARGS=("$@")
+    local i
+    local arg
+    for i in "${!ARGS[@]}"; do
+        arg="${ARGS[i]}"
+        if [ "$arg" = "--base_image" ]; then
+           base_image="${ARGS[i+1]}"
+        fi
+    done
+
+    if [[ "$base_image" == "ngc" ]]; then
+        if lsmod | grep -q nvgpu 
+        then 
+            base_image="ngc_igpu"
+        else 
+            base_image="ngc_dgpu"
+        fi
+    fi
+
+
+
+    # Skip the first argument to pass the remaining arguments to the docker command.
+    if [ -n "$1" ]; then
+        shift
+    fi
+
+    # Allow connecting from docker. This is not needed for WSL2 (`SI:localuser:wslg` is added by default)
+    run_command xhost +local:docker
+
+    for i in 0 1 2 3; do
+        if [ -e /dev/video${i} ]; then
+            mount_device_opt+=" --device /dev/video${i}:/dev/video${i}"
+        fi
+        if [ -e /dev/ajantv2${i} ]; then
+            mount_device_opt+=" --device /dev/ajantv2${i}:/dev/ajantv2${i}"
+        fi
+        # Deltacast capture boards and Videomaster SDK
+        # Deltacast SDI capture board
+	    if [ -e /dev/delta-x380${i} ]; then
+            mount_device_opt+=" --device /dev/delta-x380${i}:/dev/delta-x380${i}"
+        fi
+	    # Deltacast HDMI capture board
+	    if [ -e /dev/delta-x350${i} ]; then
+            mount_device_opt+=" --device /dev/delta-x350${i}:/dev/delta-x350${i}"
+        fi
+    done
+	
+    if [ -e /usr/lib/libvideomasterhd.so ]; then
+   	conditional_opt+=" -v /usr/lib/libvideomasterhd.so:/usr/lib/libvideomasterhd.so"
+    fi
+    if [ -d /opt/deltacast/videomaster/Include ]; then
+        conditional_opt+=" -v /opt/deltacast/videomaster/Include:/usr/local/deltacast/Include"
+    fi
+    # if running on AGX Orin (iGPU only) or on IGX Orin in iGPU mode
+    if lsmod | grep -q nvgpu ; then 
+        conditional_opt+=" --privileged"
+        conditional_opt+=" --group-add video"
+    fi
+
+    c_echo W "Launching (mount_device_opt:" G "${mount_device_opt}" W ")..."
+
+    # Find the nvidia_icd.json file which could reside at different paths
+    # Needed due to https://github.com/NVIDIA/nvidia-container-toolkit/issues/16
+    nvidia_icd_json=$(find /usr/share /etc -path '*/vulkan/icd.d/nvidia_icd.json' -type f,l -print -quit 2>/dev/null | grep .) || (echo "nvidia_icd.json not found" >&2 && false)
+
+    # DOCKER PARAMETERS
+    #
+    # -it
+    #   The container needs to be interactive to be able to interact with the X11 windows
+    #
+    # --rm
+    #   Deletes the container after the command runs
+    #
+    # -u $(id -u):$(id -g)
+    # -v /etc/group:/etc/group:ro
+    # -v /etc/passwd:/etc/passwd:ro
+    #   Ensures the generated files (build, install...) are owned by $USER and not root,
+    #   and provide the configuration files to avoid warning for user and group names
+    #
+    # -v ${HOLOHUB_ROOT}:/workspace/holoscan-sdk
+    #   Mount the source directory
+    #
+    # -w /workspace/holoscan-sdk/${working_dir}
+    #   Start in the build or install directory
+    #
+    # --runtime=nvidia \
+    # -e NVIDIA_DRIVER_CAPABILITIES=graphics,video,compute,utility,display
+    #   Enable GPU acceleration
+    #
+    # -v /tmp/.X11-unix:/tmp/.X11-unix
+    # -e DISPLAY
+    #   Enable graphical applications
+    #
+    # -v $nvidia_icd_json:$nvidia_icd_json:ro
+    #   Bind NVIDIA's Vulkan installable client driver to run Vulkan
+    #   Needed due to https://github.com/NVIDIA/nvidia-container-toolkit/issues/16
+    #   The configurations files are installed to different locations when installing
+    #   with deb packages or with run files, so we look at both places
+    #
+    # --device /dev/video${i}:/dev/video${i}
+    #   Bind video capture devices for V4L2
+    #
+    # --device /dev/ajantv2${i}:/dev/ajantv2${i}
+    #   Bind AJA capture cards for NTV2
+    #
+    # -e PYTHONPATH
+    # -e HOLOSCAN_LIB_PATH
+    # -e HOLOSCAN_SAMPLE_DATA_PATH
+    #   Define paths needed by the python applications
+    #
+    # -e CUPY_CACHE_DIR
+    #   Define path for cupy' kernel cache, needed since $HOME does
+    #   not exist when running with `-u id:group`
+
+    run_command ${HOLOSCAN_DOCKER_EXE} run -it --rm --net host \
+        -u $(id -u):$(id -g) \
+        -v /etc/group:/etc/group:ro \
+        -v /etc/passwd:/etc/passwd:ro \
+        -v ${HOLOHUB_ROOT}:/workspace/holohub \
+        -v ${HOLOHUB_ROOT}/../holoscan-sdk:/workspace/holoscan-sdk \
+        -w /workspace/holohub \
+        --runtime=nvidia \
+        -e NVIDIA_DRIVER_CAPABILITIES=graphics,video,compute,utility,display \
+        -v /tmp/.X11-unix:/tmp/.X11-unix \
+        -e DISPLAY \
+        ${mount_device_opt} \
+	${conditional_opt} \
+        -v $nvidia_icd_json:$nvidia_icd_json:ro \
+        -e PYTHONPATH=/workspace/holoscan-sdk/${working_dir}/python/lib \
+        -e HOLOSCAN_LIB_PATH=/workspace/holoscan-sdk/${working_dir}/lib \
+        -e HOLOSCAN_SAMPLE_DATA_PATH=/workspace/holoscan-sdk/data \
+        -e HOLOSCAN_TESTS_DATA_PATH=/workspace/holoscan-sdk/tests/data \
+        -e CUPY_CACHE_DIR=/workspace/holoscan-sdk/.cupy/kernel_cache \
+        ${HOLOHUB_CONTAINER_NAME}-${base_image}
+}
+
+
+#===============================================================================
+
+parse_args() {
+    local OPTIND
+    while getopts 'yh' option;
+    do
+        case "${option}" in
+            y)
+                ALWAYS_YES="true"
+                ;;
+            h)
+                print_usage
+                if [ -n "${SCRIPT_DIR}" ]; then
+                    exit 1
+                fi
+                ;;
+            *)
+                ;;
+        esac
+    done
+    shift $((OPTIND-1))
+
+    CMD="$1"
+    shift
+
+    ARGS=("$@")
+    # Check if the command has `--help`, `-h`, or `--dryrun`, and override the CMD
+    local i
+    local arg
+    local unset_pos
+    for i in "${!ARGS[@]}"; do
+        arg="${ARGS[i]}"
+        if [ "$arg" = "--help" ] || [ "$arg" = "-h" ]; then
+            ARGS=("$CMD")
+            CMD="help"
+            break
+        fi
+        if [ "$arg" = "--dryrun" ]; then
+            unset_pos=$i
+            DO_DRY_RUN="true"  # set to true to print commands to screen without running
+        fi
+    done
+    if [ "${unset_pos}" ]; then
+        unset 'ARGS[unset_pos]'
+    fi
+}
+
+print_usage() {
+    set +x
+    echo_err
+    echo_err "USAGE: $0 [command] [arguments]..."
+    echo_err ""
+    c_echo_err W "Global Arguments"
+    c_echo_err "  --help, -h      : Print help messages for [command]"
+    c_echo_err "  --dryrun        : Print commands to screen without running"
+    echo_err
+    c_echo_err W "Command List"
+    c_echo_err Y "    help  " w "----------------------------  Print detailed description for a given argument (command name)"
+    echo_err "$(get_list_of_available_commands color "${RUN_SCRIPT_FILE}" | my_cat_prefix " ")"
+    echo_err
+}
+
+print_cmd_help_messages() {
+    local cmd="$1"
+    if [ -n "${cmd}" ]; then
+        if type ${cmd}_desc > /dev/null 2>&1; then
+            ${cmd}_desc
+            exit 0
+        else
+            c_echo_err R "Command '${cmd}' doesn't exist!"
+            exit 1
+        fi
+    fi
+    print_usage
+    return 0
+}
+
+main() {
+    local ret=0
+    parse_args "$@"
+
+    case "$CMD" in
+        help)
+            print_cmd_help_messages "${ARGS[@]}"
+            exit 0
+            ;;
+        ''|main)
+            print_usage
+            ;;
+        *)
+            if type ${CMD} > /dev/null 2>&1; then
+                "$CMD" "${ARGS[@]}"
+            else
+                print_usage
+                exit 1
+            fi
+            ;;
+    esac
+    ret=$?
+    if [ -n "${SCRIPT_DIR}" ]; then
+        exit $ret
+    fi
+}
+
+init_globals
+
+if [ -n "${SCRIPT_DIR}" ]; then
+    main "$@"
+fi
+
+#===============================================================================
+# Description template
+#===============================================================================
+# Globals:
+#   HOLOSCAN_OS
+#   HOLOSCAN_TARGET
+#   HOLOSCAN_USER (used if HOLOSCAN_OS is "linux")
+#   HOLOSCAN_HOST (used if HOLOSCAN_OS is "linux")
+# Arguments:
+#   Command line to execute
+# Returns:
+#   Outputs print messages during the execution (stdout->stdout, stderr->stderr).
+#
+#   Note:
+#     This command removes "\r" characters from stdout.
+#
+#   Exit code:
+#     exit code returned from executing a given command


### PR DESCRIPTION
Minimum build and test container for Holohub sample apps. 

1. Modify Dockerfile to use Holoscan base image from NGC or local build of Holoscan SDK container. 
2. Build container via ./dev_container build_image. Will  execute Holohub's ./run setup as part of build 
3. Launch container via ./dev_container launch 
4. Within container build Holohub apps via ./run build 
5. Launch a sample app via ./run launch APP_NAME APP_ARGUMENTS, e.g. ./run launch multiai_ultrasound cpp

The launch script will also take care of adding Deltacast's Include and Library files if installed on host system and take care of adding options for iGPU with AGX Orin Dev Kit.

Tested on x86_x64 with RTX A6000, RTX 6000 multi GPU system, IGX Orin Dev with RTX A6000, AGX Orin Dev Kit (iGPU) and Clara AGX Dev Kit. 





