### PR TITLE
Launch: Append to PYTHONPATH instead of replacing

### DIFF
--- a/run
+++ b/run
@@ -691,12 +691,14 @@ for k, v in obj["application"]["run"].items():
       workdir="cd ${holohub_build_dir}"
    fi
 
-   local environment="export PYTHONPATH=${holoscan_sdk_install}/../../../python/lib:${holohub_build_dir}/python/lib:${SCRIPT_DIR}"
+   local environment="export PYTHONPATH=\${PYTHONPATH}:${holoscan_sdk_install}/../../../python/lib:${holohub_build_dir}/python/lib:${SCRIPT_DIR}"
+   local reset_environment="export PYTHONPATH=${PYTHONPATH}"
 
    # Run the command
    run_command $environment
    run_command $workdir
    run_command $command $extra_args
+   run_command $reset_environment
 }
 
 #===========================================================================================


### PR DESCRIPTION
Appends launch PYTHONPATH to the environment value instead of replacing the value of PYTHONPATH.

This intends to address the scenario where a custom Dockerfile provides a PYTHONPATH to reference Python libraries in the container, but then `./run launch` cannot be used because it overwrites PYTHONPATH.