### PR TITLE
Fix common external video source parameters

### DIFF
--- a/applications/deltacast_transmitter/deltacast_transmitter.yaml
+++ b/applications/deltacast_transmitter/deltacast_transmitter.yaml
@@ -39,4 +39,4 @@ videomaster:
   framerate: 25
   board: 0
   output: 0
-  use_rdma: false
+  rdma: false

--- a/applications/deltacast_transmitter/main.cpp
+++ b/applications/deltacast_transmitter/main.cpp
@@ -36,7 +36,7 @@ class App : public holoscan::Application {
     uint32_t width = from_config("videomaster.width").as<uint32_t>();
     uint32_t height = from_config("videomaster.height").as<uint32_t>();
     uint64_t source_block_size = width * height * 4 * 4;
-    uint64_t source_num_blocks = from_config("videomaster.use_rdma").as<bool>() ? 3 : 4;
+    uint64_t source_num_blocks = from_config("videomaster.rdma").as<bool>() ? 3 : 4;
 
     auto source = make_operator<ops::VideoStreamReplayerOp>("replayer", from_config("replayer"),
                                                             Arg("directory", datapath));

--- a/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
+++ b/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
@@ -30,7 +30,7 @@ record_type: "none"  # or "input" if you want to record input video stream, or "
 
 external_source:
   rdma: true
-  overlay: false
+  enable_overlay: false
 
 aja:
   width: 1920

--- a/applications/endoscopy_tool_tracking/cpp/main.cpp
+++ b/applications/endoscopy_tool_tracking/cpp/main.cpp
@@ -56,7 +56,7 @@ class App : public holoscan::Application {
 
     const bool use_rdma = from_config("external_source.rdma").as<bool>();
     const bool overlay_enabled =
-        (source_ != "replayer") && from_config("external_source.overlay").as<bool>();
+        (source_ != "replayer") && from_config("external_source.enable_overlay").as<bool>();
 
     uint32_t width = 0;
     uint32_t height = 0;
@@ -66,7 +66,8 @@ class App : public holoscan::Application {
     if (source_ == "aja") {
       width = from_config("aja.width").as<uint32_t>();
       height = from_config("aja.height").as<uint32_t>();
-      source = make_operator<ops::AJASourceOp>("aja", from_config("aja"));
+      source = make_operator<ops::AJASourceOp>("aja",
+         from_config("aja"), from_config("external_source"));
       source_block_size = width * height * 4 * 4;
       source_num_blocks = use_rdma ? 3 : 4;
     } else if (source_ == "deltacast") {
@@ -76,6 +77,7 @@ class App : public holoscan::Application {
       source = make_operator<ops::VideoMasterSourceOp>(
           "deltacast",
           from_config("deltacast"),
+          from_config("external_source"),
           Arg("pool") = make_resource<UnboundedAllocator>("pool"));
 #endif
       source_block_size = width * height * 4 * 4;

--- a/gxf_extensions/deltacast_videomaster/videomaster_source.cpp
+++ b/gxf_extensions/deltacast_videomaster/videomaster_source.cpp
@@ -32,7 +32,7 @@ VideoMasterSource::VideoMasterSource() : VideoMasterBase(true) {}
 
 gxf_result_t VideoMasterSource::registerInterface(gxf::Registrar *registrar) {
   gxf::Expected<void> result;
-  result &= registrar->parameter(_use_rdma, "use_rdma", "Use RDMA",
+  result &= registrar->parameter(_use_rdma, "rdma", "Use RDMA",
                                   "Specifies whether RDMA should be used.");
   result &= registrar->parameter(_board_index, "board", "Board",
                                   "Index of the Deltacast.TV board to use.");

--- a/gxf_extensions/deltacast_videomaster/videomaster_transmitter.cpp
+++ b/gxf_extensions/deltacast_videomaster/videomaster_transmitter.cpp
@@ -46,7 +46,7 @@ VideoMasterTransmitter::VideoMasterTransmitter() : VideoMasterBase(false) {}
 
 gxf_result_t VideoMasterTransmitter::registerInterface(gxf::Registrar *registrar) {
   gxf::Expected<void> result;
-  result &= registrar->parameter(_use_rdma, "use_rdma", "Use RDMA",
+  result &= registrar->parameter(_use_rdma, "rdma", "Use RDMA",
                                  "Specifies whether RDMA should be used.");
   result &= registrar->parameter(_board_index, "board", "Board",
                                  "Index of the Deltacast.TV board to use.");
@@ -61,7 +61,7 @@ gxf_result_t VideoMasterTransmitter::registerInterface(gxf::Registrar *registrar
                                  "Framerate of the signal to generate.");
   result &= registrar->parameter(_source, "source", "Source", "Source data.");
   result &= registrar->parameter(_pool, "pool", "Pool", "Pool to allocate the buffers.");
-  result &= registrar->parameter(_overlay, "overlay", "Overlay",
+  result &= registrar->parameter(_overlay, "enable_overlay", "Overlay",
                 "Specifies whether the input buffers should be treated as overlay data.", false);
 
   return gxf::ToResultCode(result);

--- a/operators/deltacast_videomaster/videomaster_source.cpp
+++ b/operators/deltacast_videomaster/videomaster_source.cpp
@@ -29,7 +29,7 @@ void VideoMasterSourceOp::setup(OperatorSpec& spec) {
   auto& signal = spec.output<gxf::Entity>("signal");
 
   spec.param(_signal, "signal", "Output", "Output signal.", &signal);
-  spec.param(_use_rdma, "use_rdma", "Use RDMA", "Specifies whether RDMA should be used.", false);
+  spec.param(_use_rdma, "rdma", "Use RDMA", "Specifies whether RDMA should be used.", false);
   spec.param(_board_index, "board", "Board", "Index of the Deltacast.TV board to use.", 0u);
   spec.param(_channel_index, "input", "Input", "Index of the input channel to use.", 0u);
   spec.param(_pool, "pool", "Pool", "Pool to allocate the buffers.");

--- a/operators/deltacast_videomaster/videomaster_transmitter.cpp
+++ b/operators/deltacast_videomaster/videomaster_transmitter.cpp
@@ -28,7 +28,7 @@ namespace holoscan::ops {
 void VideoMasterTransmitterOp::setup(OperatorSpec& spec) {
   auto& source = spec.input<gxf::Entity>("source");
 
-  spec.param(_use_rdma, "use_rdma", "Use RDMA", "Specifies whether RDMA should be used.", false);
+  spec.param(_use_rdma, "rdma", "Use RDMA", "Specifies whether RDMA should be used.", false);
   spec.param(_board_index, "board", "Board", "Index of the Deltacast.TV board to use.", 0u);
   spec.param(_channel_index, "output", "Output", "Index of the output channel to use.", 0u);
   spec.param(_width, "width", "Width", "Width of the video frames to send.", 1920u);
@@ -42,8 +42,8 @@ void VideoMasterTransmitterOp::setup(OperatorSpec& spec) {
   spec.param(_source, "source", "Source", "Source data.", &source);
   spec.param(_pool, "pool", "Pool", "Pool to allocate the buffers.");
   spec.param(_overlay,
-             "overlay",
-             "Overlay",
+             "enable_overlay",
+             "EnableOverlay",
              "Specifies whether the input buffers should be treated as overlay data.",
              false);
 }


### PR DESCRIPTION
The AJA and Deltacast operators share some common parameters but they were not using the same names and were not being forwarded to the operator constructor properly. This change ensures that both operators use parameters with the 'rdma' and 'enable_overlay' names, and then appends the common parameters to the argument list to construct the operator.