### PR TITLE
Fixing issue with project name for Prohawk

### DIFF
--- a/applications/prohawk_video_replayer/CMakeLists.txt
+++ b/applications/prohawk_video_replayer/CMakeLists.txt
@@ -14,6 +14,6 @@
 # limitations under the License.
 
 cmake_minimum_required(VERSION 3.20)
-project(prohawk_video_replayer LANGUAGES NONE)
+project(prohawk_video_replayer_apps LANGUAGES NONE)
 
 add_subdirectory(cpp)


### PR DESCRIPTION
Since the addition of Python, the top level CMakeLists.txt have language disabled but the same name as the cpp, which causes CMake not to find a compiler.