### PR TITLE
Use PeopleNet ONNX model

### DIFF
--- a/applications/tao_peoplenet/README.md
+++ b/applications/tao_peoplenet/README.md
@@ -1,6 +1,11 @@
 # TAO PeopleNet Detection Model on V4L2 Video Stream
 
-Uses the [TAO PeopleNet available on NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tao/models/peoplenet) to detect faces and people in a V4L2 supported video stream. HoloViz is used to draw bounding boxes around the detections.
+Use the TAO PeopleNet available on [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tao/models/peoplenet) to detect faces and people in a V4L2 supported video stream. HoloViz is used to draw bounding boxes around the detections.
+
+**Prerequisite**: Download the PeopleNet ONNX model from the NGC website:
+```sh
+wget --content-disposition 'https://api.ngc.nvidia.com/v2/models/org/nvidia/team/tao/peoplenet/pruned_quantized_decrypted_v2.3.3/files?redirect=true&path=resnet34_peoplenet_int8.onnx' -O applications/tao_peoplenet/resnet34_peoplenet_int8.onnx
+```
 
 ## Requirements
 
@@ -20,41 +25,9 @@ If you do not have permissions to open the video device, do:
  sudo usermod -aG video $USER
 ```
 
-### PeopleNet Model
-
-[Download the model from NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tao/models/peoplenet) and put in a folder `DATA_DIRECTORY`.
-
-### TensorRT Conversion
-
-[Download the TAO Converter app](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tao/resources/tao-converter) **for your platform** and convert the PeopleNet model to a TensorRT engine. 
-
-If you download the `tao-converter` to the folder `DATA_DIRECTORY` the conversion can be run by:
-```sh
-cd <DATA_DIRECTORY>
-chmod +x tao-converter
-./tao-converter \
-    -k tlt_encode \
-    -d 3,544,960 \
-    -w 40960M \
-    -t fp16 \
-    -o output_cov/Sigmoid,output_bbox/BiasAdd \
-    -e engine.trt \
-    model.etlt
-```
-This command will generate the TensorRT engine `engine.trt`, which is given as input to the app.
-
 ## Run Instructions
 
-First, set the environment variable to the absolute path of the folder containing the location of the TensorRT engine:
-```sh
-export HOLOSCAN_DATA_PATH=<DATA_DIRECTORY>
-```
-
-Next, build with:
-```sh
-./run build tao_peoplenet
-```
-then run with:
+Run with:
 ```sh
 ./run launch tao_peoplenet
 ```

--- a/applications/tao_peoplenet/metadata.json
+++ b/applications/tao_peoplenet/metadata.json
@@ -31,7 +31,7 @@
 			"model": "https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tao/models/peoplenet"
 		},
 		"run": {
-			"command": "python3 ../applications/tao_peoplenet/tao_peoplenet.py --engine ${HOLOSCAN_DATA_PATH}/engine.trt",
+			"command": "python3 ../applications/tao_peoplenet/tao_peoplenet.py",
 			"workdir": "holohub_bin"
 		}
 	}

--- a/applications/tao_peoplenet/tao_peoplenet.py
+++ b/applications/tao_peoplenet/tao_peoplenet.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import os
-from argparse import ArgumentParser
 
 import cupy as cp
 import holoscan as hs
@@ -80,8 +79,8 @@ class PostprocessorOp(Operator):
         in_message = op_input.receive("in")
 
         # Convert input to cupy array
-        boxes = cp.asarray(in_message.get("boxes"))
-        scores = cp.asarray(in_message.get("scores"))
+        boxes = cp.asarray(in_message.get("boxes"))[0, ...]
+        scores = cp.asarray(in_message.get("scores"))[0, ...]
 
         # PeopleNet has three classes:
         # 0. Person
@@ -222,15 +221,13 @@ class PostprocessorOp(Operator):
 
 
 class FaceDetectApp(Application):
-    def __init__(self, engine=None):
+    def __init__(self):
         """Initialize the face detection application"""
 
         super().__init__()
 
         # set name
         self.name = "Face Detection App"
-        # set engine
-        self.engine = engine
 
     def compose(self):
         pool = UnboundedAllocator(self, name="pool")
@@ -257,8 +254,10 @@ class FaceDetectApp(Application):
         )
 
         inference_args = self.kwargs("inference")
-        if self.engine is not None:
-            inference_args["model_path_map"] = {"face_detect": self.engine}
+        inference_args["model_path_map"] = {
+            "face_detect": os.path.join(os.path.dirname(__file__),
+            "resnet34_peoplenet_int8.onnx")
+        }
 
         device_map = dict()
         if "device_map" in inference_args.keys():
@@ -295,25 +294,8 @@ class FaceDetectApp(Application):
 
 
 if __name__ == "__main__":
-    # Parse args
-    parser = ArgumentParser(description="TAO PeopleNet Detection Model on Video Stream.")
-    parser.add_argument(
-        "-e",
-        "--engine",
-        default=None,
-        type=str,
-        help=("Absolute path to TensorRT engine."),
-    )
-    args = parser.parse_args()
-
-    # Sanity check
-    if args.engine is not None:
-        args.engine = os.path.expandvars(args.engine)
-        if not os.path.isfile(args.engine):
-            raise ValueError(f"Engine file {args.engine} does not exist!")
-
     config_file = os.path.join(os.path.dirname(__file__), "tao_peoplenet.yaml")
 
-    app = FaceDetectApp(engine=args.engine)
+    app = FaceDetectApp()
     app.config(config_file)
     app.run()

--- a/applications/tao_peoplenet/tao_peoplenet.yaml
+++ b/applications/tao_peoplenet/tao_peoplenet.yaml
@@ -30,11 +30,11 @@ inference:
   pre_processor_map:
     "face_detect": ["preprocessed"]
   inference_map:
-    "face_detect": ["boxes", "scores"]
+    "face_detect": ["scores", "boxes"]
   device_map:
     "face_detect": "0"
   input_on_cuda: true
-  is_engine_path: true
+  is_engine_path: false
 
 postprocessor:
   iou_threshold: 0.15


### PR DESCRIPTION
TAO models are now available in ONNX format. This PR makes the PeopleNet app use this ONNX model instead of the `.etlt` format. This means that it is no longer necessary to download and run the TAO converter app.