### PR TITLE
Infra: Default to first available application language at launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,17 +146,22 @@ To list all available applications you can run the following command:
   ./run list
 ```
 
-Then you can run the application using
+Then you can run the application using the command:
 ```bash
-  ./run launch <application> <language>
+  ./run launch <application>
 ```
 
-For example, to run the tool tracking endoscopy application in C++
+For example, to run the tool tracking endoscopy application:
 ```bash
-  ./run launch endoscopy_tool_tracking cpp
+  ./run launch endoscopy_tool_tracking
 ```
 
-and to run the same application in python:
+Several applications are implemented in both C++ and Python programming languages.
+You can request a specific implementation as a trailing argument to the `./run launch` command
+or omit the argument to use the default language.
+For instance, the following command will run the Python implementation of the tool tracking
+endoscopy application:
+
 ```bash
   ./run launch endoscopy_tool_tracking python
 ```

--- a/run
+++ b/run
@@ -571,6 +571,7 @@ launch_desc() {
   echo "Options:"
   echo "   --extra_args <args>       : additional arguments passed to the application command"
   echo "   --nsys_profile            : profile using Nsight Systems"
+  echo "   --verbose                 : output additional run command information to stdout"
   echo ""
   echo ""
   echo "Use './run list' first to list the available applications"
@@ -585,6 +586,7 @@ launch() {
    local language=""
    local extra_args=""
    local nsys_profile=false
+   local verbose=false
 
    for i in "${!ARGS[@]}"; do
      arg="${ARGS[i]}"
@@ -593,6 +595,8 @@ launch() {
        break
      elif [ "$arg" = "--nsys_profile" ]; then
        nsys_profile=true
+     elif [ "$arg" = "--verbose" ]; then
+       verbose=true
      elif [ -z "${appname}" ]; then
        appname=$arg
      elif [ -z "${language}" ]; then
@@ -693,6 +697,13 @@ for k, v in obj["application"]["run"].items():
 
    local environment="export PYTHONPATH=\${PYTHONPATH}:${holoscan_sdk_install}/../../../python/lib:${holohub_build_dir}/python/lib:${SCRIPT_DIR}"
    local reset_environment="export PYTHONPATH=${PYTHONPATH}"
+
+   if [ ${verbose} ]; then
+    echo "Run environment: $environment"
+    echo "Run workdir: $workdir"
+    echo "Run command: $command"
+    echo "Run command args: $extra_args"
+   fi
 
    # Run the command
    run_command $environment

--- a/run
+++ b/run
@@ -631,10 +631,20 @@ launch() {
    local holohub_app_bin="${holohub_build_dir}/applications/${appname}"
    local metadata_file="${holohub_app_source}/metadata.json"
 
+   # If a language was not provided but multiple are available, auto-select
+   # the first language matching the app name from the "./run list" command.
+   # Yields an empty string if a language folder is not specified.
+   # Example `list` string:
+   # ultrasound_segmentation (cpp) [Sample Application]
+   if [ -z "${language}" ]; then
+     language=$(list | grep -m 1 ${appname} | awk -F'[\\(\\)]' '{print $2}')
+     echo "Default language for ${appname} selected: ${language}"
+   fi
+
    if [[ "${language}" ]]; then
      metadata_file="${holohub_app_source}/${language}/metadata.json"
-     holohub_app_bin="${holohub_build_dir}/applications/${appname}/$2"
-     holohub_app_source="${SCRIPT_DIR}/applications/${appname}/$2"
+     holohub_app_bin="${holohub_build_dir}/applications/${appname}/${language}"
+     holohub_app_source="${SCRIPT_DIR}/applications/${appname}/${language}"
    fi
 
    # Check if the metadata file exists
@@ -716,7 +726,7 @@ for k, v in obj["application"]["run"].items():
 # Other options
 
 # Build HoloHub sample apps
-_list_desc() {
+list_desc() {
   echo ""
   echo "Display the list of applications to run."
   echo "Usage: ./run list"


### PR DESCRIPTION
Changes:
- Adds `run launch --verbose` option to aid in development
- If a language is not specified for the `./run launch` command,
      use the output of `./run list` to select the first available
      application language implementation for the requested app name
- Fix issue where positional language argument was used in place of
    updated local variable
- Fixes `list_desc` function name so that `./run list --help` prints as
      expected

Test with `multiai_ultrasound`:
```sh
$ ./dev_container build && ./dev_container launch && ./run build multiai_ultrasound
>>>$ ./dev_container launch multiai_ultrasound
Default language for multiai_ultrasound selected: cpp
...
```

Or:
```sh
$ ./dev_container build_and_run multiai_ultrasound
```

Apps that do not provide or require a language are unaffected.