### PR TITLE
Add `build_and_run` developer container target

### DIFF
--- a/dev_container
+++ b/dev_container
@@ -353,6 +353,7 @@ launch_desc() { c_echo 'Launch Docker container
     --verbose : Print variables passed to docker run command
     --add-volume : Mount additional volume
     --as_root  : Run the container with root permissions
+    --docker_opts : Additional options to pass to the Docker launch
     '
 }
 launch() {
@@ -366,6 +367,7 @@ launch() {
     local use_tini=0
     local nsys_profile=false
     local as_root=false
+    local docker_opts=""
 
     # Choose NGC Holoscan SDK base image based on local platform, default is dGPU
     local gpu_type=$(get_host_gpu)
@@ -414,6 +416,11 @@ launch() {
             path="${ARGS[i+1]}"
             base=$(basename "$path")
             additional_volumes+="-v $path:/workspace/volumes/$base "
+            shift
+            shift
+        fi
+        if [ "$arg" = "--docker_opts" ]; then
+            docker_opts="${ARGS[i+1]}"
             shift
             shift
         fi
@@ -605,7 +612,9 @@ launch() {
         c_echo W "Launch (conditional_opt: " G "${conditional_opt}" W ")..."
         c_echo W "Launch (local_sdk_opt: " G "${local_sdk_opt}" W ")..."
         c_echo W "Launch (ucx_opt: " G "${ucx_opt}" W ")..."
+        c_echo W "Launch (docker_opts: " G "${docker_opts}" W ")..."
         c_echo W "Launch (image: " G "${img}" W ")..."
+        c_echo W "Launch (trailing args: " G "$@" W ")..."
     fi
 
     run_command ${HOLOSCAN_DOCKER_EXE} run --rm --net host \
@@ -628,10 +637,10 @@ launch() {
         ${local_sdk_opt} \
         ${mount_nvoptix_bin} \
         ${ucx_opt} \
+        ${docker_opts} \
         ${img} \
         "$@"
 }
-
 
 #===============================================================================
 

--- a/dev_container
+++ b/dev_container
@@ -642,6 +642,77 @@ launch() {
         "$@"
 }
 
+build_and_run_desc() {
+    c_echo 'Build and run a requested application in a Docker container.
+    Usage: ./dev_container build_and_run <application_name> [options]
+    Options:
+        --base_img : Fully qualified base image name, e.g. holoscan-sdk-dev:latest
+        --docker_file : Path to Dockerfile to use for building container.
+            If `--img` is not specified then a custom image tag will be defined.
+        --img : Specify fully qualified output container name
+        --language : Specify the app language implementation to run.
+                     Some applications provide both `cpp` and `python` implementations.
+        --no_build : Launch the app without attempting to build it first
+        --verbose : Print extra output to console
+    '
+}
+build_and_run() {
+    local app_name=""
+    local app_language=""
+    local container_build_args=""
+    local container_launch_args="--docker_opts --entrypoint=bash"
+    local build_app=1
+    local image_name=""
+    local docker_file=""
+
+    # Parse CLI arguments next
+    ARGS=("$@")
+    local i
+    local arg
+    for i in "${!ARGS[@]}"; do
+        arg="${ARGS[i]}"
+        if [ "$arg" = "--base_img" ]; then
+           container_build_args+=" --base_img ${ARGS[i+1]}"
+        elif [ "$arg" = "--docker_file" ]; then
+            docker_file="${ARGS[i+1]}"
+            container_build_args+=" --docker_file $docker_file"
+        elif [ "$arg" = "--img" ]; then
+            image_name="${ARGS[i+1]}"
+        elif [ "$arg" = "--no_build" ]; then
+            build_app=0
+        elif [ "$arg" = "--verbose" ]; then
+           container_build_args+=" --verbose"
+           container_launch_args+=" --verbose"
+        elif [ "$arg" = "--language" ]; then
+            app_language="${ARGS[i+1]}"
+        elif [ -z "${app_name}" ]; then
+            app_name=$arg
+        fi
+    done
+
+    if [ -z "${app_name}" ]; then
+        fatal "Must specify a HoloHub application to build and run."
+    fi
+
+    if [ -z "$image_name" ]; then
+        if [ -n "$docker_file" ]; then
+            image_name="holohub:${app_name}";
+        else
+            image_name=$(get_default_img);
+        fi
+    fi
+
+    container_build_args+=" --img $image_name"
+    container_launch_args+=" --img $image_name"
+
+    build $container_build_args
+    if [[ $build_app == 1 ]]; then
+        launch $container_launch_args -c "./run build $app_name"
+    fi
+    launch $container_launch_args -c "./run launch $app_name $app_language"
+}
+
+
 #===============================================================================
 
 parse_args() {


### PR DESCRIPTION
 Adds the `./dev_container build_and_run` target for a streamlined
    first-time developer experience.
    
    `build_and_run` combines the `build`, `launch`, and `run` scripts
     into a single command to build and run most HoloHub applications.
    Running `./dev_container build_and_run <app_name>` does the following:
    1. Builds the HoloHub container;
    2. Launches the HoloHub container and builds the application;
    3. Launches the HoloHub container and launches the application.
    
    `build_and_run` exposes a subset command line options to pass to
    `build`, `launch`, and `run` targets, with the goal of providing at
    least one path to run most HoloHub applications in a single command:
    - `build`: Accepts base container, Dockerfile, image tag
    - `launch`: Accepts image tag
    - `run build`: Accepts application name; provides an option to skip this
      step for applications that do not require building, such as some
      Python applications
    - `run launch`: Accepts application name and language
    
    Provides a path for first-time developers to build and run HoloHub apps
    with a single command after downloading the HoloHub repo. Day-to-day
    developers may continue to use `build`, `launch`, and `run` scripts for
    more granular control of the containerized development workflow.