### PR TITLE
QtVideoOp: directly include the GXF header needed for CudaStreamId

### DIFF
--- a/operators/qt_video/qt_video_op.cpp
+++ b/operators/qt_video/qt_video_op.cpp
@@ -17,6 +17,7 @@
 
 #include "qt_video_op.hpp"
 
+#include <gxf/cuda/cuda_stream_id.hpp>
 #include <holoscan/holoscan.hpp>
 
 #include "qt_holoscan_video.hpp"


### PR DESCRIPTION
This includes the GXF header needed for `nvidia::gxf::CudaStreamId` instead of relying on Holoscan to indirectly include it.