### PR TITLE
Utility: Consolidate and Update Metadata Schema

### DIFF
--- a/.github/workflows/check_metadata.yml
+++ b/.github/workflows/check_metadata.yml
@@ -10,5 +10,14 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Utility Dependencies
+        run: |
+          python -m pip install -r ./utilities/requirements.txt
+
       - name: Run metadata_validator.py
         run: python utilities/metadata_validator.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ We do not require that community members conduct formal Software Quality Assuran
 Every application and operator should have an associated *metadata.json* file which describes the features
 and dependencies.
 
-`metadata.json` schemas differ slightly for [applications](./applications/metadata.schema.json), [GXF extensions](./gxf_extensions/metadata.schema.json), and [operators](./operators/metadata.schema.json), but generally follow the convention below:
+`metadata.json` schemas differ slightly for [applications](./applications/metadata.schema.json), [GXF extensions](./gxf_extensions/metadata.schema.json), [operators](./operators/metadata.schema.json), and [tutorials](./tutorials/metadata.schema.json), but generally follow the convention below:
 
 ```json
 // Main json definition for application or operator
@@ -228,9 +228,10 @@ function. This keyword should only be used for sample applications that are main
 
 Add each tutorial in its own subdirectory under the [```tutorials```](./tutorials) directory. The subdirectory should contain:
 - A README file summarizing the application's purpose and architecture;
+- A *metadata.json* file which describes its specifications and requirements in accordance with the [tutorial metadata.json schema](./tutorials/metadata.schema.json) (optional);
 - A LICENSE file governing use (optional).
 
-There are no project-wide metadata or build requirements for tutorials.
+There are no project-wide build requirements for tutorials.
 
 ### License Guidelines
 

--- a/applications/metadata.schema.json
+++ b/applications/metadata.schema.json
@@ -9,6 +9,9 @@
         "name": {
           "$ref": "holohub/project/v1#/$defs/name"
         },
+        "description": {
+          "$ref": "holohub/project/v1#/$defs/description"
+        },
         "authors": {
           "$refs": "holohub/project/v1#/$defs/authors"
         },

--- a/applications/metadata.schema.json
+++ b/applications/metadata.schema.json
@@ -35,6 +35,9 @@
         },
         "dependencies": {
           "$ref": "holohub/project/v1#/$defs/dependencies"
+        },
+        "run": {
+          "$ref": "holohub/project/v1#/$defs/run_command"
         }
       },
       "required": [

--- a/applications/metadata.schema.json
+++ b/applications/metadata.schema.json
@@ -1,128 +1,37 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "holohub/application/v1",
   "type": "object",
   "properties": {
     "application": {
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "$ref": "holohub/project/v1#/$defs/name"
         },
         "authors": {
-          "type": "array",
-          "items": [
-            {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "affiliation": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name",
-                "affiliation"
-              ]
-            }
-          ]
+          "$refs": "holohub/project/v1#/$defs/authors"
         },
         "version": {
-          "type": "string"
+          "$ref": "holohub/project/v1#/$defs/version"
         },
         "changelog": {
-          "type": "object"
+          "$ref": "holohub/project/v1#/$defs/changelog"
         },
         "platforms": {
-          "type": "array",
-          "items": [
-            {
-              "type": "string",
-              "enum": [ "amd64", "arm64" ]
-            },
-            {
-              "type": "string",
-              "enum": [ "amd64", "arm64" ]
-            }
-          ]
+          "$ref": "holohub/project/v1#/$defs/platforms"
         },
         "tags": {
-          "type": "array",
-          "items": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "$ref": "holohub/project/v1#/$defs/tags"
         },
         "holoscan_sdk": {
-          "type": "object",
-          "properties": {
-            "minimum_required_version": {
-              "type": "string"
-            },
-            "tested_versions": {
-              "type": "array",
-              "items": [
-                {
-                  "type": "string"
-                }
-              ]
-            }
-          },
-          "required": [
-            "minimum_required_version",
-            "tested_versions"
-          ]
+          "$ref": "holohub/project/v1#/$defs/sdk_version"
         },
         "ranking": {
-          "type": "integer"
+          "$ref": "holohub/project/v1#/$defs/ranking"
         },
         "dependencies": {
-          "type": "object",
-          "properties": {
-            "gxf_extensions": {
-              "type": "array",
-              "items": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "version": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name",
-                    "version"
-                  ]
-                }
-              ]
-            }
-          }
+          "$ref": "holohub/project/v1#/$defs/dependencies"
         }
       },
       "required": [

--- a/gxf_extensions/metadata.schema.json
+++ b/gxf_extensions/metadata.schema.json
@@ -1,128 +1,37 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "holohub/gxf_extension/v1",
   "type": "object",
   "properties": {
     "gxf_extension": {
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "$ref": "holohub/project/v1#/$defs/name"
         },
         "authors": {
-          "type": "array",
-          "items": [
-            {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "affiliation": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name",
-                "affiliation"
-              ]
-            }
-          ]
+          "$refs": "holohub/project/v1#/$defs/authors"
         },
         "version": {
-          "type": "string"
+          "$ref": "holohub/project/v1#/$defs/version"
         },
         "changelog": {
-          "type": "object"
+          "$ref": "holohub/project/v1#/$defs/changelog"
         },
         "platforms": {
-          "type": "array",
-          "items": [
-            {
-              "type": "string",
-              "enum": [ "amd64", "arm64" ]
-            },
-            {
-              "type": "string",
-              "enum": [ "amd64", "arm64" ]
-            }
-          ]
+          "$ref": "holohub/project/v1#/$defs/platforms"
         },
         "tags": {
-          "type": "array",
-          "items": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "$ref": "holohub/project/v1#/$defs/tags"
         },
         "gxf_version": {
-          "type": "object",
-          "properties": {
-            "minimum_required_version": {
-              "type": "string"
-            },
-            "tested_versions": {
-              "type": "array",
-              "items": [
-                {
-                  "type": "string"
-                }
-              ]
-            }
-          },
-          "required": [
-            "minimum_required_version",
-            "tested_versions"
-          ]
+          "$ref": "holohub/project/v1#/$defs/sdk_version"
         },
         "ranking": {
-          "type": "integer"
+          "$ref": "holohub/project/v1#/$defs/ranking"
         },
         "dependencies": {
-          "type": "object",
-          "properties": {
-            "gxf_extensions": {
-              "type": "array",
-              "items": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "version": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name",
-                    "version"
-                  ]
-                }
-              ]
-            }
-          }
+          "$ref": "holohub/project/v1#/$defs/dependencies"
         }
       },
       "required": [

--- a/gxf_extensions/metadata.schema.json
+++ b/gxf_extensions/metadata.schema.json
@@ -9,6 +9,9 @@
         "name": {
           "$ref": "holohub/project/v1#/$defs/name"
         },
+        "description": {
+          "$ref": "holohub/project/v1#/$defs/description"
+        },
         "authors": {
           "$refs": "holohub/project/v1#/$defs/authors"
         },

--- a/operators/metadata.schema.json
+++ b/operators/metadata.schema.json
@@ -1,128 +1,37 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "holohub/operator/v1",
   "type": "object",
   "properties": {
     "operator": {
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "$ref": "holohub/project/v1#/$defs/name"
         },
         "authors": {
-          "type": "array",
-          "items": [
-            {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "affiliation": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name",
-                "affiliation"
-              ]
-            }
-          ]
+          "$refs": "holohub/project/v1#/$defs/authors"
         },
         "version": {
-          "type": "string"
+          "$ref": "holohub/project/v1#/$defs/version"
         },
         "changelog": {
-          "type": "object"
+          "$ref": "holohub/project/v1#/$defs/changelog"
         },
         "platforms": {
-          "type": "array",
-          "items": [
-            {
-              "type": "string",
-              "enum": [ "amd64", "arm64" ]
-            },
-            {
-              "type": "string",
-              "enum": [ "amd64", "arm64" ]
-            }
-          ]
+          "$ref": "holohub/project/v1#/$defs/platforms"
         },
         "tags": {
-          "type": "array",
-          "items": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "$ref": "holohub/project/v1#/$defs/tags"
         },
         "holoscan_sdk": {
-          "type": "object",
-          "properties": {
-            "minimum_required_version": {
-              "type": "string"
-            },
-            "tested_versions": {
-              "type": "array",
-              "items": [
-                {
-                  "type": "string"
-                }
-              ]
-            }
-          },
-          "required": [
-            "minimum_required_version",
-            "tested_versions"
-          ]
+          "$ref": "holohub/project/v1#/$defs/sdk_version"
         },
         "ranking": {
-          "type": "integer"
+          "$ref": "holohub/project/v1#/$defs/ranking"
         },
         "dependencies": {
-          "type": "object",
-          "properties": {
-            "gxf_extensions": {
-              "type": "array",
-              "items": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "version": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name",
-                    "version"
-                  ]
-                }
-              ]
-            }
-          }
+          "$ref": "holohub/project/v1#/$defs/dependencies"
         }
       },
       "required": [

--- a/operators/metadata.schema.json
+++ b/operators/metadata.schema.json
@@ -9,6 +9,9 @@
         "name": {
           "$ref": "holohub/project/v1#/$defs/name"
         },
+        "description": {
+          "$ref": "holohub/project/v1#/$defs/description"
+        },
         "authors": {
           "$refs": "holohub/project/v1#/$defs/authors"
         },

--- a/tutorials/dicom_to_usd_with_monai_and_holoscan/metadata.json
+++ b/tutorials/dicom_to_usd_with_monai_and_holoscan/metadata.json
@@ -1,5 +1,5 @@
 {
-	"application": {
+	"tutorial": {
 		"name": "DICOM to OpenUSD mesh segmentation with MONAI Deploy and Holoscan",
 		"authors": [
 			{

--- a/tutorials/metadata.schema.json
+++ b/tutorials/metadata.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "holohub/tutorial/v1",
+  "type": "object",
+  "properties": {
+    "tutorial": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "holohub/project/v1#/$defs/name"
+        },
+        "description": {
+          "$ref": "holohub/project/v1#/$defs/description"
+        },
+        "authors": {
+          "$refs": "holohub/project/v1#/$defs/authors"
+        },
+        "version": {
+          "$ref": "holohub/project/v1#/$defs/version"
+        },
+        "changelog": {
+          "$ref": "holohub/project/v1#/$defs/changelog"
+        },
+        "platforms": {
+          "$ref": "holohub/project/v1#/$defs/platforms"
+        },
+        "tags": {
+          "$ref": "holohub/project/v1#/$defs/tags"
+        },
+        "holoscan_sdk": {
+          "$ref": "holohub/project/v1#/$defs/sdk_version"
+        },
+        "ranking": {
+          "$ref": "holohub/project/v1#/$defs/ranking"
+        },
+        "dependencies": {
+          "$ref": "holohub/project/v1#/$defs/dependencies"
+        },
+        "run": {
+          "$ref": "holohub/project/v1#/$defs/run_command"
+        }
+      },
+      "required": [
+        "name",
+        "authors",
+        "version",
+        "changelog",
+        "tags",
+        "holoscan_sdk",
+        "dependencies"
+      ]
+    }
+  },
+  "required": [
+    "tutorial"
+  ]
+}

--- a/utilities/metadata/project.schema.json
+++ b/utilities/metadata/project.schema.json
@@ -6,6 +6,9 @@
     "name": {
       "type": "string"
     },
+    "description": {
+      "type": "string"
+    },
     "authors": {
       "type": "array",
       "items": [

--- a/utilities/metadata/project.schema.json
+++ b/utilities/metadata/project.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "holohub/project/v1",
+  "type": "object",
+  "$defs": {
+    "name": {
+      "type": "string"
+    },
+    "authors": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "affiliation": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "affiliation"
+          ]
+        }
+      ]
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(\\.(0|[1-9].\\d*))*"
+    },
+    "changelog": {
+      "$id": "changelog",
+      "type": "object"
+    },
+    "platforms": {
+      "type": "array",
+      "items": [
+        {
+          "type": "string",
+          "enum": [ "amd64", "arm64" ]
+        }
+      ]
+    },
+    "tags": {
+      "type": "array",
+      "items": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "version_list": {
+      "type": "array",
+      "items": [
+        {
+          "$ref": "#/$defs/version"
+        }
+      ]
+    },
+    "sdk_version": {
+      "type": "object",
+      "properties": {
+        "minimum_required_version": {
+          "$ref": "#/$defs/version"
+        },
+        "tested_versions": {
+          "$ref": "#/$defs/version_list"
+        }
+      },
+      "required": [
+        "minimum_required_version",
+        "tested_versions"
+      ]
+    },
+    "ranking": {
+      "type": "integer"
+    },
+    "versioned_dependency": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "$ref": "#/$defs/version"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ]
+    },
+    "dependencies": {
+      "type": "object",
+      "properties": {
+        "gxf_extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/versioned_dependency"
+          }
+        }
+      }
+    }
+  }
+}

--- a/utilities/metadata/project.schema.json
+++ b/utilities/metadata/project.schema.json
@@ -105,6 +105,17 @@
           }
         }
       }
+    },
+    "run_command": {
+      "type": "object",
+      "properties": {
+        "command": {
+          "type": "string"
+        },
+        "workdir": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/utilities/metadata_validator.py
+++ b/utilities/metadata_validator.py
@@ -18,16 +18,25 @@ import os
 import sys
 
 import jsonschema
-from jsonschema import validate
+from jsonschema import Draft4Validator
+from referencing import Registry
+from referencing.jsonschema import DRAFT4
 
 
 def validate_json(json_data, directory):
+    BASE_SCHEMA = "utilities/metadata/project.schema.json"
+
     # Describe the schema.
+    with open(BASE_SCHEMA) as file:
+        base_schema = json.load(file)
+    registry = Registry().with_resource(base_schema["$id"], DRAFT4.create_resource(base_schema))
+
     with open(directory + "/metadata.schema.json", "r") as file:
         execute_api_schema = json.load(file)
+    validator = Draft4Validator(execute_api_schema, registry=registry)
 
     try:
-        validate(instance=json_data, schema=execute_api_schema)
+        validator.validate(json_data)
     except jsonschema.exceptions.ValidationError as err:
         return False, err
 

--- a/utilities/metadata_validator.py
+++ b/utilities/metadata_validator.py
@@ -43,7 +43,7 @@ def validate_json(json_data, directory):
     return True, "valid"
 
 
-def validate_json_directory(directory, ignore_patterns=[]):
+def validate_json_directory(directory, ignore_patterns=[], metadata_is_required: bool = True):
     exit_code = 0
     # Convert json to python object.
     current_wdir = os.getcwd()
@@ -65,8 +65,11 @@ def validate_json_directory(directory, ignore_patterns=[]):
                 )
             )
             if count == 0:
-                print("ERROR:" + subdir + " does not contain metadata.json file")
-                exit_code = 1
+                if metadata_is_required:
+                    print("ERROR:" + subdir + " does not contain metadata.json file")
+                    exit_code = 1
+                else:
+                    print("WARNING:" + subdir + " does not contain metadata.json file")
 
     # Check if the metadata is valid
     for name in glob.glob(current_wdir + "/" + directory + "/**/metadata.json", recursive=True):
@@ -88,5 +91,6 @@ if __name__ == "__main__":
     exit_code_op = validate_json_directory("operators")
     exit_code_extensions = validate_json_directory("gxf_extensions", ignore_patterns=["utils"])
     exit_code_applications = validate_json_directory("applications")
+    exit_code_tutorials = validate_json_directory("tutorials", metadata_is_required=False)
 
-    sys.exit(max(exit_code_op, exit_code_extensions, exit_code_applications))
+    sys.exit(max(exit_code_op, exit_code_extensions, exit_code_applications, exit_code_tutorials))


### PR DESCRIPTION
## Motivation

HoloHub requires that projects provide a `metadata.json` file adhering to certain structures. This allows us to implement standard processes that collect project information and improve project visibility within HoloHub.

This PR intends to address pain points in the HoloHub metadata schema strategy:
1. Reduce schema maintenance requirements by reducing duplicate definitions;
2. Implement requested fields and schema for richer project descriptions

## Metaschema Updates
- Adds `project.schema.json` metaschema to supply schema elements for
      reuse across HoloHub project types. This reduces the maintenance
      burden for any changes in metadata conventions that should apply
      across HoloHub projects. Existing `metadata.schema.json` files are
      updated to reference metaschema elements rather than duplicating
      definitions.
- Adds ID field to each project schema with versioning information,
      starting at v1. This will allow us to update schema in the future
      without requiring that we immediately enforce the updated schema on
      every HoloHub project.

## Schema enforcement updates
 - Adds regular expression in metaschema to validate and enforce
      version semantics. Regex string is based on semver but relaxed to
      accept existing HoloHub conventions (major.minor or
      major.minor.revision).
 - Adds optional "description" field
 - Adds optional application "run command" field
 - Adds optional tutorial schema

## Additional Notes
The only immediate changes impacting existing HoloHub projects are as follows:
- Version fields must now match `<major>.<minor>` or `<major>.<minor>.<revision>` regex (no violations observed);
- If a tutorial supplies a `metadata.json` it must match the provided schema

Following alignment on this change, we will discuss strategies and milestones for if/when any future field requirements can be introduced and enforced.