### PR TITLE
Doc: Add README link to GitHub Pages landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 HoloHub is a central repository for the NVIDIA Holoscan AI sensor processing community to share apps and extensions. We invite users and developers of extensions and applications for the Holoscan Platform to reuse and contribute components and sample applications.
 
+Visit the [HoloHub landing page](https://nvidia-holoscan.github.io/holohub/) for details on available HoloHub projects.
+
 # Table of Contents
 - [Overview](#overview)
 - [Prerequisites](#prerequisites)


### PR DESCRIPTION
Link to the HoloHub landing page deployment in the README description.