### PR TITLE
Doc: Add `metadata.json` for flow benchmarking tutorial

### DIFF
--- a/tutorials/holoscan_flow_benchmarking/metadata.json
+++ b/tutorials/holoscan_flow_benchmarking/metadata.json
@@ -1,0 +1,38 @@
+{
+	"tutorial": {
+		"name": "Holoscan Flow Benchmarking",
+		"description": "This is a benchmarking tool to evaluate the performance of HoloHub and other Holoscan applications.",
+		"authors": [
+			{
+				"name": "Holoscan Team",
+				"affiliation": "NVIDIA"
+			}
+		],
+		"version": "0.1.0",
+		"changelog": {
+			"0.1.0": "Initial Release"
+		},
+		"holoscan_sdk": {
+			"minimum_required_version": "1.0.3",
+			"tested_versions": [
+				"1.0.3"
+			]
+		},
+		"platforms": [
+			"amd64",
+			"arm64"
+		],
+		"tags": [
+			"Benchmarking",
+			"Flow"
+		],
+		"ranking": 3,
+		"dependencies": {
+			"python-requirements": [
+				{
+					"filepath": "requirements.txt"
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
Adds metadata.json to provide structured project information for the HSDK flow benchmarking tutorial.

Follows the addition of optional tutorial metadata schema in 998afef, which will be required in the future.