### PR TITLE
add C++ version of the basic CV-CUDA app

### DIFF
--- a/applications/cvcuda_basic/CMakeLists.txt
+++ b/applications/cvcuda_basic/CMakeLists.txt
@@ -35,4 +35,5 @@ if(HOLOHUB_DOWNLOAD_DATASETS)
   )
 endif()
 
+add_subdirectory(cpp)
 add_subdirectory(python)

--- a/applications/cvcuda_basic/README.md
+++ b/applications/cvcuda_basic/README.md
@@ -2,7 +2,10 @@
 
 This application demonstrates seamless interoperability between Holoscan tensors and CV-CUDA tensors. The image processing pipeline is just a simple flip of the video orientation.
 
+Note that the C++ version of this application currently requires extra code to handle zero-copy conversion back and forth between CV-CUDA and Holoscan tensor types. On the Python side, the conversion is trivial due to the support for the [DLPack Python specification](https://dmlc.github.io/dlpack/latest/python_spec.html) in both CV-CUDA and Holoscan. We hope to make C++ interoperability with CV-CUDA easier in the future.
+
 # Using the docker file
+
 This application requires a compiled version of [CV-CUDA](https://github.com/CVCUDA/CV-CUDA).
 For simplicity a DockerFile is available. To generate the container run:
 
@@ -10,21 +13,22 @@ For simplicity a DockerFile is available. To generate the container run:
 ./dev_container build --docker_file ./applications/cvcuda_basic/Dockerfile
 ```
 
+The C++ version of the application can then be built by launching this container and using the provided `run` script.
+
+```bash
+./dev_container launch
+./run build cvcuda_basic
+```
+
 # Running the Application
 
-This application is then run inside the container:
+This application uses the endoscopy dataset as an example. The `run build` command above will automatically download it. This application is then run inside the container.
 
 ```bash
 ./dev_container launch
 ```
 
-This application uses the endoscopy dataset as an example. To automatically download the dataset, please run:
-
-```bash
-./run build cvcuda_basic
-```
-
-The simple CV-CUDA pipeline example can then be run via
+The Python version of the simple CV-CUDA pipeline example can be run via
 ```
 python applications/cvcuda_basic/python/cvcuda_basic.py --data=/workspace/holohub/data/endoscopy
 ```
@@ -33,4 +37,15 @@ or using the run script
 
 ```bash
 ./run launch cvcuda_basic python
+```
+
+The C++ version of the simple CV-CUDA pipeline example can then be run via
+```
+./build/applications/cvcuda_basic/cpp/cvcuda_basic --data=/workspace/holohub/data/endoscopy
+```
+
+or using the run script
+
+```bash
+./run launch cvcuda_basic cpp
 ```

--- a/applications/cvcuda_basic/cpp/CMakeLists.txt
+++ b/applications/cvcuda_basic/cpp/CMakeLists.txt
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.20)
+project(cvcuda_basic CXX)
+
+find_package(holoscan 0.5 REQUIRED CONFIG
+             PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+# find_package(CUDAToolkit REQUIRED)  # Holoscan will already have included CUDA
+find_package(nvcv_types REQUIRED)
+find_package(cvcuda REQUIRED)
+
+add_executable(cvcuda_basic
+  main.cpp
+  cvcuda_utils.cpp
+  gxf_utils.cpp
+)
+
+target_link_libraries(cvcuda_basic
+  PRIVATE
+  holoscan::core
+  holoscan::ops::video_stream_replayer
+  holoscan::ops::holoviz
+  nvcv_types
+  cvcuda
+)
+
+# Copy the config to the binary directory
+add_custom_target(cvcuda_basic_deps
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/cvcuda_basic.yaml" ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS "cvcuda_basic.yaml"
+  BYPRODUCTS "cvcuda_basic.yaml"
+)
+add_dependencies(cvcuda_basic cvcuda_basic_deps)
+
+# Add testing
+if(BUILD_TESTING)
+  # Configure the yaml file to only play 10 frames
+  file(READ "${CMAKE_CURRENT_SOURCE_DIR}/cvcuda_basic.yaml" CONFIG_FILE)
+  string(REGEX REPLACE "source:[^\n]*" "source: replayer" CONFIG_FILE ${CONFIG_FILE})
+  string(REPLACE "count: 0" "count: 10" CONFIG_FILE ${CONFIG_FILE})
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/cvcuda_basic_testing.yaml" ${CONFIG_FILE})
+
+  # Add test
+  add_test(NAME cvcuda_basic_cpp_test
+           COMMAND cvcuda_basic ${CMAKE_CURRENT_BINARY_DIR}/cvcuda_basic_testing.yaml
+                   --data "${HOLOHUB_DATA_DIR}/endoscopy"
+           WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+  set_tests_properties(cvcuda_basic_cpp_test PROPERTIES
+                       PASS_REGULAR_EXPRESSION "Reach end of file or playback count reaches to the limit. Stop ticking."
+                       FAIL_REGULAR_EXPRESSION "[^a-z]Error;ERROR;Failed")
+endif()

--- a/applications/cvcuda_basic/cpp/cvcuda_basic.yaml
+++ b/applications/cvcuda_basic/cpp/cvcuda_basic.yaml
@@ -1,0 +1,29 @@
+%YAML 1.2
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+replayer:
+  basename: "surgical_video"
+  frame_rate: 0   # as specified in timestamps
+  repeat: true    # default: false
+  realtime: true  # default: true
+  count: 0        # default: 0 (no frame count restriction)
+
+holoviz:
+  tensors:
+    - name: image
+      type: color
+      opacity: 1.0
+      priority: 0

--- a/applications/cvcuda_basic/cpp/cvcuda_utils.cpp
+++ b/applications/cvcuda_basic/cpp/cvcuda_utils.cpp
@@ -1,0 +1,552 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "cvcuda_utils.hpp"
+
+#include <fmt/format.h>
+
+#include <gxf/std/tensor.hpp>
+
+namespace holoscan {
+
+nvcv::DataType dldatatype_to_nvcvdatatype(DLDataType dtype, int num_channels) {
+  nvcv::DataType type;
+  uint8_t bits = dtype.bits;
+  uint16_t channels = (num_channels == 0) ? dtype.lanes : num_channels;
+
+  switch (dtype.code) {
+    case kDLInt:
+      switch (bits) {
+        case 8:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_S8;
+              break;
+            case 2:
+              type = nvcv::TYPE_2S8;
+              break;
+            case 3:
+              type = nvcv::TYPE_3S8;
+              break;
+            case 4:
+              type = nvcv::TYPE_4S8;
+              break;
+            default:
+              throw std::runtime_error(
+                  fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                              dtype.code,
+                              dtype.bits,
+                              channels));
+          }
+          break;
+        case 16:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_S16;
+              break;
+            case 2:
+              type = nvcv::TYPE_2S16;
+              break;
+            case 3:
+              type = nvcv::TYPE_3S16;
+              break;
+            case 4:
+              type = nvcv::TYPE_4S16;
+              break;
+            default:
+              throw std::runtime_error(
+                  fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                              dtype.code,
+                              dtype.bits,
+                              channels));
+          }
+          break;
+        case 32:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_S32;
+              break;
+            case 2:
+              type = nvcv::TYPE_2S32;
+              break;
+            case 3:
+              type = nvcv::TYPE_3S32;
+              break;
+            case 4:
+              type = nvcv::TYPE_4S32;
+              break;
+            default:
+              throw std::runtime_error(
+                  fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                              dtype.code,
+                              dtype.bits,
+                              channels));
+          }
+          break;
+        case 64:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_S64;
+              break;
+            case 2:
+              type = nvcv::TYPE_2S64;
+              break;
+            case 3:
+              type = nvcv::TYPE_3S64;
+              break;
+            case 4:
+              type = nvcv::TYPE_4S64;
+              break;
+            default:
+              throw std::runtime_error(
+                  fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                              dtype.code,
+                              dtype.bits,
+                              channels));
+          }
+          break;
+        default:
+          throw std::runtime_error(
+              fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                          dtype.code,
+                          dtype.bits,
+                          channels));
+      }
+      break;
+    case kDLUInt:
+      switch (bits) {
+        case 8:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_U8;
+              break;
+            case 2:
+              type = nvcv::TYPE_2U8;
+              break;
+            case 3:
+              type = nvcv::TYPE_3U8;
+              break;
+            case 4:
+              type = nvcv::TYPE_4U8;
+              break;
+            default:
+              throw std::runtime_error(
+                  fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                              dtype.code,
+                              dtype.bits,
+                              channels));
+          }
+          break;
+        case 16:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_U16;
+              break;
+            case 2:
+              type = nvcv::TYPE_2U16;
+              break;
+            case 3:
+              type = nvcv::TYPE_3U16;
+              break;
+            case 4:
+              type = nvcv::TYPE_4U16;
+              break;
+            default:
+              throw std::runtime_error(
+                  fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                              dtype.code,
+                              dtype.bits,
+                              channels));
+          }
+          break;
+        case 32:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_U32;
+              break;
+            case 2:
+              type = nvcv::TYPE_2U32;
+              break;
+            case 3:
+              type = nvcv::TYPE_3U32;
+              break;
+            case 4:
+              type = nvcv::TYPE_4U32;
+              break;
+            default:
+              throw std::runtime_error(
+                  fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                              dtype.code,
+                              dtype.bits,
+                              channels));
+          }
+          break;
+        case 64:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_U64;
+              break;
+            case 2:
+              type = nvcv::TYPE_2U64;
+              break;
+            case 3:
+              type = nvcv::TYPE_3U64;
+              break;
+            case 4:
+              type = nvcv::TYPE_4U64;
+              break;
+            default:
+              throw std::runtime_error(
+                  fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                              dtype.code,
+                              dtype.bits,
+                              channels));
+          }
+          break;
+        default:
+          throw std::runtime_error(
+              fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                          dtype.code,
+                          dtype.bits,
+                          channels));
+      }
+      break;
+    case kDLFloat:
+      switch (bits) {
+        case 16:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_F16;
+              break;
+            case 2:
+              type = nvcv::TYPE_2F16;
+              break;
+            case 3:
+              type = nvcv::TYPE_3F16;
+              break;
+            case 4:
+              type = nvcv::TYPE_4F16;
+              break;
+            default:
+              throw std::runtime_error(
+                  fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                              dtype.code,
+                              dtype.bits,
+                              channels));
+          }
+          break;
+        case 32:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_F32;
+              break;
+            case 2:
+              type = nvcv::TYPE_2F32;
+              break;
+            case 3:
+              type = nvcv::TYPE_3F32;
+              break;
+            case 4:
+              type = nvcv::TYPE_4F32;
+              break;
+            default:
+              throw std::runtime_error(
+                  fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                              dtype.code,
+                              dtype.bits,
+                              channels));
+          }
+          break;
+        case 64:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_F64;
+              break;
+            case 2:
+              type = nvcv::TYPE_2F64;
+              break;
+            case 3:
+              type = nvcv::TYPE_3F64;
+              break;
+            case 4:
+              type = nvcv::TYPE_4F64;
+              break;
+            default:
+              throw std::runtime_error(
+                  fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                              dtype.code,
+                              dtype.bits,
+                              channels));
+          }
+          break;
+        default:
+          throw std::runtime_error(
+              fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                          dtype.code,
+                          dtype.bits,
+                          channels));
+      }
+      break;
+    case kDLComplex:
+      switch (bits) {
+        case 64:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_C64;
+              break;
+            case 2:
+              type = nvcv::TYPE_2C64;
+              break;
+            case 3:
+              type = nvcv::TYPE_3C64;
+              break;
+            case 4:
+              type = nvcv::TYPE_4C64;
+              break;
+            default:
+              throw std::runtime_error(
+                  fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                              dtype.code,
+                              dtype.bits,
+                              channels));
+          }
+          break;
+        case 128:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_C128;
+              break;
+            case 2:
+              type = nvcv::TYPE_2C128;
+              break;
+            default:
+              throw std::runtime_error(
+                  fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                              dtype.code,
+                              dtype.bits,
+                              channels));
+          }
+          break;
+        default:
+          throw std::runtime_error(
+              fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                          dtype.code,
+                          dtype.bits,
+                          channels));
+      }
+      break;
+    default:
+      throw std::runtime_error(
+          fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                      dtype.code,
+                      dtype.bits,
+                      channels));
+  }
+  return type;
+}
+
+nvidia::gxf::PrimitiveType nvcvdatatype_to_gxfprimitivetype(nvcv::DataType dtype) {
+  nvidia::gxf::PrimitiveType type;
+  switch (dtype) {
+    case nvcv::TYPE_U8:
+    case nvcv::TYPE_2U8:
+    case nvcv::TYPE_3U8:
+    case nvcv::TYPE_4U8:
+      type = nvidia::gxf::PrimitiveType::kUnsigned8;
+      break;
+    case nvcv::TYPE_U16:
+    case nvcv::TYPE_2U16:
+    case nvcv::TYPE_3U16:
+    case nvcv::TYPE_4U16:
+      type = nvidia::gxf::PrimitiveType::kUnsigned16;
+      break;
+    case nvcv::TYPE_U32:
+    case nvcv::TYPE_2U32:
+    case nvcv::TYPE_3U32:
+    case nvcv::TYPE_4U32:
+      type = nvidia::gxf::PrimitiveType::kUnsigned32;
+      break;
+    case nvcv::TYPE_U64:
+    case nvcv::TYPE_2U64:
+    case nvcv::TYPE_3U64:
+    case nvcv::TYPE_4U64:
+      type = nvidia::gxf::PrimitiveType::kUnsigned64;
+      break;
+    case nvcv::TYPE_S8:
+    case nvcv::TYPE_2S8:
+    case nvcv::TYPE_3S8:
+    case nvcv::TYPE_4S8:
+      type = nvidia::gxf::PrimitiveType::kInt8;
+      break;
+    case nvcv::TYPE_S16:
+    case nvcv::TYPE_2S16:
+    case nvcv::TYPE_3S16:
+    case nvcv::TYPE_4S16:
+      type = nvidia::gxf::PrimitiveType::kInt16;
+      break;
+    case nvcv::TYPE_S32:
+    case nvcv::TYPE_2S32:
+    case nvcv::TYPE_3S32:
+    case nvcv::TYPE_4S32:
+      type = nvidia::gxf::PrimitiveType::kInt32;
+      break;
+    case nvcv::TYPE_S64:
+    case nvcv::TYPE_2S64:
+    case nvcv::TYPE_3S64:
+    case nvcv::TYPE_4S64:
+      type = nvidia::gxf::PrimitiveType::kInt64;
+      break;
+    case nvcv::TYPE_F32:
+    case nvcv::TYPE_2F32:
+    case nvcv::TYPE_3F32:
+    case nvcv::TYPE_4F32:
+      type = nvidia::gxf::PrimitiveType::kFloat32;
+    case nvcv::TYPE_F64:
+    case nvcv::TYPE_2F64:
+    case nvcv::TYPE_3F64:
+    case nvcv::TYPE_4F64:
+      type = nvidia::gxf::PrimitiveType::kFloat64;
+      break;
+    // Can uncomment the complex types below for Holoscan v1.0, but they are unsupported in v0.6.
+    // case nvcv::TYPE_C64:
+    // case nvcv::TYPE_2C64:
+    // case nvcv::TYPE_3C64:
+    // case nvcv::TYPE_4C64:
+    //   type = nvidia::gxf::PrimitiveType::kComplex64;
+    //   break;
+    // case nvcv::TYPE_C128:
+    // case nvcv::TYPE_2C128:
+    //   type = nvidia::gxf::PrimitiveType::kComplex128;
+    //   break;
+    default:
+      throw std::runtime_error("nvcv::DataType does not have a corresponding GXF primitive type");
+  }
+  return type;
+}
+
+nvcv::TensorDataStridedCuda::Buffer nhwc_buffer_from_holoscan_tensor(
+    std::shared_ptr<holoscan::Tensor> tensor) {
+  auto ndim = tensor->ndim();
+
+  nvcv::TensorDataStridedCuda::Buffer in_buffer;
+  auto in_strides = tensor->strides();
+  if (ndim == 4) {
+    // assume tensor has NHWC layout
+    // copy strides from in_tensor->strides()
+    for (auto d = 0; d < ndim; d++) { in_buffer.strides[d] = in_strides[d]; }
+  } else if (ndim == 3) {
+    // assume tensor has HWC layout
+    // stride for batch dimension
+    in_buffer.strides[0] = in_strides[0] * tensor->shape()[0];
+    // remaining strides match in_tensor->strides()
+    for (auto d = 0; d < ndim; d++) { in_buffer.strides[d + 1] = in_strides[d]; }
+  } else if (ndim == 2) {
+    // assume tensor has HW layout
+    // stride for batch dimension
+    in_buffer.strides[0] = in_strides[0] * tensor->shape()[0];
+    // remaining strides match in_tensor->strides()
+    for (auto d = 0; d < ndim; d++) { in_buffer.strides[d + 1] = in_strides[d]; }
+    in_buffer.strides[3] = in_buffer.strides[2];
+  } else {
+    throw std::runtime_error(
+        "expected a tensor with (height, width) or (height, width, channels) or "
+        "(batch, height, width, channels) dimensions");
+  }
+  in_buffer.basePtr = static_cast<NVCVByte*>(tensor->data());
+  return in_buffer;
+}
+
+/**
+ * @brief Generate output message containing a single tensor
+ *
+ * This function only supports holoscan tensors with shapes corresponding to one of the following:
+ * - (height, width)
+ * - (height, width, channels)
+ * - (batch, height, width, channels)
+ *
+ * @param in_tensor The holoscan tensor from which the CV-CUDA tensor will be initialized.
+ * @return CV-CUDA tensor and corresponding buffer
+ */
+std::pair<nvcv::Tensor, nvcv::TensorDataStridedCuda::Buffer> holoscan_tensor_to_cvcuda_NHWC(
+    std::shared_ptr<holoscan::Tensor> in_tensor) {
+  // The output tensor will always be created in NHWC format even if no batch dimension existed
+  // on the GXF tensor.
+  int ndim = in_tensor->ndim();
+  int batch_size, image_height, image_width, num_channels;
+  auto in_shape = in_tensor->shape();
+  if (ndim == 4) {
+    batch_size = in_shape[0];
+    image_height = in_shape[1];
+    image_width = in_shape[2];
+    num_channels = in_shape[3];
+  } else if (ndim == 3) {
+    batch_size = 1;
+    image_height = in_shape[0];
+    image_width = in_shape[1];
+    num_channels = in_shape[2];
+  } else if (ndim == 2) {
+    batch_size = 1;
+    image_height = in_shape[0];
+    image_width = in_shape[1];
+    num_channels = 1;
+  } else {
+    throw std::runtime_error(
+        "expected a tensor with (height, width) or (height, width, channels) or "
+        "(batch, height, width, channels) dimensions");
+  }
+
+  // buffer with strides defined for NHWC format (For cvcuda::Flip could also just use HWC)
+  auto in_buffer = nhwc_buffer_from_holoscan_tensor(in_tensor);
+  nvcv::TensorShape cv_tensor_shape{{batch_size, image_height, image_width, num_channels},
+                                    NVCV_TENSOR_NHWC};
+  nvcv::DataType cv_dtype = dldatatype_to_nvcvdatatype(in_tensor->dtype());
+
+  // Create a tensor buffer to store the data pointer and pitch bytes for each plane
+  nvcv::TensorDataStridedCuda in_data(cv_tensor_shape, cv_dtype, in_buffer);
+
+  // TensorWrapData allows for interoperation of external tensor representations with CVCUDA
+  // Tensor.
+  nvcv::Tensor cv_in_tensor = nvcv::TensorWrapData(in_data);
+  return std::make_pair(cv_in_tensor, in_buffer);
+}
+
+std::pair<nvidia::gxf::Entity, std::shared_ptr<void*>> create_out_message_with_tensor_like(
+    gxf_context_t context, nvcv::Tensor reference_nhwc_tensor) {
+  // Create an out_message entity containing a single GXF tensor corresponding to the output.
+  // We will then reuse the same data pointer to intialize the CV-CUDA output tensor.
+  auto element_type = nvcvdatatype_to_gxfprimitivetype(reference_nhwc_tensor.dtype());
+  auto shape = reference_nhwc_tensor.shape();
+  if (shape.size() != 4) { throw std::runtime_error("expected 4D tensor (NHWC format)"); }
+  nvidia::gxf::Shape out_shape;
+  int n = shape[0];
+  int h = shape[1];
+  int w = shape[2];
+  int c = shape[3];
+  if (shape[0] == 1) {
+    // note: omit singleton batch size since, e.g. HolovizOp expects HWC, not NHWC
+    if (shape[3] == 1) {
+      // note: omit singleton channel size
+      out_shape = nvidia::gxf::Shape{h, w};
+    } else {
+      out_shape = nvidia::gxf::Shape{h, w, c};
+    }
+  } else {
+    out_shape = nvidia::gxf::Shape{n, h, w, c};
+  }
+  auto storage_type = nvidia::gxf::MemoryStorageType::kDevice;
+  return create_out_message_with_tensor(context, out_shape, element_type, storage_type);
+}
+}  // namespace holoscan

--- a/applications/cvcuda_basic/cpp/cvcuda_utils.hpp
+++ b/applications/cvcuda_basic/cpp/cvcuda_utils.hpp
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HOLOHUB_APPLICATIONS_CVCUDA_BASIC_CVCUDA_UTILS_HPP
+#define HOLOHUB_APPLICATIONS_CVCUDA_BASIC_CVCUDA_UTILS_HPP
+
+#include <dlpack/dlpack.h>
+
+#include <memory>
+
+#include "gxf_utils.hpp"
+#include <gxf/std/tensor.hpp>
+#include <holoscan/core/domain/tensor.hpp>
+#include <nvcv/DataType.hpp>  // nvcv::DataType
+#include <nvcv/Tensor.hpp>
+#include <nvcv/TensorData.hpp>
+
+namespace holoscan {
+
+/**
+ * @brief Convert from a DLPack data type structure to a corresponding CV-CUDA data type
+ *
+ * @param dtype DLPack data type.
+ * @param num_channels The number of channels (optional). If specified, overrides `dtype.lanes`.
+ * @return CV-CUDA data type.
+ */
+nvcv::DataType dldatatype_to_nvcvdatatype(DLDataType dtype, int num_channels = 0);
+
+/**
+ * @brief Return the GXF tensor primitive type corresponding to a CV-CUDA dtype.
+ *
+ * The GXF primitive type does not include information on the number of interleaved channels.
+ *
+ * @param dtype CV-CUDA data type.
+ * @return The GXF tensor primitive type
+ */
+nvidia::gxf::PrimitiveType nvcvdatatype_to_gxfprimitivetype(nvcv::DataType dtype);
+
+/**
+ * @brief Convert a holoscan::Tensor to a CV-CUDA tensor and corresponding Buffer class.
+ *
+ * This function only supports holoscan tensors with C-ordered memory layout and shape
+ * corresponding to one of the following:
+ * - (height, width)
+ * - (height, width, channels)
+ * - (batch, height, width, channels)
+ *
+ * @param in_tensor The holoscan tensor from which the CV-CUDA tensor will be initialized.
+ * @return CV-CUDA tensor and corresponding buffer
+ */
+std::pair<nvcv::Tensor, nvcv::TensorDataStridedCuda::Buffer> holoscan_tensor_to_cvcuda_NHWC(
+    std::shared_ptr<holoscan::Tensor> in_tensor);
+
+/**
+ * @brief Generate output message containing a single Holoscan tensor like reference_nhwc_tensor
+ *
+ * Note: If dimensions N or C have size 1, the corresponding dimensions will be dropped from
+ * the output tensor.
+ *
+ * @param context The GXF context.
+ * @param reference_nhwc_tensor The reference CV-CUDA tensor.
+ * @return A GXF entity containing a single tensor like reference_nhwc_tensor.
+ */
+std::pair<nvidia::gxf::Entity, std::shared_ptr<void*>> create_out_message_with_tensor_like(
+    gxf_context_t context, nvcv::Tensor reference_nhwc_tensor);
+
+}  // namespace holoscan
+
+#endif /* HOLOHUB_APPLICATIONS_CVCUDA_BASIC_CVCUDA_UTILS_HPP */

--- a/applications/cvcuda_basic/cpp/gxf_utils.cpp
+++ b/applications/cvcuda_basic/cpp/gxf_utils.cpp
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cuda_runtime.h>
+
+#include <memory>
+
+#include <gxf/std/tensor.hpp>
+#include <holoscan/core/domain/tensor.hpp>
+
+namespace holoscan {
+
+std::pair<nvidia::gxf::Entity, std::shared_ptr<void*>> create_out_message_with_tensor(
+    gxf_context_t context, nvidia::gxf::Shape shape, nvidia::gxf::PrimitiveType element_type,
+    nvidia::gxf::MemoryStorageType storage_type) {
+  int element_size = nvidia::gxf::PrimitiveTypeSize(element_type);
+  size_t nbytes = shape.size() * element_size;
+  // Create a shared pointer for the CUDA memory with a custom deleter.
+  auto pointer = std::shared_ptr<void*>(new void*, [](void** pointer) {
+    if (pointer != nullptr) {
+      if (*pointer != nullptr) { cudaFree(*pointer); }
+      delete pointer;
+    }
+  });
+
+  // Allocate the CUDA memory (don't need to explicitly intialize)
+  cudaError_t err = cudaMalloc(pointer.get(), nbytes);
+  // Holoscan Tensor doesn't support direct memory allocation.
+  // Thus, create an Entity and use GXF tensor to wrap the CUDA memory.
+  auto out_message = nvidia::gxf::Entity::New(context);
+  auto gxf_tensor = out_message.value().add<nvidia::gxf::Tensor>("image");
+  gxf_tensor.value()->wrapMemory(shape,
+                                 element_type,
+                                 element_size,
+                                 nvidia::gxf::ComputeTrivialStrides(shape, element_size),
+                                 nvidia::gxf::MemoryStorageType::kDevice,
+                                 *pointer,
+                                 [orig_pointer = pointer](void*) mutable {
+                                   orig_pointer.reset();  // decrement ref count
+                                   return nvidia::gxf::Success;
+                                 });
+
+  return std::make_pair(out_message.value(), pointer);
+}
+}  // namespace holoscan

--- a/applications/cvcuda_basic/cpp/gxf_utils.hpp
+++ b/applications/cvcuda_basic/cpp/gxf_utils.hpp
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef HOLOHUB_APPLICATIONS_CVCUDA_BASIC_GXF_UTILS_HPP
+#define HOLOHUB_APPLICATIONS_CVCUDA_BASIC_GXF_UTILS_HPP
+
+#include <memory>
+
+#include <gxf/std/tensor.hpp>
+#include <holoscan/core/domain/tensor.hpp>
+
+namespace holoscan {
+
+/**
+ * @brief Generate output message containing a single tensor
+ *
+ * @param context The GXF context.
+ * @param shape The element type of the tensor.
+ * @param element_type The element type of the tensor.
+ * @param storage_type The storage type of the tensor.
+ * @return Pair containing the GXF entity as well as a std::shared_ptr<void*> corresponding to
+ * the tensor data.
+ */
+std::pair<nvidia::gxf::Entity, std::shared_ptr<void*>> create_out_message_with_tensor(
+    gxf_context_t context, nvidia::gxf::Shape shape, nvidia::gxf::PrimitiveType element_type,
+    nvidia::gxf::MemoryStorageType storage_type = nvidia::gxf::MemoryStorageType::kDevice);
+
+}  // namespace holoscan
+
+#endif /* HOLOHUB_APPLICATIONS_CVCUDA_BASIC_GXF_UTILS_HPP */

--- a/applications/cvcuda_basic/cpp/main-stream-version.cpp
+++ b/applications/cvcuda_basic/cpp/main-stream-version.cpp
@@ -1,0 +1,261 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuda_runtime.h>
+#include <dlpack/dlpack.h>
+#include <getopt.h>
+
+#include "holoscan/holoscan.hpp"
+#include <holoscan/operators/video_stream_replayer/video_stream_replayer.hpp>
+#include <holoscan/operators/format_converter/format_converter.hpp>
+#include <holoscan/operators/holoviz/holoviz.hpp>
+
+#include <cvcuda/OpFlip.hpp>     // cvcuda::Flip
+#include <nvcv/DataType.hpp>     // nvcv::DataType
+#include <nvcv/ImageFormat.hpp>  // nvcv::FMT_RGB8, etc.
+#include <nvcv/Tensor.hpp>       // nvcv::Tensor
+#include <nvcv/TensorData.hpp>   // nvcv::TensorDataStridedCuda
+#include <nvcv/TensorShape.hpp>  // nvcv::TensorShape
+
+namespace holoscan::ops {
+
+// Apply basic CV-CUDA processing to the input frame
+
+class ImageProcessingOp : public holoscan::Operator {
+ public:
+  HOLOSCAN_OPERATOR_FORWARD_ARGS(ImageProcessingOp);
+  ImageProcessingOp() = default;
+
+  void setup(holoscan::OperatorSpec& spec) override {
+    spec.input<holoscan::TensorMap>("input_tensor");
+    spec.output<holoscan::TensorMap>("output_tensor");
+
+    cuda_stream_handler_.defineParams(spec);
+  }
+
+  void initialize() override {
+    HOLOSCAN_LOG_INFO("Converting incoming packet data to Complex Tensor data");
+    holoscan::Operator::initialize();
+  }
+
+  void compute(holoscan::InputContext& op_input, holoscan::OutputContext& op_output,
+               holoscan::ExecutionContext& context) override {
+    // The type of `in_message` is 'holoscan::TensorMap'.
+    auto in_message = op_input.receive<holoscan::TensorMap>("input_tensor").value();
+
+    // get the CUDA stream from the input message
+    gxf_result_t stream_handler_result =
+        cuda_stream_handler_.fromMessage(context.context(), in_message);
+    if (stream_handler_result != GXF_SUCCESS) {
+      throw std::runtime_error("Failed to get the CUDA stream from incoming messages");
+    }
+
+    auto& [inReqs, cv_inTensor] = tensormap_2d_rgb_tensor(in_message);
+
+    // // // tensor output of VideoReplayerOp is just an empty string ""
+    // // std::shared_ptr<holoscan::Tensor> in_tensor = in_message[""];
+
+    // std::shared_ptr<holoscan::Tensor> in_tensor;
+    // auto n_tensors = in_message.size();
+    // if (n_tensors != 1) {
+    //   throw std::runtime_error(
+    //       fmt::format("expected exactly 1 tensor in input_tensor map, found {}", n_tensors));
+    // } else {
+    //   // get the tensor without needing to know the key name
+    //   for (auto& [key, tensor] : in_message) { in_tensor = tensor; }
+    // }
+
+    // // Sanity checks that the input tensor is C-contiguous RGB data in HWC format
+    // if (in_tensor->itemsize() != sizeof(uint8_t)) {
+    //   HOLOSCAN_LOG_ERROR("expected in_tensor with itemsize of 1 byte");
+    // }
+    // if (in_tensor->ndim() != 3) {
+    //   HOLOSCAN_LOG_ERROR("expected in_tensor with 3 dimensions: (height, width, channels)");
+    //   return;
+    // }
+    // if (in_tensor->shape()[2] != 3) {
+    //   HOLOSCAN_LOG_ERROR("expected in_tensor with 3 channels (RGB)");
+    // }
+    // if (in_tensor->strides()[0] != (in_tensor->shape()[1] * in_tensor->shape()[2])) {
+    //   HOLOSCAN_LOG_ERROR("expected C-contiguous in_tensor");
+    // }
+
+    // int batchSize = 1;
+    int ImageWidth = in_tensor->shape()[1];   // 854
+    int ImageHeight = in_tensor->shape()[0];  // 480
+    int num_channels = 3;                     // RGB
+
+    // // buffer with strides defined for NHWC format (For cvcuda::Flip could also just use HWC)
+    // nvcv::TensorDataStridedCuda::Buffer inBuf;
+    // inBuf.strides[3] = sizeof(uint8_t);
+    // inBuf.strides[2] = num_channels * inBuf.strides[3];
+    // inBuf.strides[1] = ImageWidth * inBuf.strides[2];
+    // inBuf.strides[0] = ImageHeight * inBuf.strides[1];
+    // inBuf.basePtr = static_cast<NVCVByte*>(in_tensor->data());
+
+    // // Calculate the requirements for the RGBI uint8_t Tensor which include
+    // // pitch bytes, alignment, shape  and tensor layout
+    // nvcv::Tensor::Requirements inReqs =
+    //     nvcv::Tensor::CalcRequirements(batchSize, {ImageWidth, ImageHeight}, nvcv::FMT_RGB8);
+
+    // // Create a tensor buffer to store the data pointer and pitch bytes for each plane
+    // nvcv::TensorDataStridedCuda inData(nvcv::TensorShape{inReqs.shape, inReqs.rank, inReqs.layout},
+    //                                    nvcv::DataType{inReqs.dtype},
+    //                                    inBuf);
+
+    // // TensorWrapData allows for interoperation of external tensor representations with CVCUDA
+    // // Tensor.
+    // nvcv::Tensor cv_inTensor = nvcv::TensorWrapData(inData);
+
+
+    // Create a GXF tensor for the output (we will then reuse the same data pointer to intialize
+    // the CV-CUDA output tensor)
+    nvidia::gxf::PrimitiveType element_type = nvidia::gxf::PrimitiveType::kUnsigned8;
+    int element_size = nvidia::gxf::PrimitiveTypeSize(element_type);
+    nvidia::gxf::Shape shape = nvidia::gxf::Shape{ImageHeight, ImageWidth, num_channels};
+    size_t nbytes = ImageHeight * ImageWidth * num_channels;
+    // Create a shared pointer for the CUDA memory with a custom deleter.
+    auto pointer = std::shared_ptr<void*>(new void*, [](void** pointer) {
+      if (pointer != nullptr) {
+        if (*pointer != nullptr) { cudaFree(*pointer); }
+        delete pointer;
+      }
+    });
+    // Allocate the CUDA memory (don't need to explicitly intialize)
+    cudaError_t err = cudaMalloc(pointer.get(), nbytes);
+    // Holoscan Tensor doesn't support direct memory allocation.
+    // Thus, create an Entity and use GXF tensor to wrap the CUDA memory.
+    auto out_message = nvidia::gxf::Entity::New(context.context());
+    auto gxf_tensor = out_message.value().add<nvidia::gxf::Tensor>("image");
+    gxf_tensor.value()->wrapMemory(shape,
+                                   element_type,
+                                   element_size,
+                                   nvidia::gxf::ComputeTrivialStrides(shape, element_size),
+                                   nvidia::gxf::MemoryStorageType::kDevice,
+                                   *pointer,
+                                   [orig_pointer = pointer](void*) mutable {
+                                     orig_pointer.reset();  // decrement ref count
+                                     return nvidia::gxf::Success;
+                                   });
+
+    // Create a CV-CUDA cv_outTensor pointing to the same CUDA memory as gxf_tensor.
+    // Note: If we allocated the memory in CV-CUDA, it would be deallocated once the CV-CUDA
+    // tensor goes out of scope (at the end of this compute call). To avoid this, we allocated a
+    // GXF Tensor above and then create cv_outTensor using nvcv::TensorWrapData on its data.
+    nvcv::TensorDataStridedCuda::Buffer outBuf = inBuf;
+    outBuf.basePtr = static_cast<NVCVByte*>(*pointer);
+    nvcv::TensorDataStridedCuda outData(nvcv::TensorShape{inReqs.shape, inReqs.rank, inReqs.layout},
+                                        nvcv::DataType{inReqs.dtype},
+                                        outBuf);
+    nvcv::Tensor cv_outTensor = nvcv::TensorWrapData(outData);
+
+    // apply the Flip operator
+    cvcuda::Flip flipOp;
+    int32_t flipCode = 0;
+    // Using default stream (0) here for simplicity, but could add cuda_stream_handler_ support
+    cudaStream_t stream = cuda_stream_handler_.getCudaStream(context.context());
+    flipOp(stream, cv_inTensor, cv_outTensor, flipCode);  // first argument is the CUDA stream
+
+    // Emit the tensor.
+    op_output.emit(out_message.value(), "output_tensor");
+  }
+ private:
+  CudaStreamHandler cuda_stream_handler_;
+};
+
+}  // namespace holoscan::ops
+
+class App : public holoscan::Application {
+ public:
+  void set_datapath(const std::string& path) { datapath = path; }
+
+  void compose() override {
+    using namespace holoscan;
+
+    uint32_t width = 854;
+    uint32_t height = 480;
+    auto source = make_operator<ops::VideoStreamReplayerOp>(
+        "replayer", from_config("replayer"), Arg("directory", datapath));
+
+    // TODO: Could use a BlockMemoryPool with ImageProcessingOp
+    // TODO: Could use CudaStreamPool with ImageProcessingOp
+    auto image_processing = make_operator<ops::ImageProcessingOp>("image_processing");
+
+    const std::shared_ptr<CudaStreamPool> cuda_stream_pool =
+        make_resource<CudaStreamPool>("cuda_stream", 0, 0, 0, 1, 5);
+
+    std::shared_ptr<ops::HolovizOp> visualizer = make_operator<ops::HolovizOp>(
+        "holoviz",
+        from_config("holoviz"),
+        // Modify width to account for row padding added by CV-CUDA (TODO: should not be necessary?)
+        // Arg("width") = width % 32 == 0 ? width : (width / 32 + 1) * 32,
+        Arg("width") = width,
+        Arg("height") = height,
+        Arg("cuda_stream_pool") = cuda_stream_pool);
+
+    // Flow definition
+    add_flow(source, image_processing);
+    add_flow(image_processing, visualizer, {{"output_tensor", "receivers"}});
+  }
+
+ private:
+  std::string datapath = "data/endoscopy";
+};
+
+/** Helper function to parse the command line arguments */
+bool parse_arguments(int argc, char** argv, std::string& config_name, std::string& data_path) {
+  static struct option long_options[] = {{"data", required_argument, 0, 'd'}, {0, 0, 0, 0}};
+
+  while (int c = getopt_long(argc, argv, "d", long_options, NULL)) {
+    if (c == -1 || c == '?') break;
+
+    switch (c) {
+      case 'd':
+        data_path = optarg;
+        break;
+      default:
+        std::cout << "Unknown arguments returned: " << c << std::endl;
+        return false;
+    }
+  }
+
+  if (optind < argc) { config_name = argv[optind++]; }
+  return true;
+}
+
+/** Main function */
+int main(int argc, char** argv) {
+  auto app = holoscan::make_application<App>();
+
+  // Parse the arguments
+  std::string data_path = "";
+  std::string config_name = "";
+  if (!parse_arguments(argc, argv, config_name, data_path)) { return 1; }
+
+  if (config_name != "") {
+    app->config(config_name);
+  } else {
+    auto config_path = std::filesystem::canonical(argv[0]).parent_path();
+    config_path += "/cvcuda_basic.yaml";
+    app->config(config_path);
+  }
+  if (data_path != "") app->set_datapath(data_path);
+
+  app->run();
+
+  return 0;
+}

--- a/applications/cvcuda_basic/cpp/main.cpp
+++ b/applications/cvcuda_basic/cpp/main.cpp
@@ -1,0 +1,240 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <getopt.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "cvcuda_utils.hpp"
+#include "holoscan/holoscan.hpp"
+#include <holoscan/operators/video_stream_replayer/video_stream_replayer.hpp>
+#include <holoscan/operators/format_converter/format_converter.hpp>
+#include <holoscan/operators/holoviz/holoviz.hpp>
+
+#include <cvcuda/OpFlip.hpp>     // cvcuda::Flip
+#include <nvcv/DataType.hpp>     // nvcv::DataType
+#include <nvcv/Tensor.hpp>       // nvcv::Tensor
+#include <nvcv/TensorData.hpp>   // nvcv::TensorDataStridedCuda
+
+namespace holoscan::ops {
+
+/**
+ * @brief Find a tensor in the tensormap and validate that it has the expected shape and dtype
+ *
+ * @param tensormap A holoscan::TensorMap containing a single RGB tensor.
+ * @return A shared pointer to the holoscan tensor.
+ */
+std::shared_ptr<holoscan::Tensor> validate_and_get_rgb_image(holoscan::TensorMap tensormap,
+                                                             bool has_batch_dimension = false) {
+  std::shared_ptr<holoscan::Tensor> in_tensor;
+  auto n_tensors = tensormap.size();
+  if (n_tensors != 1) {
+    throw std::runtime_error(
+        fmt::format("expected exactly 1 tensor in input_tensor map, found {}", n_tensors));
+  } else {
+    // get the tensor without needing to know the key name
+    for (auto& [key, tensor] : tensormap) { in_tensor = tensor; }
+  }
+
+  int expected_ndim = has_batch_dimension ? 4 : 3;
+
+  // assume 2D + channels without batch dimension
+  if (in_tensor->ndim() != expected_ndim) {
+    if (expected_ndim == 4) {
+      throw std::runtime_error(
+          "expected input tensor with 4 dimensions: (batch, height, width, channels)");
+    } else {
+      throw std::runtime_error(
+          "expected input tensor with 3 dimensions: (height, width, channels)");
+    }
+  }
+
+  // raise error if tensor data is not on the device
+  DLDevice dev = in_tensor->device();
+  if (dev.device_type != kDLCUDA) {
+    throw std::runtime_error("expected input tensor to be on a CUDA device");
+  }
+
+  auto ndim_in = in_tensor->ndim();
+  HOLOSCAN_LOG_DEBUG("in_tensor.ndim() = {}", ndim_in);
+  HOLOSCAN_LOG_DEBUG("in_tensor.itemsize() = {}", in_tensor->itemsize());
+  HOLOSCAN_LOG_DEBUG("in_tensor.shape()[0] = {}", in_tensor->shape()[0]);
+  HOLOSCAN_LOG_DEBUG("in_tensor.shape()[1] = {}", in_tensor->shape()[1]);
+  HOLOSCAN_LOG_DEBUG("in_tensor.shape()[2] = {}", in_tensor->shape()[2]);
+  if (ndim_in > 3) { HOLOSCAN_LOG_DEBUG("in_tensor.shape()[3] = {}", in_tensor->shape()[3]); }
+  HOLOSCAN_LOG_DEBUG("in_tensor.strides()[0] = {}", in_tensor->strides()[0]);
+  HOLOSCAN_LOG_DEBUG("in_tensor.strides()[1] = {}", in_tensor->strides()[1]);
+  HOLOSCAN_LOG_DEBUG("in_tensor.strides()[2] = {}", in_tensor->strides()[2]);
+  if (ndim_in > 3) { HOLOSCAN_LOG_DEBUG("in_tensor.strides()[3] = {}", in_tensor->strides()[3]); }
+
+  auto itemsize = in_tensor->itemsize();
+
+  // Sanity checks that the input tensor is 8-bit RGB data in HWC format
+  DLDataType dtype = in_tensor->dtype();
+  if ((dtype.code != kDLUInt) || (dtype.bits != 8)) {
+    throw std::runtime_error(
+        fmt::format("expected 8-bit unsigned integer data, found DLDataTypeCode: {}, bits: {}",
+                    static_cast<int>(dtype.code),
+                    dtype.bits));
+  }
+
+  if (in_tensor->shape()[ndim_in - 1] != 3) {
+    throw std::runtime_error("expected in_tensor with 3 channels on the last dimension (RGB)");
+  }
+
+  return in_tensor;
+}
+
+// Apply basic CV-CUDA processing to the input frame
+
+class ImageProcessingOp : public holoscan::Operator {
+ public:
+  HOLOSCAN_OPERATOR_FORWARD_ARGS(ImageProcessingOp);
+  ImageProcessingOp() = default;
+
+  void setup(holoscan::OperatorSpec& spec) override {
+    spec.input<holoscan::TensorMap>("input_tensor");
+    spec.output<holoscan::TensorMap>("output_tensor");
+  }
+
+  void initialize() override {
+    HOLOSCAN_LOG_INFO("Converting incoming packet data to Complex Tensor data");
+    holoscan::Operator::initialize();
+  }
+
+  void compute(holoscan::InputContext& op_input, holoscan::OutputContext& op_output,
+               holoscan::ExecutionContext& context) override {
+    // The type of `in_message` is 'holoscan::TensorMap'.
+    auto maybe_tensormap = op_input.receive<holoscan::TensorMap>("input_tensor");
+    if (!maybe_tensormap) { HOLOSCAN_LOG_ERROR("no input tensor found"); }
+    auto in_tensor = validate_and_get_rgb_image(maybe_tensormap.value());
+    const auto& [cv_in_tensor, cv_in_buffer] = holoscan_tensor_to_cvcuda_NHWC(in_tensor);
+
+    // cv_in_tensor will be in NHWC format
+    int num_batch = cv_in_tensor.shape()[0];
+    int image_height = cv_in_tensor.shape()[1];
+    int image_width = cv_in_tensor.shape()[2];
+    int num_channels = cv_in_tensor.shape()[3];
+    if (num_batch > 1) {
+      HOLOSCAN_LOG_ERROR("batch_size > 1 is not supported (HolovizOp needs a single image)");
+    }
+
+    // Create an out_message entity containing a single GXF tensor corresponding to the output.
+    const auto& [out_message, tensor_data_pointer] =
+        create_out_message_with_tensor_like(context.context(), cv_in_tensor);
+
+    // Create a CV-CUDA cv_out_tensor pointing to the same CUDA memory (`tensor_data_pointer`)
+    // as the tensor in `out_message`.
+    // Note: If we allocated the memory in CV-CUDA, it would instead be deallocated once the
+    // CV-CUDA tensor goes out of scope (at the end of this compute call).
+
+    // copy strides from cv_in_buffer
+    nvcv::TensorDataStridedCuda::Buffer cv_out_buffer = cv_in_buffer;
+    cv_out_buffer.basePtr = static_cast<NVCVByte*>(*tensor_data_pointer);
+    nvcv::TensorDataStridedCuda out_data(cv_in_tensor.shape(), cv_in_tensor.dtype(), cv_out_buffer);
+    nvcv::Tensor cv_out_tensor = nvcv::TensorWrapData(out_data);
+
+    // apply the Flip operator
+    cvcuda::Flip flipOp;
+    int32_t flipCode = 0;
+    flipOp(0, cv_in_tensor, cv_out_tensor, flipCode);  // Using default stream (0) here
+
+    // Emit the tensor.
+    op_output.emit(out_message, "output_tensor");
+  }
+};
+
+}  // namespace holoscan::ops
+
+class App : public holoscan::Application {
+ public:
+  void set_datapath(const std::string& path) { datapath = path; }
+
+  void compose() override {
+    using namespace holoscan;
+
+    uint32_t width = 854;
+    uint32_t height = 480;
+    auto source = make_operator<ops::VideoStreamReplayerOp>(
+        "replayer", from_config("replayer"), Arg("directory", datapath));
+
+    auto image_processing = make_operator<ops::ImageProcessingOp>("image_processing");
+
+    const std::shared_ptr<CudaStreamPool> cuda_stream_pool =
+        make_resource<CudaStreamPool>("cuda_stream", 0, 0, 0, 1, 5);
+
+    std::shared_ptr<ops::HolovizOp> visualizer =
+        make_operator<ops::HolovizOp>("holoviz",
+                                      from_config("holoviz"),
+                                      Arg("width") = width,
+                                      Arg("height") = height,
+                                      Arg("cuda_stream_pool") = cuda_stream_pool);
+
+    // Flow definition
+    add_flow(source, image_processing);
+    add_flow(image_processing, visualizer, {{"output_tensor", "receivers"}});
+  }
+
+ private:
+  std::string datapath = "data/endoscopy";
+};
+
+/** Helper function to parse the command line arguments */
+bool parse_arguments(int argc, char** argv, std::string& config_name, std::string& data_path) {
+  static struct option long_options[] = {{"data", required_argument, 0, 'd'}, {0, 0, 0, 0}};
+
+  while (int c = getopt_long(argc, argv, "d", long_options, NULL)) {
+    if (c == -1 || c == '?') break;
+
+    switch (c) {
+      case 'd':
+        data_path = optarg;
+        break;
+      default:
+        std::cout << "Unknown arguments returned: " << c << std::endl;
+        return false;
+    }
+  }
+
+  if (optind < argc) { config_name = argv[optind++]; }
+  return true;
+}
+
+/** Main function */
+int main(int argc, char** argv) {
+  auto app = holoscan::make_application<App>();
+
+  // Parse the arguments
+  std::string data_path = "";
+  std::string config_name = "";
+  if (!parse_arguments(argc, argv, config_name, data_path)) { return 1; }
+
+  if (config_name != "") {
+    app->config(config_name);
+  } else {
+    auto config_path = std::filesystem::canonical(argv[0]).parent_path();
+    config_path += "/cvcuda_basic.yaml";
+    app->config(config_path);
+  }
+  if (data_path != "") app->set_datapath(data_path);
+
+  app->run();
+
+  return 0;
+}

--- a/applications/cvcuda_basic/cpp/metadata.json
+++ b/applications/cvcuda_basic/cpp/metadata.json
@@ -1,0 +1,43 @@
+{
+	"application": {
+		"name": "CV-CUDA: Basic Interoperability",
+		"authors": [
+			{
+				"name": "Holoscan Team",
+				"affiliation": "NVIDIA"
+			}
+		],
+		"language": "C++",
+		"version": "1.0",
+		"changelog": {
+			"1.0": "Initial Release"
+		},
+		"holoscan_sdk": {
+			"minimum_required_version": "0.6.0",
+			"tested_versions": [
+				"0.6.0"
+			]
+		},
+		"platforms": [
+			"amd64",
+			"arm64"
+		],
+		"tags": [
+			"CV-CUDA",
+			"Computer Vision",
+			"CV"
+		],
+		"ranking": 1,
+		"dependencies": {
+			"data": "https://catalog.ngc.nvidia.com/orgs/nvidia/teams/clara-holoscan/resources/holoscan_endoscopy_sample_data",
+			"libraries": [{
+				"name": "cvcuda",
+				"version": "0.3.1-beta"
+			}]
+		},
+		"run": {
+			"command": "<holohub_app_bin>/cvcuda_basic --data <holohub_data_dir>/endoscopy",
+			"workdir": "holohub_bin"
+		}
+	}
+}

--- a/applications/cvcuda_basic/cpp/util.cpp
+++ b/applications/cvcuda_basic/cpp/util.cpp
@@ -1,0 +1,369 @@
+// FMT_S8
+// FMT_S16
+// FMT_S32
+// FMT_U8
+// FMT_U16
+// FMT_U32
+// FMT_F16
+// FMT_F32
+// FMT_F64
+// FMT_C64
+// FMT_C128
+// // also RGBA, BGR and BGRA variants of the below
+// FMT_RGB8    // HWC
+// FMT_RGBf16  // HWC
+// FMT_RGBf32  // HWC
+// FMT_RGB8p   // CHW
+// FMT_RGBf16p // CHW
+// FMT_RGBf32p // CHW
+
+// ImageFormat fmt_from_dtype() {
+
+// }
+
+nvcv::DataType dldatatype_to_nvcvdtype(DLDataType dtype, int num_channels=0) {
+  nvcv::DataType type;
+  uint8_t bits = dtype.bits;
+  uint16_t channels = (num_channels == 0) ? dtype.lanes : num_channels;
+
+  switch (dtype.code) {
+    case kDLInt:
+      switch (bits) {
+        case 8:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_S8
+              break;
+            case 2:
+              type = nvcv::TYPE_2S8
+              break;
+            case 3:
+              type = nvcv::TYPE_3S8
+              break;
+            case 4:
+              type = nvcv::TYPE_4S8
+              break;
+            default:
+              throw std::runtime_error(
+                fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                             dtype.code,
+                             dtype.bits,
+                             channels));
+          }
+          break;
+        case 16:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_S16
+              break;
+            case 2:
+              type = nvcv::TYPE_2S16
+              break;
+            case 3:
+              type = nvcv::TYPE_3S16
+              break;
+            case 4:
+              type = nvcv::TYPE_4S16
+              break;
+            default:
+              throw std::runtime_error(
+                fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                             dtype.code,
+                             dtype.bits,
+                             channels));
+          }
+          break;
+        case 32:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_S32
+              break;
+            case 2:
+              type = nvcv::TYPE_2S32
+              break;
+            case 3:
+              type = nvcv::TYPE_3S32
+              break;
+            case 4:
+              type = nvcv::TYPE_4S32
+              break;
+            default:
+              throw std::runtime_error(
+                fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                             dtype.code,
+                             dtype.bits,
+                             channels));
+          }
+          break;
+        case 64:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_S64
+              break;
+            case 2:
+              type = nvcv::TYPE_2S64
+              break;
+            case 3:
+              type = nvcv::TYPE_3S64
+              break;
+            case 4:
+              type = nvcv::TYPE_4S64
+              break;
+            default:
+              throw std::runtime_error(
+                fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                             dtype.code,
+                             dtype.bits,
+                             channels));
+          }
+          break;
+        default:
+          throw std::runtime_error(
+            fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                         dtype.code,
+                         dtype.bits,
+                         channels));
+      }
+      break;
+    case kDLUInt:
+      switch (bits) {
+        case 8:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_U8
+              break;
+            case 2:
+              type = nvcv::TYPE_2U8
+              break;
+            case 3:
+              type = nvcv::TYPE_3U8
+              break;
+            case 4:
+              type = nvcv::TYPE_4U8
+              break;
+            default:
+              throw std::runtime_error(
+                fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                             dtype.code,
+                             dtype.bits,
+                             channels));
+          }
+          break;
+        case 16:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_U16
+              break;
+            case 2:
+              type = nvcv::TYPE_2U16
+              break;
+            case 3:
+              type = nvcv::TYPE_3U16
+              break;
+            case 4:
+              type = nvcv::TYPE_4U16
+              break;
+            default:
+              throw std::runtime_error(
+                fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                             dtype.code,
+                             dtype.bits,
+                             channels));
+          }
+          break;
+        case 32:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_U32
+              break;
+            case 2:
+              type = nvcv::TYPE_2U32
+              break;
+            case 3:
+              type = nvcv::TYPE_3U32
+              break;
+            case 4:
+              type = nvcv::TYPE_4U32
+              break;
+            default:
+              throw std::runtime_error(
+                fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                             dtype.code,
+                             dtype.bits,
+                             channels));
+          }
+          break;
+        case 64:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_U64
+              break;
+            case 2:
+              type = nvcv::TYPE_2U64
+              break;
+            case 3:
+              type = nvcv::TYPE_3U64
+              break;
+            case 4:
+              type = nvcv::TYPE_4U64
+              break;
+            default:
+              throw std::runtime_error(
+                fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                             dtype.code,
+                             dtype.bits,
+                             channels));
+          }
+          break;
+        default:
+          throw std::runtime_error(
+            fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                         dtype.code,
+                         dtype.bits,
+                         channels));
+      }
+      break;
+    case kDLFloat:
+      switch (bits) {
+        case 16:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_F16
+              break;
+            case 2:
+              type = nvcv::TYPE_2F16
+              break;
+            case 3:
+              type = nvcv::TYPE_3F16
+              break;
+            case 4:
+              type = nvcv::TYPE_4F16
+              break;
+            default:
+              throw std::runtime_error(
+                fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                             dtype.code,
+                             dtype.bits,
+                             channels));
+          }
+          break;
+        case 32:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_F32
+              break;
+            case 2:
+              type = nvcv::TYPE_2F32
+              break;
+            case 3:
+              type = nvcv::TYPE_3F32
+              break;
+            case 4:
+              type = nvcv::TYPE_4F32
+              break;
+            default:
+              throw std::runtime_error(
+                fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                             dtype.code,
+                             dtype.bits,
+                             channels));
+          }
+          break;
+        case 64:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_F64
+              break;
+            case 2:
+              type = nvcv::TYPE_2F64
+              break;
+            case 3:
+              type = nvcv::TYPE_3F64
+              break;
+            case 4:
+              type = nvcv::TYPE_4F64
+              break;
+            default:
+              throw std::runtime_error(
+                fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                             dtype.code,
+                             dtype.bits,
+                             channels));
+          }
+          break;
+        default:
+          throw std::runtime_error(
+            fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                         dtype.code,
+                         dtype.bits,
+                         channels));
+      }
+      break;
+    case kDLComplex:
+      switch (bits) {
+        case 64:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_C64
+              break;
+            case 2:
+              type = nvcv::TYPE_2C64
+              break;
+            case 3:
+              type = nvcv::TYPE_3C64
+              break;
+            case 4:
+              type = nvcv::TYPE_4C64
+              break;
+            default:
+              throw std::runtime_error(
+                fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                             dtype.code,
+                             dtype.bits,
+                             channels));
+          }
+          break;
+        case 128:
+          switch (channels) {
+            case 1:
+              type = nvcv::TYPE_C128
+              break;
+            case 2:
+              type = nvcv::TYPE_2C128
+              break;
+            default:
+              throw std::runtime_error(
+                fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                             dtype.code,
+                             dtype.bits,
+                             channels));
+          }
+          break;
+        default:
+          throw std::runtime_error(
+            fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                         dtype.code,
+                         dtype.bits,
+                         channels));
+      }
+      break;
+    default:
+      throw std::runtime_error(
+        fmt::format("Unsupported DLPack data type (code: {}, bits: {}, channels: {})",
+                     dtype.code,
+                     dtype.bits,
+                     channels));
+  }
+}
+
+
+
+  // nvcv::Tensor::Requirements in_reqs =
+  //     nvcv::Tensor::CalcRequirements(cv_tensor_shape, cv_dtype);
+
+  // // Create a tensor buffer to store the data pointer and pitch bytes for each plane
+  // nvcv::TensorDataStridedCuda in_data(
+  //     nvcv::TensorShape{in_reqs.shape, in_reqs.rank, in_reqs.layout},
+  //     nvcv::DataType{in_reqs.dtype},
+  //     in_buffer);
+

--- a/applications/cvcuda_basic/python/CMakeLists.txt
+++ b/applications/cvcuda_basic/python/CMakeLists.txt
@@ -22,7 +22,7 @@ if(BUILD_TESTING)
   # Add test
   add_test(NAME cvcuda_basic_python_test
            COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/cvcuda_basic.py
-                   --data ${HOLOHUB_DATA_DIR}/endoscopy
+                   --data ${HOLOHUB_DATA_DIR}/endoscopy --count 10
            WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
   set_property(TEST cvcuda_basic_python_test PROPERTY ENVIRONMENT

--- a/applications/cvcuda_basic/python/cvcuda_basic.py
+++ b/applications/cvcuda_basic/python/cvcuda_basic.py
@@ -42,7 +42,6 @@ class ImageProcessingOp(Operator):
     """
 
     def __init__(self, fragment, *args, use_flip_into=False, **kwargs):
-        self.count = 1
         self.cv_out = None
 
         # Need to call the base class constructor last
@@ -55,9 +54,6 @@ class ImageProcessingOp(Operator):
     def compute(self, op_input, op_output, context):
         tensormap = op_input.receive("input_tensor")
         input_tensor = tensormap[""]  # stride (2562, 3, 1)
-
-        print(f"message received (count: {self.count})")
-        self.count += 1
 
         cv_in = nvcv.as_tensor(input_tensor, "HWC")  # Input_tensor is (480, 854, 3)
 
@@ -88,13 +84,14 @@ class MyVideoProcessingApp(Application):
     The HolovizOp displays the processed frames.
     """
 
-    def __init__(self, data):
-        super().__init__()
+    def __init__(self, *args, data, count=0, **kwargs):
+        super().__init__(*args, **kwargs)
 
         if data == "none":
             data = os.path.join(os.environ.get("HOLOSCAN_DATA_PATH", "../data"), "endoscopy")
 
         self.sample_data_path = data
+        self.count = count
 
     def compose(self):
         width = 854
@@ -110,7 +107,7 @@ class MyVideoProcessingApp(Application):
             frame_rate=0,
             repeat=True,
             realtime=True,
-            count=0,
+            count=self.count,
         )
 
         image_processing = ImageProcessingOp(self, name="image_processing")
@@ -136,6 +133,13 @@ if __name__ == "__main__":
         default="none",
         help=("Set the data path"),
     )
+    parser.add_argument(
+        "-c",
+        "--count",
+        type=int,
+        default=0,
+        help=("Number of frames to play (0 = run until user closes the window)"),
+    )
     args = parser.parse_args()
-    app = MyVideoProcessingApp(data=args.data)
+    app = MyVideoProcessingApp(data=args.data, count=args.count)
     app.run()


### PR DESCRIPTION
This MR adds a C++ version of the existing basic CV-CUDA application. Hopefully in future releases of Holoscan/CV-CUDA we can reduce the amount of code needed for tensor interoperability. For Python it was much simpler due to the DLPack protocol support present in the Python wrappers of each library.

Along with adding the C++ app, this MR makes a minor update to Python app for consistently and to limit the test case to 10 frames.

attn: @jjomier