### PR TITLE
Doc: Add `metadata.json` for Local-Llama tutorial

### DIFF
--- a/tutorials/local-llama/README.md
+++ b/tutorials/local-llama/README.md
@@ -145,7 +145,8 @@ Now, you can interact with the simple web front end by browsing to http://127.0.
 >Llama.cpp includes a nifty Flask app `api_like_OAI.py`. This Flask app sets up a server that emulates the OpenAI API. Its trick is that it converts the OpenAI API requests into the format expected by the Llama model, and forwards the captured requests to our local Llama-2 model. This allows you to use the popular OpenAI Python backend, and thus, countless powerful LLM libraries like [LangChain](https://python.langchain.com/docs/get_started/introduction.html), [Scikit-LLM](https://github.com/iryna-kondr/scikit-llm), [Haystack](https://haystack.deepset.ai/), and more. However, instead of your data being sent to OpenAI’s servers, it is all processed locally on your machine!
 1. In order to run the OpenAI API server and our eventual Gradio chat app, we need to open a new terminal and install a few Python dependencies:
 ```bash
-pip install gradio openai flask requests
+cd tutorials/local-llama
+pip install -r requirements.txt
 ```
 2. This then allows us to run the Flask server:
 ```bash

--- a/tutorials/local-llama/metadata.json
+++ b/tutorials/local-llama/metadata.json
@@ -1,0 +1,64 @@
+{
+	"tutorial": {
+		"name": "Deploying Llama-2 70b model on the edge with IGX Orin",
+		"description": "This tutorial will walk you through how to run a quantized version of Meta's Llama-2 70b model as the backend LLM for a Gradio chatbot app, all running on an NVIDIA IGX Orin.",
+		"authors": [
+			{
+				"name": "Nigel Nelson",
+				"affiliation": "NVIDIA"
+			}
+		],
+		"language": "Python",
+		"version": "0.1.0",
+		"changelog": {
+			"0.1.0": "Initial Release"
+		},
+		"holoscan_sdk": {
+			"minimum_required_version": "0.6.0",
+			"tested_versions": [
+				"0.6.0"
+			]
+		},
+		"platforms": [
+			"arm64"
+		],
+		"tags": [
+			"Chatbot",
+			"CUDA",
+			"HuggingFace",
+			"Llama",
+			"LLM"
+		],
+		"ranking": 1,
+		"dependencies": {
+			"data": [
+				{
+					"name": "Llama-2",
+					"url": "https://about.fb.com/news/2023/07/llama-2/"
+				}
+			],
+			"libraries": [
+				{
+					"name": "CUDA Toolkit",
+					"url": "https://developer.nvidia.com/cuda-downloads",
+					"minimum_required_version": "11.8"
+				},
+				{
+					"name": "llama.cpp",
+					"url": "https://github.com/ggerganov/llama.cpp"
+				}
+			],
+			"python-requirements": [
+				{
+					"filepath": "requirements.txt"
+				}
+			],
+			"services": [
+				{
+					"name": "HuggingFace",
+					"url": "https://huggingface.co/"
+				}
+			]
+		}
+	}
+}

--- a/tutorials/local-llama/requirements.txt
+++ b/tutorials/local-llama/requirements.txt
@@ -1,0 +1,4 @@
+flask
+gradio
+openai
+requests


### PR DESCRIPTION
Adds `metadata.json` to provide structured project information for the Local-Llama tutorial. Follows the addition of optional tutorial metadata schema in 998afef, which will be required in the future.

Also moves Python requirements into a `requirements.txt` file for dependency visibility.