### PR TITLE
update ToolTrackingPostprocessorOp for compatibility with distributed apps

### DIFF
--- a/applications/endoscopy_tool_tracking/cpp/main.cpp
+++ b/applications/endoscopy_tool_tracking/cpp/main.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -190,7 +190,17 @@ class App : public holoscan::Application {
 
     // Flow definition
     add_flow(lstm_inferer, tool_tracking_postprocessor, {{"tensor", "in"}});
-    add_flow(tool_tracking_postprocessor, visualizer_operator, {{"out", input_annotations_signal}});
+
+    if (this->visualizer_name == "holoviz") {
+      add_flow(tool_tracking_postprocessor,
+               visualizer_operator,
+               {{"out_coords", input_annotations_signal}, {"out_mask", input_annotations_signal}});
+    } else {
+      // device tensor on the out_mask port is not used by VtkRendererOp
+      add_flow(tool_tracking_postprocessor,
+               visualizer_operator,
+               {{"out_coords", input_annotations_signal}});
+    }
 
     std::string output_signal = "output";  // replayer output signal name
     if (source_ == "deltacast") {

--- a/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py
+++ b/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py
@@ -205,7 +205,11 @@ class EndoscopyApp(Application):
 
         # Flow definition
         self.add_flow(lstm_inferer, tool_tracking_postprocessor, {("tensor", "in")})
-        self.add_flow(tool_tracking_postprocessor, visualizer, {("out", "receivers")})
+        self.add_flow(
+            tool_tracking_postprocessor,
+            visualizer,
+            {("out_coords", "receivers"), ("out_mask", "receivers")},
+        )
         self.add_flow(
             source,
             format_converter,

--- a/applications/h264/h264_endoscopy_tool_tracking/main.cpp
+++ b/applications/h264/h264_endoscopy_tool_tracking/main.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,9 +31,7 @@
 
 class App : public holoscan::Application {
  public:
-  void set_datapath(const std::string& path) {
-     datapath = path;
-  }
+  void set_datapath(const std::string& path) { datapath = path; }
 
   void compose() override {
     using namespace holoscan;
@@ -43,18 +41,17 @@ class App : public holoscan::Application {
     int64_t source_block_size = width * height * 3 * 4;
     int64_t source_num_blocks = 2;
 
-    auto bitstream_reader =
-        make_operator<ops::VideoReadBitstreamOp>("bitstream_reader",
-            from_config("bitstream_reader"),
-            Arg("input_file_path", datapath+"/surgical_video.264"),
-            make_condition<CountCondition>(2000),
-            Arg("pool") = make_resource<BlockMemoryPool>("pool",
-            0, source_block_size, source_num_blocks));
+    auto bitstream_reader = make_operator<ops::VideoReadBitstreamOp>(
+        "bitstream_reader",
+        from_config("bitstream_reader"),
+        Arg("input_file_path", datapath + "/surgical_video.264"),
+        make_condition<CountCondition>(2000),
+        Arg("pool") =
+            make_resource<BlockMemoryPool>("pool", 0, source_block_size, source_num_blocks));
 
-    auto response_condition =
-        make_condition<AsynchronousCondition>("response_condition");
-    auto video_decoder_context = make_resource<ops::VideoDecoderContext>(
-        Arg("async_scheduling_term") = response_condition);
+    auto response_condition = make_condition<AsynchronousCondition>("response_condition");
+    auto video_decoder_context =
+        make_resource<ops::VideoDecoderContext>(Arg("async_scheduling_term") = response_condition);
 
     auto request_condition = make_condition<AsynchronousCondition>("request_condition");
     auto video_decoder_request = make_operator<ops::VideoDecoderRequestOp>(
@@ -64,130 +61,120 @@ class App : public holoscan::Application {
         Arg("async_scheduling_term") = request_condition,
         Arg("videodecoder_context") = video_decoder_context);
 
-    auto video_decoder_response =
-        make_operator<ops::VideoDecoderResponseOp>("video_decoder_response",
-            from_config("video_decoder_response"),
-            response_condition,
-            Arg("pool") = make_resource<BlockMemoryPool>("pool", 1,
-                source_block_size, source_num_blocks),
-            Arg("videodecoder_context") = video_decoder_context);
+    auto video_decoder_response = make_operator<ops::VideoDecoderResponseOp>(
+        "video_decoder_response",
+        from_config("video_decoder_response"),
+        response_condition,
+        Arg("pool") =
+            make_resource<BlockMemoryPool>("pool", 1, source_block_size, source_num_blocks),
+        Arg("videodecoder_context") = video_decoder_context);
 
     auto decoder_output_format_converter =
         make_operator<ops::FormatConverterOp>("decoder_output_format_converter",
-            from_config("decoder_output_format_converter"),
-            Arg("pool") = make_resource<BlockMemoryPool>("pool",
-                1, source_block_size, source_num_blocks));
+                                              from_config("decoder_output_format_converter"),
+                                              Arg("pool") = make_resource<BlockMemoryPool>(
+                                                  "pool", 1, source_block_size, source_num_blocks));
 
     auto rgb_float_format_converter =
         make_operator<ops::FormatConverterOp>("rgb_float_format_converter",
-            from_config("rgb_float_format_converter"),
-            Arg("pool") = make_resource<BlockMemoryPool>("pool", 1,
-                source_block_size, source_num_blocks));
+                                              from_config("rgb_float_format_converter"),
+                                              Arg("pool") = make_resource<BlockMemoryPool>(
+                                                  "pool", 1, source_block_size, source_num_blocks));
 
-    const std::string model_file_path = datapath+"/tool_loc_convlstm.onnx";
-    const std::string engine_cache_dir = datapath+"/engines";
+    const std::string model_file_path = datapath + "/tool_loc_convlstm.onnx";
+    const std::string engine_cache_dir = datapath + "/engines";
 
-    auto lstm_inferer =
-        make_operator<ops::LSTMTensorRTInferenceOp>("lstm_inferer",
-            from_config("lstm_inference"),
-            Arg("model_file_path", model_file_path),
-            Arg("engine_cache_dir", engine_cache_dir),
-            Arg("pool") =
-            make_resource<UnboundedAllocator>("pool"),
-            Arg("cuda_stream_pool") = make_resource<CudaStreamPool>(
-                "cuda_stream", 0, 0, 0, 1, 5));
+    auto lstm_inferer = make_operator<ops::LSTMTensorRTInferenceOp>(
+        "lstm_inferer",
+        from_config("lstm_inference"),
+        Arg("model_file_path", model_file_path),
+        Arg("engine_cache_dir", engine_cache_dir),
+        Arg("pool") = make_resource<UnboundedAllocator>("pool"),
+        Arg("cuda_stream_pool") = make_resource<CudaStreamPool>("cuda_stream", 0, 0, 0, 1, 5));
 
-    auto tool_tracking_postprocessor =
-        make_operator<ops::ToolTrackingPostprocessorOp>(
-            "tool_tracking_postprocessor",
-            from_config("tool_tracking_postprocessor"),
-            Arg("device_allocator") = make_resource<UnboundedAllocator>(
-                "device_allocator"),
-            Arg("host_allocator") = make_resource<UnboundedAllocator>(
-                "host_allocator"));
+    auto tool_tracking_postprocessor = make_operator<ops::ToolTrackingPostprocessorOp>(
+        "tool_tracking_postprocessor",
+        from_config("tool_tracking_postprocessor"),
+        Arg("device_allocator") = make_resource<UnboundedAllocator>("device_allocator"),
+        Arg("host_allocator") = make_resource<UnboundedAllocator>("host_allocator"));
 
     const bool record_output = from_config("record_output").as<bool>();
 
     std::shared_ptr<BlockMemoryPool> visualizer_allocator =
-        make_resource<BlockMemoryPool>("allocator", 1,
-            source_block_size, source_num_blocks);
+        make_resource<BlockMemoryPool>("allocator", 1, source_block_size, source_num_blocks);
     auto visualizer =
-        make_operator<ops::HolovizOp>("holoviz", from_config("holoviz"),
-            Arg("width") = width,
-            Arg("height") = height,
-            Arg("enable_render_buffer_input") = false,
-            Arg("enable_render_buffer_output") = record_output == true,
-            Arg("allocator") = visualizer_allocator);
+        make_operator<ops::HolovizOp>("holoviz",
+                                      from_config("holoviz"),
+                                      Arg("width") = width,
+                                      Arg("height") = height,
+                                      Arg("enable_render_buffer_input") = false,
+                                      Arg("enable_render_buffer_output") = record_output == true,
+                                      Arg("allocator") = visualizer_allocator);
 
-    add_flow(bitstream_reader, video_decoder_request,
-        {{"output_transmitter", "input_frame"}});
-    add_flow(video_decoder_response, decoder_output_format_converter,
-        {{"output_transmitter", "source_video"}});
-    add_flow(decoder_output_format_converter, visualizer,
-       {{"tensor", "receivers"}});
-    add_flow(decoder_output_format_converter, rgb_float_format_converter,
-        {{"tensor", "source_video"}});
+    add_flow(bitstream_reader, video_decoder_request, {{"output_transmitter", "input_frame"}});
+    add_flow(video_decoder_response,
+             decoder_output_format_converter,
+             {{"output_transmitter", "source_video"}});
+    add_flow(decoder_output_format_converter, visualizer, {{"tensor", "receivers"}});
+    add_flow(
+        decoder_output_format_converter, rgb_float_format_converter, {{"tensor", "source_video"}});
     add_flow(rgb_float_format_converter, lstm_inferer);
     add_flow(lstm_inferer, tool_tracking_postprocessor, {{"tensor", "in"}});
-    add_flow(tool_tracking_postprocessor, visualizer, {{"out", "receivers"}});
-
+    add_flow(tool_tracking_postprocessor,
+             visualizer,
+             {{"out_coords", "receivers"}, {"out_mask", "receivers"}});
 
     if (record_output) {
       auto encoder_async_condition =
           make_condition<AsynchronousCondition>("encoder_async_condition");
       auto video_encoder_context =
-          make_resource<ops::VideoEncoderContext>(
-              Arg("scheduling_term") = encoder_async_condition);
+          make_resource<ops::VideoEncoderContext>(Arg("scheduling_term") = encoder_async_condition);
 
       auto video_encoder_request = make_operator<ops::VideoEncoderRequestOp>(
           "video_encoder_request",
           from_config("video_encoder_request"),
           Arg("videoencoder_context") = video_encoder_context);
 
-      auto video_encoder_response =
-          make_operator<ops::VideoEncoderResponseOp>("video_encoder_response",
-              from_config("video_encoder_response"),
-              encoder_async_condition,
-              Arg("pool") = make_resource<BlockMemoryPool>("pool", 1,
-                  source_block_size, source_num_blocks),
-              Arg("videoencoder_context") = video_encoder_context);
+      auto video_encoder_response = make_operator<ops::VideoEncoderResponseOp>(
+          "video_encoder_response",
+          from_config("video_encoder_response"),
+          encoder_async_condition,
+          Arg("pool") =
+              make_resource<BlockMemoryPool>("pool", 1, source_block_size, source_num_blocks),
+          Arg("videoencoder_context") = video_encoder_context);
 
-      auto holoviz_output_format_converter =
-          make_operator<ops::FormatConverterOp>(
-              "holoviz_output_format_converter",
-              from_config("holoviz_output_format_converter"),
-              Arg("pool") = make_resource<BlockMemoryPool>("pool", 1,
-                  source_block_size, source_num_blocks));
+      auto holoviz_output_format_converter = make_operator<ops::FormatConverterOp>(
+          "holoviz_output_format_converter",
+          from_config("holoviz_output_format_converter"),
+          Arg("pool") =
+              make_resource<BlockMemoryPool>("pool", 1, source_block_size, source_num_blocks));
 
-      auto encoder_input_format_converter =
-          make_operator<ops::FormatConverterOp>(
-              "encoder_input_format_converter",
-              from_config("encoder_input_format_converter"),
-              Arg("pool") = make_resource<BlockMemoryPool>("pool", 1,
-                  source_block_size, source_num_blocks));
+      auto encoder_input_format_converter = make_operator<ops::FormatConverterOp>(
+          "encoder_input_format_converter",
+          from_config("encoder_input_format_converter"),
+          Arg("pool") =
+              make_resource<BlockMemoryPool>("pool", 1, source_block_size, source_num_blocks));
 
-      auto tensor_to_video_buffer =
-          make_operator<ops::TensorToVideoBufferOp>("tensor_to_video_buffer",
-              from_config("tensor_to_video_buffer"));
+      auto tensor_to_video_buffer = make_operator<ops::TensorToVideoBufferOp>(
+          "tensor_to_video_buffer", from_config("tensor_to_video_buffer"));
 
-      auto bitstream_writer =
-          make_operator<ops::VideoWriteBitstreamOp>("bitstream_writer",
-              from_config("bitstream_writer"),
-              Arg("output_video_path", datapath+"/surgical_video_output.264"),
-              Arg("input_crc_file_path", datapath+"/surgical_video_output.txt"),
-              Arg("pool") = make_resource<BlockMemoryPool>("pool", 0,
-                  source_block_size, source_num_blocks));
+      auto bitstream_writer = make_operator<ops::VideoWriteBitstreamOp>(
+          "bitstream_writer",
+          from_config("bitstream_writer"),
+          Arg("output_video_path", datapath + "/surgical_video_output.264"),
+          Arg("input_crc_file_path", datapath + "/surgical_video_output.txt"),
+          Arg("pool") =
+              make_resource<BlockMemoryPool>("pool", 0, source_block_size, source_num_blocks));
 
-      add_flow(visualizer, holoviz_output_format_converter,
-          {{"render_buffer_output", "source_video"}});
-      add_flow(holoviz_output_format_converter, encoder_input_format_converter,
-          {{"tensor", "source_video"}});
-      add_flow(encoder_input_format_converter, tensor_to_video_buffer,
-          {{"tensor", "in_tensor"}});
-      add_flow(tensor_to_video_buffer, video_encoder_request,
-          {{"out_video_buffer", "input_frame"}});
-      add_flow(video_encoder_response, bitstream_writer,
-          {{"output_transmitter", "data_receiver"}});
+      add_flow(
+          visualizer, holoviz_output_format_converter, {{"render_buffer_output", "source_video"}});
+      add_flow(holoviz_output_format_converter,
+               encoder_input_format_converter,
+               {{"tensor", "source_video"}});
+      add_flow(encoder_input_format_converter, tensor_to_video_buffer, {{"tensor", "in_tensor"}});
+      add_flow(
+          tensor_to_video_buffer, video_encoder_request, {{"out_video_buffer", "input_frame"}});
+      add_flow(video_encoder_response, bitstream_writer, {{"output_transmitter", "data_receiver"}});
     }
   }
 
@@ -197,13 +184,9 @@ class App : public holoscan::Application {
 
 /** Helper function to parse the command line arguments */
 bool parse_arguments(int argc, char** argv, std::string& config_name, std::string& data_path) {
-  static struct option long_options[] = {
-      {"data",    required_argument, 0,  'd' },
-      {0,         0,                 0,  0 }
-  };
+  static struct option long_options[] = {{"data", required_argument, 0, 'd'}, {0, 0, 0, 0}};
 
-  while (int c = getopt_long(argc, argv, "d",
-                   long_options, NULL))  {
+  while (int c = getopt_long(argc, argv, "d", long_options, NULL)) {
     if (c == -1 || c == '?') break;
 
     switch (c) {
@@ -216,9 +199,7 @@ bool parse_arguments(int argc, char** argv, std::string& config_name, std::strin
     }
   }
 
-  if (optind < argc) {
-    config_name = argv[optind++];
-  }
+  if (optind < argc) { config_name = argv[optind++]; }
   return true;
 }
 
@@ -229,9 +210,7 @@ int main(int argc, char** argv) {
   // Parse the arguments
   std::string data_path = "";
   std::string config_name = "";
-  if (!parse_arguments(argc, argv, config_name, data_path)) {
-    return 1;
-  }
+  if (!parse_arguments(argc, argv, config_name, data_path)) { return 1; }
 
   if (config_name != "") {
     app->config(config_name);

--- a/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor.cpp
+++ b/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor.cpp
@@ -75,14 +75,13 @@ class PyToolTrackingPostprocessorOp : public ToolTrackingPostprocessorOp {
       Fragment* fragment, const py::args& args, std::shared_ptr<Allocator> device_allocator,
       std::shared_ptr<Allocator> host_allocator, float min_prob = 0.5f,
       std::vector<std::vector<float>> overlay_img_colors = VIZ_TOOL_DEFAULT_COLORS,
-      std::shared_ptr<holoscan::CudaStreamPool> cuda_stream_pool =
-          std::shared_ptr<holoscan::CudaStreamPool>(),
+      std::shared_ptr<holoscan::CudaStreamPool> cuda_stream_pool = nullptr,
       const std::string& name = "tool_tracking_postprocessor")
       : ToolTrackingPostprocessorOp(ArgList{Arg{"device_allocator", device_allocator},
                                             Arg{"host_allocator", host_allocator},
                                             Arg{"min_prob", min_prob},
-                                            Arg{"overlay_img_colors", overlay_img_colors},
-                                            Arg{"cuda_stream_pool", cuda_stream_pool}}) {
+                                            Arg{"overlay_img_colors", overlay_img_colors}}) {
+    if (cuda_stream_pool) { this->add_arg(Arg{"cuda_stream_pool", cuda_stream_pool}); }
     add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;
@@ -128,12 +127,8 @@ PYBIND11_MODULE(_tool_tracking_postprocessor, m) {
            "host_allocator"_a,
            "min_prob"_a = 0.5f,
            "overlay_img_colors"_a = VIZ_TOOL_DEFAULT_COLORS,
-           "cuda_stream_pool"_a = std::shared_ptr<holoscan::CudaStreamPool>(),
+           "cuda_stream_pool"_a = py::none(),
            "name"_a = "tool_tracking_postprocessor"s,
-           doc::ToolTrackingPostprocessorOp::doc_ToolTrackingPostprocessorOp_python)
-      .def("setup",
-           &ToolTrackingPostprocessorOp::setup,
-           "spec"_a,
-           doc::ToolTrackingPostprocessorOp::doc_setup);
+           doc::ToolTrackingPostprocessorOp::doc_ToolTrackingPostprocessorOp_python);
 }  // PYBIND11_MODULE NOLINT
 }  // namespace holoscan::ops

--- a/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor.cpp
+++ b/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor.cpp
@@ -97,8 +97,7 @@ PYBIND11_MODULE(_tool_tracking_postprocessor, m) {
         .. currentmodule:: _tool_tracking_postprocessor
         .. autosummary::
            :toctree: _generate
-           add
-           subtract
+           ToolTrackingPostprocessorOp
     )pbdoc";
 
 #ifdef VERSION_INFO
@@ -113,7 +112,7 @@ PYBIND11_MODULE(_tool_tracking_postprocessor, m) {
              std::shared_ptr<ToolTrackingPostprocessorOp>>(
       m,
       "ToolTrackingPostprocessorOp",
-      doc::ToolTrackingPostprocessorOp::doc_ToolTrackingPostprocessorOp)
+      doc::ToolTrackingPostprocessorOp::doc_ToolTrackingPostprocessorOp_python)
       .def(py::init<Fragment*,
                     const py::args&,
                     std::shared_ptr<Allocator>,

--- a/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor_pydoc.hpp
+++ b/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor_pydoc.hpp
@@ -68,23 +68,6 @@ cuda_stream_pool : ``holoscan.resources.CudaStreamPool``, optional
 name : str, optional
     The name of the operator.
 )doc")
-
-PYDOC(initialize, R"doc(
-Initialize the operator.
-
-This method is called only once when the operator is created for the first time,
-and uses a light-weight initialization.
-)doc")
-
-PYDOC(setup, R"doc(
-Define the operator specification.
-
-Parameters
-----------
-spec : ``holoscan.core.OperatorSpec``
-    The operator specification.
-)doc")
-
 }  // namespace ToolTrackingPostprocessorOp
 
 

--- a/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor_pydoc.hpp
+++ b/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor_pydoc.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,6 +34,21 @@ Operator performing post-processing for the endoscopy tool tracking demo.
 PYDOC(ToolTrackingPostprocessorOp_python, R"doc(
 Operator performing post-processing for the endoscopy tool tracking demo.
 
+**==Named Inputs==**
+
+    in : nvidia::gxf::Entity containing multiple nvidia::gxf::Tensor
+        Must contain input tensors named "probs", "scaled_coords" and "binary_masks" that
+        correspond to the output of the LSTMTensorRTInfereceOp as used in the endoscopy
+        tool tracking example applications.
+
+**==Named Outputs==**
+
+    out_coords : nvidia::gxf::Tensor
+        Coordinates tensor, stored on the host (CPU).
+
+    out_mask : nvidia::gxf::Tensor
+        Binary mask tensor, stored on device (GPU).
+
 Parameters
 ----------
 fragment : Fragment
@@ -43,11 +58,13 @@ device_allocator : ``holoscan.resources.Allocator``
 host_allocator : ``holoscan.resources.Allocator``
     Output allocator used on the host side.
 min_prob : float, optional
-    Minimum probability (in range [0, 1]).
+    Minimum probability (in range [0, 1]). Default value is 0.5.
 overlay_img_colors : sequence of sequence of float, optional
     Color of the image overlays, a list of RGB values with components between 0 and 1.
+    The default value is a qualitative colormap with a sequence of 12 colors.
 cuda_stream_pool : ``holoscan.resources.CudaStreamPool``, optional
-    CudaStreamPool instance to allocate CUDA streams.
+    `holoscan.resources.CudaStreamPool` instance to allocate CUDA streams.
+    Default value is ``None``.
 name : str, optional
     The name of the operator.
 )doc")

--- a/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor_pydoc.hpp
+++ b/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor_pydoc.hpp
@@ -26,10 +26,6 @@ namespace holoscan::doc {
 
 namespace ToolTrackingPostprocessorOp {
 
-PYDOC(ToolTrackingPostprocessorOp, R"doc(
-Operator performing post-processing for the endoscopy tool tracking demo.
-)doc")
-
 // PyToolTrackingPostprocessorOp Constructor
 PYDOC(ToolTrackingPostprocessorOp_python, R"doc(
 Operator performing post-processing for the endoscopy tool tracking demo.

--- a/operators/tool_tracking_postprocessor/tool_tracking_postprocessor.hpp
+++ b/operators/tool_tracking_postprocessor/tool_tracking_postprocessor.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,38 @@
 
 namespace holoscan::ops {
 
+/**
+ * @brief Post-processing operator for tool tracking inference with LSTMTensorRTInferenceOp.
+ *
+ * ==Named Inputs==
+ *
+ * - **in** : `nvidia::gxf::Entity` containing multiple `nvidia::gxf::Tensor`
+ *   - Must contain input tensors named "probs", "scaled_coords" and "binary_masks" that
+ *     correspond to the output of the LSTMTensorRTInfereceOp as used in the endoscopy
+ *     tool tracking example applications.
+ *
+ * ==Named Outputs==
+ *
+ * - **out_coords** : `nvidia::gxf::Tensor`
+ *   - Coordinates tensor, stored on the host (CPU).
+ *
+ * - **out_mask** : `nvidia::gxf::Tensor`
+ *   - Binary mask tensor, stored on device (GPU).
+ *
+ * ==Parameters==
+ *
+ * - **host_allocator**: The holoscan::Allocator class (e.g. UnboundedAllocator) use for host
+ *   memory allocation of the `out_coords` tensor.
+ * - **device_allocator**: The holoscan::Allocator class (e.g. UnboundedAllocator or
+ *   BlockMemoryPool) used for device memory allocation for the `out_mask` tensor.
+ * - **min_prob**: Minimum probability threshold used by the operator.
+ *   Optional (default: 0.5).
+ * - **overlay_img_colors**: A `vector<vector<float>>` where each inner vector is a set of three
+ *   floats corresponding to normalized RGB values in range [0, 1.0].
+ *   Optional (default: a 12-class qualitative color scheme).
+ * - **cuda_stream_pool**: `holoscan::CudaStreamPool` instance to allocate CUDA streams.
+ *   Optional (default: `nullptr`).
+ */
 class ToolTrackingPostprocessorOp : public holoscan::Operator {
  public:
   HOLOSCAN_OPERATOR_FORWARD_ARGS(ToolTrackingPostprocessorOp)
@@ -41,7 +73,8 @@ class ToolTrackingPostprocessorOp : public holoscan::Operator {
 
  private:
   Parameter<holoscan::IOSpec*> in_;
-  Parameter<holoscan::IOSpec*> out_;
+  Parameter<holoscan::IOSpec*> out_coords_;
+  Parameter<holoscan::IOSpec*> out_mask_;
 
   Parameter<float> min_prob_;
   Parameter<std::vector<std::vector<float>>> overlay_img_colors_;

--- a/tutorials/creating-multi-node-applications/scenario2/endoscopy_distributed_app.py
+++ b/tutorials/creating-multi-node-applications/scenario2/endoscopy_distributed_app.py
@@ -184,7 +184,11 @@ class Fragment1(Fragment):
 
         # Flow definition
         self.add_flow(lstm_inferer, tool_tracking_postprocessor, {("tensor", "in")})
-        self.add_flow(tool_tracking_postprocessor, visualizer, {("out", "receivers")})
+        self.add_flow(
+            tool_tracking_postprocessor,
+            visualizer,
+            {("out_coords", "receivers"), ("out_mask", "receivers")},
+        )
         self.add_flow(
             source,
             format_converter,


### PR DESCRIPTION
## Description
This MR makes some updates to the existing `ToolTrackingPostprocessorOp`. The behavior of the operator is the same as before **except** that the coordinate and mask tensors are now emitted on separate ports. This is done to enable compatibility of this operator with connection between fragments in a distributed application. For distributed apps, it is not allowed to transmit a mixture of host and device tensors on the same port.

This is not backwards compatible, but the changes needed on the application side are small (just changing one `add_flow` call as done here for Holohub's apps). There likely may not be any apps outside of Holohub using this operator as it is pretty specific to the tool tracking model used in the endoscopy examples.

## List of changes
* split the former `out` port into separate `out_coords` and `out_mask` ports (to separate CPU and GPU tensors for distributed app compatibility)
* document the input and output ports in the documentation strings
* document parameters in the C++ doxygen string
* clang-format was applied to modified C++ files (most changes in the H264 app are due to that)

## Tests done
I ran both the C++ and Python versions of the endoscopy tool tracking application and they continue to work as before. 

There is not currently a distributed version of this app on Holohub to verify that this fixes use in distributed applications. However, it is known that the UCX API used by `UcxTransmitter` cannot mix host and device tensors. Given that, it is necessary to use separate ports for host vs. device tensors as done here (in Holoscan SDK, each port has its own, independent transmitter).
