### PR TITLE
Fix build qcap_source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,10 @@ RUN echo ". /etc/bash_completion.d/holohub_autocomplete" >> /etc/bash.bashrc
 #   performed at docker run time in case users want to use a different BUILD_TYPE
 ARG CMAKE_BUILD_TYPE=Release
 
-
+# Qcap dependency
+RUN apt update \
+    && apt install --no-install-recommends -y \
+        libgstreamer1.0-0 \
+        libgstreamer-plugins-base1.0-0 \
+        libgles2 \
+        libopengl0 \

--- a/dev_container
+++ b/dev_container
@@ -398,6 +398,12 @@ launch() {
     if [ -d /opt/deltacast/videomaster/Include ]; then
         conditional_opt+=" -v /opt/deltacast/videomaster/Include:/usr/local/deltacast/Include"
     fi
+    if [ -d /opt/yuan/qcap/include ]; then
+        conditional_opt+=" -v /opt/yuan/qcap/include:/opt/yuan/qcap/include"
+    fi
+    if [ -d /opt/yuan/qcap/lib ]; then
+        conditional_opt+=" -v /opt/yuan/qcap/lib:/opt/yuan/qcap/lib"
+    fi
 
     # add user in container to group video to access video devices, e.g. /dev/video0
     conditional_opt+=" --group-add video"


### PR DESCRIPTION
Need some modifications to build and run the qcap_source operator.
1. Install depended library in docker for running QCAP SDK.
2. Map /opt/yuan/qcap/include and lib into docker for building qcap_source.
3. Add the define BUILD_WITH_QCAP_SDK to the file, qcap_source.cpp.
    The define BUILD_WITH_QCAP_SDK to control qcap_source has capture function or just a fake operator. 
    Original intent is avoid build breaking for the user who don't have QCAP SDK.