### PR TITLE
Add pre-commit hook to summarize subprojects

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+python3 ./utilities/summarize_metadata.py -q --markdown ./PROJECTS.md
+git add ./PROJECTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,20 +45,26 @@ We recommend that new developers review GitHub's [starting documentation](https:
 
 1. Developers must first [fork](https://help.github.com/en/articles/fork-a-repo) the [upstream](https://github.com/nvidia-holoscan/holohub) HoloHub repository.
 
-2. Git clone the forked repository and push changes to the personal fork.
+2. Run the commands below to clone the forked repository and set up [developer hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) with Git.
 
 ```bash
-git clone https://github.com/YOUR_USERNAME/YOUR_FORK.git HoloHub
+git clone https://github.com/<YOUR_USERNAME>/holohub.git HoloHub
+cd HoloHub
+git config --local core.hookspath .githooks && sudo chmod u+x ./githooks/pre-commit
+```
+3. Develop, commit your changes, and push to your cloned repository.
+
+```
 # Checkout the targeted branch and commit changes
 # Push the commits to a branch on the fork (remote).
 git push -u origin <local-branch>:<remote-branch>
 ```
 
-3. Once the code changes are staged on the fork and ready for review, please [submit](https://help.github.com/en/articles/creating-a-pull-request) a [Pull Request](https://help.github.com/en/articles/about-pull-requests) (PR) to merge the changes from a branch of the fork into a selected branch of upstream.
+4. Once the code changes are staged on the fork and ready for review, please [submit](https://help.github.com/en/articles/creating-a-pull-request) a [Pull Request](https://help.github.com/en/articles/about-pull-requests) (PR) to merge the changes from a branch of the fork into a selected branch of upstream.
   * Exercise caution when selecting the source and target branches for the PR.
   * Creation of a PR creation kicks off the [code review](#preparing-your-submission) process.
 
-4. HoloHub maintainers will review the PR and accept the proposal if changes meet HoloHub standards.
+5. HoloHub maintainers will review the PR and accept the proposal if changes meet HoloHub standards.
 
 Thanks in advance for your patience as we review your contributions. We do appreciate them!
 

--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -1,0 +1,53 @@
+|    | name                                                         | project_type   | platforms          | language   |   ranking | holoscan_sdk.tested_versions   |
+|---:|:-------------------------------------------------------------|:---------------|:-------------------|:-----------|----------:|:-------------------------------|
+|  0 | Basic PDW Pipeline                                           | application    | ['amd64', 'arm64'] | C++        |         4 | ['0.5.0']                      |
+|  1 | Colonoscopy segmentation                                     | application    | ['amd64', 'arm64'] | Python     |         1 | ['0.5.0']                      |
+|  2 | Endoscopy Depth Estimation                                   | application    | ['amd64', 'arm64'] | Python     |         2 | ['0.6.0']                      |
+|  3 | Endoscopy Out of Body Detection Pipeline in C++              | application    | ['amd64', 'arm64'] | C++        |         1 | ['0.5.0']                      |
+|  4 | Endoscopy Tool Segmentation from MONAI Model Zoo Application | application    | ['amd64', 'arm64'] | Python     |         2 | ['0.6.0']                      |
+|  5 | FM-ASR                                                       | application    | ['amd64']          | Python     |         3 | ['0.4.1', '0.5.0']             |
+|  6 | HoloChat-local                                               | application    | ['amd64', 'arm64'] | Python     |         4 | ['0.6.0']                      |
+|  7 | Hyperspectral image segmentation                             | application    | ['amd64', 'arm64'] | Python     |         2 | ['0.6.0']                      |
+|  8 | Medical Image viewer in XR                                   | application    | ['amd64', 'arm64'] | C++        |         2 | ['0.6.0']                      |
+|  9 | Object detection using frcnn based pytorch model in C++      | application    | ['amd64', 'arm64'] | C++        |         1 | ['0.6.0']                      |
+| 10 | Power Spectral Density with cuNumeric                        | application    | ['amd64']          | Python     |         2 | ['0.5.0']                      |
+| 11 | Qt Video Replayer                                            | application    | ['amd64', 'arm64'] | C++        |         1 | ['0.6.0']                      |
+| 12 | Riva ASR to local-LLM                                        | application    | ['amd64', 'arm64'] | Python     |         4 | ['0.6.0']                      |
+| 13 | SSD Detection Application                                    | application    | ['amd64', 'arm64'] | Python     |         2 | ['0.6.0']                      |
+| 14 | Software Defined Radio FM Demodulation                       | application    | ['amd64']          | Python     |         2 | ['0.4.0']                      |
+| 15 | Speech-to-text + Large Language Model                        | application    | ['amd64']          | Python     |         2 | ['0.5.0']                      |
+| 16 | Streaming Synthetic Aperture Radar                           | application    | ['amd64', 'arm64'] | Python     |         4 | ['0.5.0']                      |
+| 17 | TAO PeopleNet Detection Model on Video Stream                | application    | ['amd64', 'arm64'] | Python     |         2 | ['0.6.0']                      |
+| 18 | Videomaster transmitter example                              | application    | ['amd64', 'arm64'] | C++        |         2 | ['0.5.0']                      |
+| 19 | Volume Rendering                                             | application    | ['amd64', 'arm64'] | C++        |         1 | ['0.6.0']                      |
+| 20 | WebRTC Holoviz Server                                        | application    | ['amd64', 'arm64'] | Python     |         1 | ['0.6.0']                      |
+| 21 | WebRTC Video Client                                          | application    | ['amd64', 'arm64'] | Python     |         1 | ['0.6.0']                      |
+| 22 | WebRTC Video Server                                          | application    | ['amd64', 'arm64'] | Python     |         1 | ['0.6.0']                      |
+| 23 | Yolo Detection Application                                   | application    | ['amd64', 'arm64'] | Python     |         2 | ['0.6.0']                      |
+| 24 | cuda_quantum                                                 | application    | ['amd64', 'arm64'] | Python     |         4 | ['0.6.0']                      |
+| 25 | emergent_source                                              | gxf_extension  | ['amd64', 'arm64'] | nan        |         1 | nan                            |
+| 26 | lstm_tensor_rt_inference                                     | gxf_extension  | ['amd64', 'arm64'] | nan        |         1 | nan                            |
+| 27 | videomaster                                                  | gxf_extension  | ['amd64', 'arm64'] | nan        |         2 | nan                            |
+| 28 | yuan_qcap                                                    | gxf_extension  | ['amd64', 'arm64'] | nan        |         2 | nan                            |
+| 29 | XrFrameOp                                                    | operator       | ['amd64', 'arm64'] | C++        |         2 | ['0.6.0']                      |
+| 30 | XrTransformOp                                                | operator       | ['amd64', 'arm64'] | C++        |         2 | ['0.6.0']                      |
+| 31 | advanced_network                                             | operator       | ['amd64', 'arm64'] | nan        |         1 | ['0.6.0']                      |
+| 32 | basic_network                                                | operator       | ['amd64', 'arm64'] | nan        |         1 | ['0.6.0']                      |
+| 33 | cvcuda_holoscan_interop                                      | operator       | ['amd64', 'arm64'] | C++        |         1 | ['0.6.0']                      |
+| 34 | emergent_source                                              | operator       | ['amd64', 'arm64'] | nan        |         1 | ['0.5.0']                      |
+| 35 | lstm_tensor_rt_inference                                     | operator       | ['amd64', 'arm64'] | nan        |         1 | ['0.5.0']                      |
+| 36 | npp_filter                                                   | operator       | ['amd64', 'arm64'] | C++        |         1 | ['0.6.0']                      |
+| 37 | openigtlink                                                  | operator       | ['amd64', 'arm64'] | C++        |         2 | ['1.0.3']                      |
+| 38 | prohawk_video_processing                                     | operator       | ['arm64']          | C++        |         4 | ['0.5.1', '0.6.0']             |
+| 39 | qt_video                                                     | operator       | ['amd64', 'arm64'] | C++        |         1 | ['0.6.0']                      |
+| 40 | tensor_to_video_buffer                                       | operator       | ['amd64', 'arm64'] | nan        |         1 | ['0.5.0']                      |
+| 41 | tool_tracking_postprocessor                                  | operator       | ['amd64', 'arm64'] | nan        |         1 | ['0.5.0']                      |
+| 42 | video_read_bitstream                                         | operator       | ['amd64', 'arm64'] | nan        |         1 | ['0.5.0']                      |
+| 43 | video_write_bitstream                                        | operator       | ['amd64', 'arm64'] | nan        |         1 | ['0.5.0']                      |
+| 44 | videomaster                                                  | operator       | ['amd64', 'arm64'] | nan        |         2 | ['0.5.0']                      |
+| 45 | visualizer_icardio                                           | operator       | ['amd64', 'arm64'] | nan        |         1 | ['0.5.0']                      |
+| 46 | volume_loader                                                | operator       | ['amd64', 'arm64'] | C++        |         1 | ['0.6.0']                      |
+| 47 | volume_renderer                                              | operator       | ['amd64', 'arm64'] | C++        |         1 | ['0.6.0']                      |
+| 48 | webrtc_client                                                | operator       | ['amd64', 'arm64'] | nan        |         1 | ['0.6.0']                      |
+| 49 | webrtc_server                                                | operator       | ['amd64', 'arm64'] | nan        |         1 | ['0.6.0']                      |
+| 50 | yuan_qcap                                                    | operator       | ['amd64', 'arm64'] | nan        |         2 | ['0.5.0']                      |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The following directories make up the core of HoloHub:
   reusable Holoscan modules.
 - Tutorials: Visit [`tutorials`](./tutorials/) for extended walkthroughs and tips for the Holoscan platform.
 
+View a full list of available HoloHub projects in our [summary table](./PROJECTS.md) or on [GitHub Pages](https://nvidia-holoscan.github.io/holohub/).
+
 Visit the [Holoscan SDK User Guide](https://docs.nvidia.com/holoscan/sdk-user-guide/overview.html) to learn more about the NVIDIA Holoscan AI sensor processing platform.
 
 # Prerequisites


### PR DESCRIPTION
Changes:
- Adds `PROJECTS.md` containing a markdown table of existing HoloHub
  projects and high-level metadata details such as supported platform
  and tested Holoscan versions;
- Adds pre-commit hook to automatically run the HoloHub summary utility
  and commit any updates to `PROJECTS.md` with each commit.
- References `PROJECTS.md` and GitHub Pages in README