### PR TITLE
Volume_Rendering_XR: Ignore third party files

### DIFF
--- a/applications/volume_rendering_xr/.gitignore
+++ b/applications/volume_rendering_xr/.gitignore
@@ -1,0 +1,2 @@
+thirdparty/magicleap/
+


### PR DESCRIPTION
Small fixup adding `.gitignore` for `volume_rendering_xr` application to prevent Magic Leap third party sources fetched with the `thirdparty/magicleap.sh` script from being added to git history.

Setting up the `volume_rendering_xr` app with the command `./thirdparty/magicleap.sh` adds `windrunner` and `ml_remove_viewer` sources to the `applications/volume_rendering_xr/3rdparty/magicleap` subdirectory.