### PR TITLE
Infra: Do not show empty `./run launch` default language

### DIFF
--- a/run
+++ b/run
@@ -638,7 +638,9 @@ launch() {
    # ultrasound_segmentation (cpp) [Sample Application]
    if [ -z "${language}" ]; then
      language=$(list | grep -m 1 ${appname} | awk -F'[\\(\\)]' '{print $2}')
-     echo "Default language for ${appname} selected: ${language}"
+     if [[ "${language}" ]]; then
+       echo "Default language for ${appname} selected: ${language}"
+     fi
    fi
 
    if [[ "${language}" ]]; then


### PR DESCRIPTION
Addresses issue where an application that does not support a language specifier, such as colonoscopy_segmentation, would print out an empty language string from its language detection attempt. That printout could be confusing for users.

For example, under previous behavior the following line was printed to the console:
"Default language for colonoscopy segmentation selected: "

Under updated behavior the line is not printed.

Applications that do accept a language specifier are not impacted by this change and will continue to print the default selection.