### PR TITLE
Doc: Add `metadata.json` for AWS Playground tutorial

### DIFF
--- a/tutorials/holoscan-playground-on-aws/metadata.json
+++ b/tutorials/holoscan-playground-on-aws/metadata.json
@@ -1,0 +1,41 @@
+{
+	"tutorial": {
+		"name": "Holoscan Playground on AWS",
+		"description": "The Holoscan on AWS EC2 experience is an easy way for having a first try at the Holoscan SDK.",
+		"authors": [
+			{
+				"name": "Jin Li",
+				"affiliation": "NVIDIA"
+			}
+		],
+		"version": "0.1.0",
+		"changelog": {
+			"0.1.0": "Initial Release"
+		},
+		"holoscan_sdk": {
+			"minimum_required_version": "0.6.0",
+			"tested_versions": [
+				"0.6.0"
+			]
+		},
+		"platforms": [
+			"amd64",
+			"arm64"
+		],
+		"tags": [
+			"Amazon Web Services",
+			"AWS",
+			"Cloud",
+			"EC2"
+		],
+		"ranking": 1,
+		"dependencies": {
+			"services": [
+				{
+					"name": "Amazon Web Services EC2",
+					"url": "https://aws.amazon.com/ec2/"
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
Adds metadata.json to provide structured project information for the AWS playground tutorial.

Follows the addition of optional tutorial metadata schema in 998afef, which will be required in the future.