### PR TITLE
[CVCUDA/Holoscan Interop] Set pointer to null after freeing them

### DIFF
--- a/operators/cvcuda_holoscan_interop/gxf_utils.hpp
+++ b/operators/cvcuda_holoscan_interop/gxf_utils.hpp
@@ -42,7 +42,7 @@ inline std::shared_ptr<void*> get_custom_shared_ptr(
     if (pointer != nullptr) {
       if (*pointer != nullptr) {
         cudaFree(*pointer);
-        pointer = nullptr;
+        *pointer = nullptr;
       }
       delete pointer;
       pointer = nullptr;

--- a/operators/cvcuda_holoscan_interop/gxf_utils.hpp
+++ b/operators/cvcuda_holoscan_interop/gxf_utils.hpp
@@ -40,8 +40,12 @@ inline std::shared_ptr<void*> get_custom_shared_ptr(
 
   std::shared_ptr<void*> pointer(new void*(ptr), [](void** pointer) {
     if (pointer != nullptr) {
-      if (*pointer != nullptr) { cudaFree(*pointer); }
+      if (*pointer != nullptr) {
+        cudaFree(*pointer);
+        pointer = nullptr;
+      }
       delete pointer;
+      pointer = nullptr;
     }
   });
   return pointer;


### PR DESCRIPTION
As Stroustrup mentions, `delete`ing/`free`ing a pointer would not necessarily set it to null. It is good idea to set such  a pointer to null.