### PR TITLE
Doc: Fix README documentation for getting dev_container command help

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ See also: [Advanced Launch Options](#advanced-launch-options-container)
 
 Run the following to view all build options available for the HoloHub container script:
 ```sh
-$ ./dev_container build help
+$ ./dev_container help build
 ```
 
 #### Custom Base Image


### PR DESCRIPTION
Updates the command provided in the HoloHub README to properly print out
command help for the `./dev_container build` command.

The previous command, provided as `./dev_container build help`, would
attempt to run a container build and ignore the "help" trailing
argument. Either `./dev_container help build` or `./dev_container build
--help` are valid commands to view help documentation for the container
build command. The former is selected for consistency with the
`./dev_container help launch` command later in the README.