### PR TITLE
Build: Update benchmarking dependencies in container Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,9 @@ RUN apt update \
     && apt install --no-install-recommends -y \
     libcairo2-dev \
     libgirepository1.0-dev \
-    gobject-introspection
+    gobject-introspection \
+    libgtk-3-dev \
+    libcanberra-gtk-module \
+    graphviz
 COPY tutorials/holoscan_flow_benchmarking/requirements.txt /tmp/benchmarking_requirements.txt
 RUN pip install -r /tmp/benchmarking_requirements.txt


### PR DESCRIPTION

Updates the default HoloHub container Dockerfile to install a complete
list of dependencies to use flow benchmarking tools.

The Holoscan Flow Benchmarking tutorial was updated in https://github.com/nvidia-holoscan/holohub/commit/86e980098e5ca0f11d813ad597499e59d11f896c to
include the `pydot` and `xdot` Python packages in its requirements.
`pydot` has a transitive dependency on `graphviz`, while `xdot` has a
GUI dependency on GTK and canberra-gtk along with `graphviz`.

With these changes applied I was able to follow the benchmarking
tutorial to view visual graphs of my application flow latency via the
HoloHub container.