### PR TITLE
Respect the `storage_type` argument of the provided GXF `create_out_message_with_tensor` utility

### DIFF
--- a/applications/cvcuda_basic/cpp/gxf_utils.cpp
+++ b/applications/cvcuda_basic/cpp/gxf_utils.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include <cuda_runtime.h>
+#include <fmt/format.h>
 
 #include <memory>
 
@@ -28,16 +29,65 @@ std::pair<nvidia::gxf::Entity, std::shared_ptr<void*>> create_out_message_with_t
     nvidia::gxf::MemoryStorageType storage_type) {
   int element_size = nvidia::gxf::PrimitiveTypeSize(element_type);
   size_t nbytes = shape.size() * element_size;
-  // Create a shared pointer for the CUDA memory with a custom deleter.
-  auto pointer = std::shared_ptr<void*>(new void*, [](void** pointer) {
-    if (pointer != nullptr) {
-      if (*pointer != nullptr) { cudaFree(*pointer); }
-      delete pointer;
-    }
-  });
 
-  // Allocate the CUDA memory (don't need to explicitly initialize)
-  cudaError_t err = cudaMalloc(pointer.get(), nbytes);
+  std::shared_ptr<void*> pointer;
+
+  switch (storage_type) {
+    case nvidia::gxf::MemoryStorageType::kHost: {
+      // Page-locked memory on the host
+
+      // Create a shared pointer for the page-locked memory with a custom deleter.
+      pointer = std::shared_ptr<void*>(new void*, [](void** pointer) {
+        if (pointer != nullptr) {
+          if (*pointer != nullptr) { cudaFreeHost(*pointer); }
+          delete pointer;
+        }
+      });
+
+      // Allocate the page-locked memory (don't need to explicitly initialize)
+      const cudaError_t err = cudaMallocHost(pointer.get(), nbytes);
+      if (err != cudaSuccess) {
+        throw std::runtime_error(
+            fmt::format("Failure in cudaMallocHost. cuda_error: {}, error_str: {}",
+                        cudaGetErrorName(err),
+                        cudaGetErrorString(err)));
+      }
+    } break;
+    case nvidia::gxf::MemoryStorageType::kDevice: {
+      // Create a shared pointer for the CUDA memory with a custom deleter.
+      pointer = std::shared_ptr<void*>(new void*, [](void** pointer) {
+        if (pointer != nullptr) {
+          if (*pointer != nullptr) { cudaFree(*pointer); }
+          delete pointer;
+        }
+      });
+
+      // Allocate the CUDA memory (don't need to explicitly initialize)
+      const cudaError_t err = cudaMalloc(pointer.get(), nbytes);
+      if (err != cudaSuccess) {
+        throw std::runtime_error(fmt::format("Failure in cudaMalloc. cuda_error: {}, error_str: {}",
+                                             cudaGetErrorName(err),
+                                             cudaGetErrorString(err)));
+      }
+    } break;
+    case nvidia::gxf::MemoryStorageType::kSystem: {
+      // system memory (via new/delete)
+
+      // Create a shared pointer for system memory with a custom deleter.
+      pointer = std::shared_ptr<void*>(new void*, [](void** pointer) {
+        if (pointer != nullptr) {
+          if (*pointer != nullptr) { ::operator delete(*pointer); }
+          delete pointer;
+        }
+      });
+
+      // Allocate system memory.
+      *pointer = ::operator new(nbytes);
+    } break;
+    default:
+      throw std::runtime_error("storage_type out of range");
+  }
+
   // Holoscan Tensor doesn't support direct memory allocation.
   // Thus, create an Entity and use GXF tensor to wrap the CUDA memory.
   auto out_message = nvidia::gxf::Entity::New(context);


### PR DESCRIPTION
I noticed that the `create_out_message_with_tensor` utility function provided in the CV-CUDA C++ application was ignoring the provided `storage_type` argument and always allocating a device array. Device tensors are what is wanted for the CV-CUDA application, but the `gxf_utils.hpp` was intended to be general for GXF tensors and so should also support being able to allocate system memory or page-locked host memory as well. That update is made in this PR.

This PR does not modify the behavior of the existing application, just addresses this shortcoming in the provided utility function.
