### PR TITLE
Doc: Add GitHub badges with project statistics and workflow automation

### DIFF
--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -1,0 +1,34 @@
+name: Update HoloHub README Statistics
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Update README
+        run: |
+          python ./utilities/gather_metadata.py --output aggregate_metadata.json
+          app_count=$(cat aggregate_metadata.json | grep "\"source_folder\": \"applications\"" | wc -l)
+          sed -i -E "s/Applications-([0-9]+)/Applications-$app_count/" README.md
+          ops_count=$(cat aggregate_metadata.json | grep "\"source_folder\": \"operators\"" | wc -l)
+          sed -i -E "s/Operators-([0-9]+)/Operators-$ops_count/" README.md
+      
+      - name: Auto-Commit README Changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: 'README.md'
+          commit: '--signoff'
+          message: Update README Project Statistics

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ data/
 ci/
 CTestConfig.cmake
 *__pycache__
+
+# Utilities
+aggregate_metadata.json

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 )
 [![Pages](https://img.shields.io/github/actions/workflow/status/nvidia-holoscan/holohub/generate_pages.yml?branch=main&label=Pages)](https://nvidia-holoscan.github.io/holohub/)
 
+[![Applications](https://img.shields.io/badge/Applications-0-59A700)](https://github.com/nvidia-holoscan/holohub/tree/main/applications)
+[![Operators](https://img.shields.io/badge/Operators-0-59A700)](https://github.com/nvidia-holoscan/holohub/tree/main/operators)
+
 HoloHub is a central repository for the NVIDIA Holoscan AI sensor processing community to share apps and extensions. We invite users and developers of extensions and applications for the Holoscan Platform to reuse and contribute components and sample applications.
 
 Visit the [HoloHub landing page](https://nvidia-holoscan.github.io/holohub/) for details on available HoloHub projects.

--- a/utilities/__init__.py
+++ b/utilities/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.1.0"

--- a/utilities/gather_metadata.py
+++ b/utilities/gather_metadata.py
@@ -1,0 +1,80 @@
+import codecs
+import json
+import os
+
+
+def find_metadata_files(repo_paths):
+    metadata_files = []
+
+    # Recursively search for metadata.json files in the specified repository paths
+    for repo_path in repo_paths:
+        for root, dirs, files in os.walk(repo_path):
+            if "metadata.json" in files:
+                metadata_files.append(os.path.join(root, "metadata.json"))
+
+    return metadata_files
+
+
+def extract_readme(file_path):
+    # Check for the README.md file in the current directory
+    readme_path = os.path.join(os.path.dirname(file_path), "README.md")
+    if os.path.exists(readme_path):
+        with codecs.open(readme_path, "r", "utf-8") as readme_file:
+            return readme_file.read()
+    else:
+        # If README.md is not found, look for it one level up
+        readme_path = os.path.join(os.path.dirname(os.path.dirname(file_path)), "README.md")
+        if os.path.exists(readme_path):
+            with codecs.open(readme_path, "r", "utf-8") as readme_file:
+                return readme_file.read()
+        else:
+            return ""
+
+
+def extract_application_name(readme_path):
+    # Extract the application name from the README file path
+    parts = readme_path.split(os.sep)
+    if "applications" in parts:
+        index = parts.index("applications")
+        if index + 1 < len(parts):
+            return parts[index + 1]
+    elif "operators" in parts:
+        index = parts.index("operators")
+        if index + 1 < len(parts):
+            return parts[index + 1]
+    return ""
+
+
+def gather_metadata(repo_path, output_file):
+    metadata_files = find_metadata_files(repo_path)
+    metadata = []
+
+    # Iterate over the found metadata files
+    for file_path in metadata_files:
+        with open(file_path, "r") as file:
+            data = json.load(file)
+
+            if "application" in data:
+                data["metadata"] = data.pop("application")
+            elif "operator" in data:
+                data["metadata"] = data.pop("operator")
+
+            readme = extract_readme(file_path)
+            application_name = extract_application_name(file_path)
+            source_folder = "applications" if "applications" in file_path else "operators"
+            data["readme"] = readme
+            data["application_name"] = application_name
+            data["source_folder"] = source_folder
+            metadata.append(data)
+
+    # Write the metadata to the output file
+    with open(output_file, "w") as output:
+        json.dump(metadata, output, indent=4)
+
+
+# Specify the repository path and the output file name
+repo_paths = ["holohub/applications", "holohub/operators"]
+output_file = "aggregate_metadata.json"
+
+# Call the function to gather metadata
+gather_metadata(repo_paths, output_file)


### PR DESCRIPTION
Changes:

- Checks in and updates the `gather_metadata.py` utility as a standard source of "truth" to collect metadata from HoloHub subprojects. Updates the `summarize_metadata.py` utility to use those results, fixing an issue where that utility previously failed to reflect some metadata from nested folders.
- Adds badges to the HoloHub README to reflect the number of applications and operators available in HoloHub. We can add more badges later to reflect other statistics, such as tutorial counts or latest HSDK supported versions.
- Adds workflow to automatically update project statistics badges in the HoloHub README. If a branch adds a new project, the README will be updated in a new commit appended to the branch co-authored by a GitHub bot.

README after this change:

![image](https://github.com/nvidia-holoscan/holohub/assets/40648863/13b3859f-acb7-44bb-add1-37cf8a4f8fbe)
