### PR TITLE
update the CV-CUDA demo to use CV-CUDA v0.5.0-beta

### DIFF
--- a/applications/cvcuda_basic/Dockerfile
+++ b/applications/cvcuda_basic/Dockerfile
@@ -29,8 +29,8 @@ ARG GPU_TYPE
 FROM ${BASE_IMAGE} as cvcuda-downloader
 
 ARG GCC_VERSION=11
-ARG CVCUDA_TAG=v0.4.0-beta
-ARG CVCUDA_RELEASE_BRANCH=release_v0.4.x
+ARG CVCUDA_TAG=v0.5.0-beta
+ARG CVCUDA_RELEASE_BRANCH=feat/milesp/release_v0.5.0-beta3
 ARG DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /opt/nvidia
@@ -43,7 +43,7 @@ RUN apt update \
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y
 RUN apt install -y gcc-${GCC_VERSION} g++-${GCC_VERSION}
 
-# download patch for building CV-CUDA with CUDA 11.6
+# download patch for building CV-CUDA with CUDA 11.6 (works for both CV-CUDA 0.4-beta and 0.5-beta)
 RUN curl -S -L -o cvcuda_cuda11_6.patch  "https://gist.githubusercontent.com/grlee77/ba5d1449ae37ff2e13c7ee93710fe482/raw/f335c08d00fb6e6efeb94e99889fd15957f01d47/cvcuda_cuda11_6.patch"
 
 # download and patch CV-CUDA

--- a/applications/cvcuda_basic/python/cvcuda_basic.py
+++ b/applications/cvcuda_basic/python/cvcuda_basic.py
@@ -18,12 +18,10 @@ limitations under the License.
 import os
 from argparse import ArgumentParser
 
+import cvcuda
+import nvcv
 from holoscan.core import Application, Operator, OperatorSpec
 from holoscan.operators import HolovizOp, VideoStreamReplayerOp
-
-# currently must import cvcuda after holoscan
-import cvcuda  # isort:skip
-import nvcv  # isort:skip
 
 
 # Define custom Operators for use in the demo


### PR DESCRIPTION
The latest beta of CV-CUDA resolved an issue where it was required to import `cvcuda` after `holoscan`. After updating the version in the Docker container, we can restore imports to the order preferred by `isort`.