### PR TITLE
Lint: Add missing `metadata.json`

### DIFF
--- a/operators/cvcuda_holoscan_interop/metadata.json
+++ b/operators/cvcuda_holoscan_interop/metadata.json
@@ -1,0 +1,39 @@
+{
+    "operator": {
+        "name": "cvcuda_holoscan_interop",
+        "authors": [
+            {
+                "name": "Holoscan Team",
+                "affiliation": "NVIDIA"
+            }
+        ],
+        "language": "C++",
+        "version": "1.0",
+        "changelog": {
+            "1.0": "Initial Release"
+        },
+        "holoscan_sdk": {
+            "minimum_required_version": "0.6.0",
+            "tested_versions": [
+                "0.6.0"
+            ]
+        },
+        "platforms": [
+            "amd64",
+            "arm64"
+        ],
+        "tags": [
+            "CV-CUDA",
+            "Computer Vision",
+            "CV"
+        ],
+        "ranking": 1,
+        "dependencies": {
+            "data": "https://catalog.ngc.nvidia.com/orgs/nvidia/teams/clara-holoscan/resources/holoscan_endoscopy_sample_data",
+            "libraries": [{
+                "name": "cvcuda",
+                "version": "0.3.1-beta"
+            }]
+        }
+    }
+}


### PR DESCRIPTION
Adds missing `metadata.json` file for CVCUDA-Holoscan operators to resolve linting workflow failures.

CVCUDA-Holoscan operators were previously migrated from the "CV-CUDA: Basic Interoperability" application in 46c6bdd.