### PR TITLE
Doc: Fix tutorial badge hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Applications](https://img.shields.io/badge/Applications-61-59A700)](https://github.com/nvidia-holoscan/holohub/tree/main/applications)
 [![Operators](https://img.shields.io/badge/Operators-38-59A700)](https://github.com/nvidia-holoscan/holohub/tree/main/operators)
-[![Tutorials](https://img.shields.io/badge/Tutorials-1-59A700)](https://github.com/nvidia-holoscan/holohub/tree/main/operators)
+[![Tutorials](https://img.shields.io/badge/Tutorials-1-59A700)](https://github.com/nvidia-holoscan/holohub/tree/main/tutorials)
 
 HoloHub is a central repository for the NVIDIA Holoscan AI sensor processing community to share apps and extensions. We invite users and developers of extensions and applications for the Holoscan Platform to reuse and contribute components and sample applications.
 


### PR DESCRIPTION
Updates the tutorial badge hyperlink to point to the "tutorials" folder rather than the "operators" folder.