### PR TITLE
Doc: Add tutorials count badge to public README

### DIFF
--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -25,6 +25,8 @@ jobs:
           sed -i -E "s/Applications-([0-9]+)/Applications-$app_count/" README.md
           ops_count=$(cat aggregate_metadata.json | grep "\"source_folder\": \"operators\"" | wc -l)
           sed -i -E "s/Operators-([0-9]+)/Operators-$ops_count/" README.md
+          tutorial_count=$(cat aggregate_metadata.json | grep "\"source_folder\": \"tutorials\"" | wc -l)
+          sed -i -E "s/Tutorials-([0-9]+)/Tutorials-$tutorial_count/" README.md
       
       - name: Auto-Commit README Changes
         uses: EndBug/add-and-commit@v9

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![Applications](https://img.shields.io/badge/Applications-61-59A700)](https://github.com/nvidia-holoscan/holohub/tree/main/applications)
 [![Operators](https://img.shields.io/badge/Operators-38-59A700)](https://github.com/nvidia-holoscan/holohub/tree/main/operators)
+[![Tutorials](https://img.shields.io/badge/Tutorials-0-59A700)](https://github.com/nvidia-holoscan/holohub/tree/main/operators)
 
 HoloHub is a central repository for the NVIDIA Holoscan AI sensor processing community to share apps and extensions. We invite users and developers of extensions and applications for the Holoscan Platform to reuse and contribute components and sample applications.
 

--- a/utilities/gather_metadata.py
+++ b/utilities/gather_metadata.py
@@ -65,7 +65,7 @@ def extract_application_name(readme_path):
 
 def gather_metadata(repo_path) -> dict:
     """Collect project metadata from JSON files into a single dictionary"""
-    SCHEMA_TYPES = ["application", "operator", "gxf_extension"]
+    SCHEMA_TYPES = ["application", "operator", "gxf_extension", "tutorial"]
 
     metadata_files = find_metadata_files(repo_path)
     metadata = []
@@ -94,7 +94,7 @@ def gather_metadata(repo_path) -> dict:
 def main(args: argparse.Namespace):
     """Run the gather application"""
 
-    DEFAULT_INCLUDE_PATHS = ["applications", "operators"]
+    DEFAULT_INCLUDE_PATHS = ["applications", "operators", "tutorials"]
     DEFAULT_OUTPUT_FILEPATH = "aggregate_metadata.json"
 
     repo_paths = args.include or DEFAULT_INCLUDE_PATHS


### PR DESCRIPTION
Adds badge to HoloHub README to display the number of tutorials
currently available in HoloHub alongside apps and operators.

Includes tutorials in README update CI workflow so that the count is
automatically updated in a commit to `main` when a new tutorial metadata
file is added to HoloHub.