### PR TITLE
Added TURN server support to webRTC server example app

### DIFF
--- a/applications/webrtc_video_server/webrtc_server.py
+++ b/applications/webrtc_video_server/webrtc_server.py
@@ -29,8 +29,57 @@ from operators.webrtc_server.webrtc_server_op import WebRTCServerOp
 ROOT = os.path.dirname(__file__)
 
 
+def parse_ice_strings(ice_server_strings):
+    """
+    Convert a list of ICE server strings into a list of dictionaries of the iceServers format.
+    The iceServers format is from https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection#iceservers
+
+    Parameters:
+    - ice_server_strings (list): A list of ICE server strings. Each string is expected to be
+      in the format 'protocol:host:port[username:credential]' where '[username:credential]' is needed for TURN server.
+
+
+    Returns:
+    list: A list of dictionaries, where each dictionary represents an ICE server.
+          Each dictionary has at least a 'urls' key, and may include 'username' and 'credential' keys.
+
+    Example:
+    If input_list is ['turn:10.0.0.131:3478[admin:admin]', 'stun:stun.l.google.com:19302'],
+    the output will be [
+        {
+            'urls': 'turn:10.0.0.131:3478',
+            'username': 'admin',
+            'credential': 'admin',
+        },
+        {
+            'urls': 'stun:stun.l.google.com:19302',
+        },
+    ]
+    """
+    ice_server_list = []
+    for ice_string in ice_server_strings:
+        if "[" in ice_string:
+            parts = ice_string.split("[")
+            url = parts[0]
+            creds = parts[1].split(":")
+            if len(creds) != 2:
+                raise ValueError(
+                    "Expected ice-server with credentials to be in form of turn:<ip>:<port>[<username>:<password>] "
+                )
+            username = creds[0]
+            password = creds[1][:-1]
+            ice_server = {"urls": url, "username": username, "credential": password}
+        else:
+            ice_server = {"urls": ice_string}
+        ice_server_list.append(ice_server)
+    logging.debug(f"Parsed ice strings into {ice_server_list}")
+    return ice_server_list
+
+
 class WebAppThread(Thread):
-    def __init__(self, webrtc_server_op, host, port, cert_file=None, key_file=None):
+    def __init__(
+        self, webrtc_server_op, host, port, cert_file=None, key_file=None, ice_server=None
+    ):
         super().__init__()
         self._webrtc_server_op = webrtc_server_op
         self._host = host
@@ -42,11 +91,16 @@ class WebAppThread(Thread):
         else:
             self._ssl_context = None
 
+        self._ice_servers = []
+        if ice_server:
+            self._ice_servers = parse_ice_strings(ice_server)
+
         app = web.Application()
         app.on_shutdown.append(self._on_shutdown)
         app.router.add_get("/", self._index)
         app.router.add_get("/client.js", self._javascript)
         app.router.add_post("/offer", self._offer)
+        app.router.add_get("/iceServers", self._get_ice_servers)
 
         self._runner = web.AppRunner(app)
 
@@ -60,6 +114,10 @@ class WebAppThread(Thread):
     async def _javascript(self, request):
         content = open(os.path.join(ROOT, "client.js"), "r").read()
         return web.Response(content_type="application/javascript", text=content)
+
+    async def _get_ice_servers(self, request):
+        logging.info(f"Available ice servers are {json.dumps(self._ice_servers)}")
+        return web.Response(content_type="application/json", text=json.dumps(self._ice_servers))
 
     async def _offer(self, request):
         params = await request.json()
@@ -126,6 +184,7 @@ class WebRTCServerApp(holoscan.core.Application):
             self._cmdline_args.port,
             self._cmdline_args.cert_file,
             self._cmdline_args.key_file,
+            self._cmdline_args.ice_server,
         )
         self._web_app_thread.start()
 
@@ -139,6 +198,12 @@ if __name__ == "__main__":
         "--port", type=int, default=8080, help="Port for HTTP server (default: 8080)"
     )
     parser.add_argument("--verbose", "-v", action="store_true")
+    parser.add_argument(
+        "--ice-server",
+        action="append",
+        help="ICE server config in the form of `turn:<ip>:<port>[<username>:<password>]` or `stun:<ip>:<port>`. "
+        "This option can be specified multiple times to add multiple ICE servers.",
+    )
     cmdline_args = parser.parse_args()
 
     if cmdline_args.verbose:


### PR DESCRIPTION
This PR contains the minimum changes needed for the webRTC video server example application to support TURN server configurations, which enables Kubernetes deployment & Docker deployment of the application without host networking.

Here are the changes:
1. The `WebRTCServerApp`  is modified to support a flag `[--ice-server ICE_SERVER]` which can be specified multiple times if the user need to pass in more than one TURN/STUN server.

2. An `iceServer` REST endpoint is added to the `WebAppThread` so that javascript can obtain the list of specified ice servers before creating the RTCPeerConnection.
3. `client.js` has modifications to fetch the iceServers
4. The `negotiate()` function in `client.js` has gone through a slight re-ordering to align with webRTC and ICE protocol. (See details below) 
5. README has also been updated with TURN server instructions.

**Note on reordering of `negotiate()` function:**

Before this PR, the call order inside negotiate function is: createOffer -> setLocalDescription -> waitForICEGathering -> sendOffer -> receiveAnswer -> setRemoteDescription.

The way webRTC works is that the two peers must first exchange SDP via the signaling server before exchanging ICE candidates needed for data to flow through. In our case the two peers are the client.js application and webRTC Server operator, and the signalling server is the webAppServer which is able to pass on messages between the two peers.  (More on webRTC signalling can be seen https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling#signaling_transaction_flow)

Therefore, the proper call order following the webRTC protocol is: createOffer -> setLocalDescription ->  sendOffer -> receiveAnswer -> setRemoteDescription -> waitForICEGathering, which this PR hopes to address.

This change of ordering in call stack leads to a a few seconds of speed up for the latency from "clicking start" to seeing the frame. The speed up was most prominent in Firefox when accessed from remote machine. 

| Browser | Accessed via | Avg Latency Before Reorder (s) | Avg Latency Before Reorder (s) | Speed up (s)
| ------------- | ------------- | ------------- | ------------- |------------- |
| Firefox | localhost  | 6.97 | 6.0 | 0.97|
| Firefox | remote machine | 17.47  | 5.59 | 11.88|
| Chrome | localhost  | 6.76 |  5.62 | 1.14|
| Chrome | remote machine | 6.60 |  5.56 | 1.04|


Raw data, collected over 5 trials.

| Browser | Accessed via  | 5 Trials Before Reorder (s)  | 5 Trials After Reorder(s)  |
| ------------- | ------------- | ------------- | ------------- |
| Firefox | localhost  |  7.05, 7.30, 6.81, 6.78, 6.91 | 5.80, 7.41, 5.47, 5.68, 5.63 |
| Firefox | remote machine | 17.84, 16.99, 16.93, 17.77,  17.80 | 5.52, 5.54, 5.56,  5.64,  5.67|
| Chrome | localhost  | 6.80, 6.83, 6.68, 6.68,  6.80 | 5.65, 5.62,  5.65, 5.54,  5.62 |
| Chrome | remote machine | 5.78, 6.79, 6.73, 6.81, 6.88  |  5.52, 5.56, 5.63, 5.57, 5.54 |
