### PR TITLE
Optional launch parameter ssh-x11

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ The launch script will also inspect for available video devices (V4L2, AJA captu
   ./dev_container launch --img holohub:ngc-sdk-sample-app
 ```
 
+3. Enable X11 forwarding of graphical HoloHub applications over SSH
+
+```bash
+  ./dev_container launch --ssh_x11
+```
+
 ***Note***:  To print the values passed to the docker run command, add the ```--verbose``` option to the launch command.
 
 For example, on an x86_64 system with dGPU ```./dev_container launch --verbose``` will print the following values. 

--- a/dev_container
+++ b/dev_container
@@ -339,6 +339,7 @@ launch() {
     local conditional_opt=""
     local print_verbose=0
     local local_sdk_root="undefined"
+    local ssh_x11=0
 
     # Choose NGC Holoscan SDK base image based on local platform, default is dGPU
     local gpu_type=$(get_host_gpu)
@@ -359,7 +360,9 @@ launch() {
         if [ "$arg" = "--local_sdk_root" ]; then
            local_sdk_root="${ARGS[i+1]}"
         fi
-
+        if [ "$arg" = "--ssh_x11" ]; then
+           ssh_x11=1
+        fi
     done
 
 
@@ -431,6 +434,17 @@ launch() {
     # Find the nvidia_icd.json file which could reside at different paths
     # Needed due to https://github.com/NVIDIA/nvidia-container-toolkit/issues/16
     nvidia_icd_json=$(find /usr/share /etc -path '*/vulkan/icd.d/nvidia_icd.json' -type f,l -print -quit 2>/dev/null | grep .) || (echo "nvidia_icd.json not found" >&2 && false)
+
+    # Allow X11 forwarding over SSH
+    if [[ $ssh_x11 -gt 0 ]]; then
+	XAUTH=/tmp/.docker.xauth
+	xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
+	chmod 777 $XAUTH
+
+	conditional_opt+=" -v $XAUTH:$XAUTH"
+	conditional_opt+=" -e XAUTHORITY=$XAUTH"
+    fi
+
 
     # DOCKER PARAMETERS
     #


### PR DESCRIPTION
This PR enables X11 forwarding of graphical HoloHub applications over SSH, via an optional argument to `dev_container launch`:
```sh
dev_container launch --ssh-x11
```
If this argument it not given, then a graphical HoloHub application will fail with an error message:
```sh
MoTTY X11 proxy: Unsupported authorisation protocol
Glfw Error 65544: X11: Failed to open display localhost:11.0
terminate called after throwing an instance of 'std::runtime_error'
  what():  Failed to initialize glfw
./run: line 83:   122 Aborted  
```
when a user starts an application connected over ssh (via `ssh -X ...`).