### PR TITLE
Tutorial: Add flow benchmarking support for Python applications

### DIFF
--- a/tutorials/holoscan_flow_benchmarking/benchmark.py
+++ b/tutorials/holoscan_flow_benchmarking/benchmark.py
@@ -97,9 +97,17 @@ def main():
         "--holohub-application",
         type=str,
         required=False,
-        help="name of HoloHub application to run. It runs the cpp version of an application\n\
-To run a python application, use --run-command option.",
+        help="name of HoloHub application to run",
         default="endoscopy_tool_tracking",
+    )
+
+    parser.add_argument(
+        "--language",
+        type=str,
+        required=False,
+        help="Application language to run. Runs cpp version of an application by default. "
+        "Must also specify an application to run with an argument to '-a' or '--holohub-application'.",
+        default="cpp",
     )
 
     parser.add_argument(
@@ -204,7 +212,7 @@ assignment in Holoscan's Inference operator.",
         env["HOLOSCAN_NUM_SOURCE_MESSAGES"] = str(args.num_messages)
 
     if args.run_command == "":
-        app_launch_command = "./run launch " + args.holohub_application + " cpp"
+        app_launch_command = "./run launch " + args.holohub_application + " " + args.language
     else:
         app_launch_command = args.run_command
 


### PR DESCRIPTION
Adds support for benchmarking Python applications in HoloHub as a parameter to the Holoscan Flow Benchmarking tutorial `benchmark.py` script.

Under previous behavior the benchmarking script primarily supported only HoloHub C++ applications. The recommended path to benchmark Python applications was to pass the full command string to "--run-command". This approach disallowed use of the "run" script that provides infrastructure for environment setup and working directory management. As a result, in practice "--run-command" alone required manual setup of the environment and working directory, i.e. several extra steps on the user's part.

This update allows users to launch a Python application with the "run" script to minimize additional user effort. The "--language" argument is forwarded to the "run" script which executes as otherwise recommended in HoloHub instructions. The "--run-command" parameter is left intact.