### PR TITLE
Fix error when giving local SDK root

### DIFF
--- a/dev_container
+++ b/dev_container
@@ -378,6 +378,7 @@ launch() {
         if [ "$arg" = "--local_sdk_root" ]; then
            local_sdk_root="${ARGS[i+1]}"
            shift
+           shift
         fi
         if [ "$arg" = "--ssh_x11" ]; then
            ssh_x11=1


### PR DESCRIPTION
With the addition of  `"$@"` to the end of the `run_command` in `launch()`  (in `dev_container.sh`), giving a local SDK root with the argument `--local_sdk_root` fails. This was because one `skip` was missing when parsing the input argument. This PR fixes that issue.