### PR TITLE
Fix bug in Holoscan 2.0 code path of TensorToVideoBufferOp

### DIFF
--- a/applications/h264/h264_endoscopy_tool_tracking/README.md
+++ b/applications/h264/h264_endoscopy_tool_tracking/README.md
@@ -36,7 +36,7 @@ Once inside Holohub dev container, run below command from a top level Holohub
 directory.
 
 ```bash
-./run build h264/endoscopy_tool_tracking
+./run build h264_endoscopy_tool_tracking
 ```
 
 ## Running the application
@@ -44,13 +44,13 @@ directory.
 * Running the application from the top level Holohub directory
 
 ```bash
-./run launch h264/endoscopy_tool_tracking
+./run launch h264_endoscopy_tool_tracking
 ```
 
 * Running the application `h264_endoscopy_tool_tracking` from the build directory.
 
 ```bash
-cd <build_dir>/applications/h264/endoscopy_tool_tracking/ \
+cd <build_dir>/applications/h264/h264_endoscopy_tool_tracking/ \
   && ./h264_endoscopy_tool_tracking --data <HOLOHUB_DATA_DIR>/endoscopy
 ```
 

--- a/applications/h264/h264_video_decode/README.md
+++ b/applications/h264/h264_video_decode/README.md
@@ -33,7 +33,7 @@ Once inside Holohub dev container, run below command from a top level Holohub
 directory.
 
 ```bash
-./run build h264/video_decode
+./run build h264_video_decode
 ```
 
 ## Running the application
@@ -41,12 +41,12 @@ directory.
 * Running the application from the top level Holohub directory
 
 ```bash
-./run launch h264/video_decode
+./run launch h264_video_decode
 ```
 
 * Running the application `h264_video_decode` from the build directory.
 
 ```bash
-cd <build_dir>/applications/h264/video_decode/ \
+cd <build_dir>/applications/h264/h264_video_decode/ \
   && ./h264_video_decode --data <HOLOHUB_DATA_DIR>/endoscopy
 ```

--- a/operators/tensor_to_video_buffer/tensor_to_video_buffer.cpp
+++ b/operators/tensor_to_video_buffer/tensor_to_video_buffer.cpp
@@ -82,10 +82,10 @@ void TensorToVideoBufferOp::compute(InputContext& op_input, OutputContext& op_ou
     }
   }
   #if GXF_HAS_DLPACK_SUPPORT
-    // Get the nvidia::gxf::Tensor from holoscan::Tensor'.
-    nvidia::gxf::Tensor in_tensor{(maybe_tensor->dl_ctx())};
+    // Get a std::shared_ptr<nvidia::gxf::Tensor> from std::shared_ptr<holoscan::Tensor>'.
+    auto in_tensor = std::make_shared<nvidia::gxf::Tensor>(maybe_tensor->dl_ctx());
   #else
-    // Get the holoscan::gxf::GXFTensor from holoscan::Tensor'.
+    // Get a std::shared_ptr<holoscan::gxf::GXFTensor> from std::shared_ptr<holoscan::Tensor>'.
     auto in_tensor = gxf::GXFTensor::from_tensor(maybe_tensor);
   #endif
 


### PR DESCRIPTION
The primary purpose of this MR is to fix a broken code path for Holoscan 2.0 within TensorToVideoBufferOp

Specifically, there was a location where a `Tensor` was created instead of the expected `shared_ptr<Tensor>`.

This MR also fixes some mistakes in the h264 application README files.

I confirmed that compilation of `h264_endoscopy_tool_tracking ` is fixed by this change.