### PR TITLE
Update CUDA stream handler includes and function names

### DIFF
--- a/operators/npp_filter/npp_filter.cpp
+++ b/operators/npp_filter/npp_filter.cpp
@@ -75,7 +75,7 @@ void NppFilterOp::setup(OperatorSpec& spec) {
   spec.input<holoscan::gxf::Entity>("input");
   spec.output<holoscan::gxf::Entity>("output");
 
-  cuda_stream_handler_.defineParams(spec);
+  cuda_stream_handler_.define_params(spec);
 }
 
 void NppFilterOp::compute(InputContext& op_input, OutputContext& op_output,
@@ -86,13 +86,13 @@ void NppFilterOp::compute(InputContext& op_input, OutputContext& op_output,
   auto& entity = static_cast<nvidia::gxf::Entity&>(maybe_entity.value());
 
   // get the CUDA stream from the input message
-  gxf_result_t stream_handler_result = cuda_stream_handler_.fromMessage(context.context(), entity);
+  gxf_result_t stream_handler_result = cuda_stream_handler_.from_message(context.context(), entity);
   if (stream_handler_result != GXF_SUCCESS) {
     throw std::runtime_error("Failed to get the CUDA stream from incoming messages");
   }
 
   // assign the CUDA stream to the NPP stream context
-  npp_stream_ctx_->hStream = cuda_stream_handler_.getCudaStream(context.context());
+  npp_stream_ctx_->hStream = cuda_stream_handler_.get_cuda_stream(context.context());
 
   nvidia::gxf::VideoBufferInfo in_video_buffer_info{};
   void* in_pointer;
@@ -286,7 +286,7 @@ void NppFilterOp::compute(InputContext& op_input, OutputContext& op_output,
   }
 
   // pass the CUDA stream to the output message
-  stream_handler_result = cuda_stream_handler_.toMessage(out_message);
+  stream_handler_result = cuda_stream_handler_.to_message(out_message);
   if (stream_handler_result != GXF_SUCCESS) {
     throw std::runtime_error("Failed to add the CUDA stream to the outgoing messages");
   }

--- a/operators/orsi/orsi_format_converter/format_converter.cpp
+++ b/operators/orsi/orsi_format_converter/format_converter.cpp
@@ -232,13 +232,13 @@ void FormatConverterOp::compute(InputContext& op_input, OutputContext& op_output
 
   // get the CUDA stream from the input message
   gxf_result_t stream_handler_result =
-      cuda_stream_handler_.fromMessage(context.context(), in_message);
+      cuda_stream_handler_.from_message(context.context(), in_message);
   if (stream_handler_result != GXF_SUCCESS) {
     throw std::runtime_error("Failed to get the CUDA stream from incoming messages");
   }
 
   // assign the CUDA stream to the NPP stream context
-  npp_stream_ctx_.hStream = cuda_stream_handler_.getCudaStream(context.context());
+  npp_stream_ctx_.hStream = cuda_stream_handler_.get_cuda_stream(context.context());
 
   nvidia::gxf::Shape out_shape{0, 0, 0};
   void* in_tensor_data = nullptr;
@@ -479,7 +479,7 @@ void FormatConverterOp::compute(InputContext& op_input, OutputContext& op_output
   }
 
   // pass the CUDA stream to the output message
-  stream_handler_result = cuda_stream_handler_.toMessage(out_message);
+  stream_handler_result = cuda_stream_handler_.to_message(out_message);
   if (stream_handler_result != GXF_SUCCESS) {
     throw std::runtime_error("Failed to add the CUDA stream to the outgoing messages");
   }
@@ -934,7 +934,7 @@ void FormatConverterOp::setup(OperatorSpec& spec) {
 
   spec.param(allocator_, "allocator", "Allocator", "Output Allocator");
 
-  cuda_stream_handler_.defineParams(spec);
+  cuda_stream_handler_.define_params(spec);
 
   // TODO (gbae): spec object holds an information about errors
   // TODO (gbae): incorporate std::expected to not throw exceptions

--- a/operators/orsi/orsi_segmentation_postprocessor/segmentation_postprocessor.cpp
+++ b/operators/orsi/orsi_segmentation_postprocessor/segmentation_postprocessor.cpp
@@ -84,7 +84,7 @@ void SegmentationPostprocessorOp::setup(OperatorSpec& spec) {
              "Output image size after resize",
              "Output image size [ width, height ] after resize");
 
-  cuda_stream_handler_.defineParams(spec);
+  cuda_stream_handler_.define_params(spec);
 
   // TODO (gbae): spec object holds an information about errors
   // TODO (gbae): incorporate std::expected to not throw exceptions
@@ -115,7 +115,7 @@ void SegmentationPostprocessorOp::compute(InputContext& op_input, OutputContext&
 
   // get the CUDA stream from the input message
   gxf_result_t stream_handler_result =
-      cuda_stream_handler_.fromMessage(context.context(), in_message);
+      cuda_stream_handler_.from_message(context.context(), in_message);
   if (stream_handler_result != GXF_SUCCESS) {
     throw std::runtime_error("Failed to get the CUDA stream from incoming messages");
   }
@@ -213,7 +213,7 @@ void SegmentationPostprocessorOp::compute(InputContext& op_input, OutputContext&
                    shape,
                    in_tensor_data,
                    post_process_output_buffer,
-                   cuda_stream_handler_.getCudaStream(context.context()));
+                   cuda_stream_handler_.get_cuda_stream(context.context()));
 
   if (roi_enabled) {
     // ------------------------------------------------------------------------
@@ -264,7 +264,7 @@ void SegmentationPostprocessorOp::compute(InputContext& op_input, OutputContext&
   }
 
   // pass the CUDA stream to the output message
-  stream_handler_result = cuda_stream_handler_.toMessage(out_message);
+  stream_handler_result = cuda_stream_handler_.to_message(out_message);
   if (stream_handler_result != GXF_SUCCESS) {
     throw std::runtime_error("Failed to add the CUDA stream to the outgoing messages");
   }

--- a/operators/orsi/orsi_segmentation_preprocessor/segmentation_preprocessor.cpp
+++ b/operators/orsi/orsi_segmentation_preprocessor/segmentation_preprocessor.cpp
@@ -112,7 +112,7 @@ void SegmentationPreprocessorOp::setup(OperatorSpec& spec) {
 
   spec.param(allocator_, "allocator", "Allocator", "Output Allocator");
 
-  cuda_stream_handler_.defineParams(spec);
+  cuda_stream_handler_.define_params(spec);
 
   // TODO (gbae): spec object holds an information about errors
   // TODO (gbae): incorporate std::expected to not throw exceptions
@@ -133,7 +133,7 @@ void SegmentationPreprocessorOp::compute(InputContext& op_input, OutputContext& 
   auto in_tensor = getTensorByName(in_message, in_tensor_name);
   // get the CUDA stream from the input message
   gxf_result_t stream_handler_result =
-      cuda_stream_handler_.fromMessage(context.context(), in_message);
+      cuda_stream_handler_.from_message(context.context(), in_message);
   if (stream_handler_result != GXF_SUCCESS) {
     throw std::runtime_error("Failed to get the CUDA stream from incoming messages");
   }
@@ -190,7 +190,7 @@ void SegmentationPreprocessorOp::compute(InputContext& op_input, OutputContext& 
                   stds_cuda_);
 
   // pass the CUDA stream to the output message
-  stream_handler_result = cuda_stream_handler_.toMessage(out_message);
+  stream_handler_result = cuda_stream_handler_.to_message(out_message);
   if (stream_handler_result != GXF_SUCCESS) {
     throw std::runtime_error("Failed to add the CUDA stream to the outgoing messages");
   }

--- a/operators/orsi/orsi_visualizer/orsi_visualizer.cpp
+++ b/operators/orsi/orsi_visualizer/orsi_visualizer.cpp
@@ -146,7 +146,7 @@ void OrsiVisualizationOp::setup(OperatorSpec& spec) {
 
   pimpl_->setup(spec);
 
-  cuda_stream_handler_.defineParams(spec);
+  cuda_stream_handler_.define_params(spec);
 }
 
 void OrsiVisualizationOp::initialize() {
@@ -251,7 +251,7 @@ void OrsiVisualizationOp::compute(InputContext& op_input, OutputContext& op_outp
   }
 
      // get the CUDA stream from the input message
-  const gxf_result_t result = cuda_stream_handler_.fromMessages(context.context(), messages);
+  const gxf_result_t result = cuda_stream_handler_.from_messages(context.context(), messages);
   if (result != GXF_SUCCESS) {
     throw std::runtime_error("Failed to get the CUDA stream from incoming messages");
   }


### PR DESCRIPTION
The CudaStreamHandler's API has been updated to use underscores, causing warning messages when the old method names are used, starting from version 1.0.

```
[warning] [cuda_stream_handler.cpp:86] CudaStreamHandler's `fromMessage` method has been renamed to `from_message`. The old name is deprecated and may be removed in a future release.
[warning] [cuda_stream_handler.cpp:224] CudaStreamHandler's `getCudaStream` method has been renamed to `get_cuda_stream`. The old name is deprecated and may be removed in a future release.
...
```

This pull request updates the CUDA stream handler includes and function names in the lstm_tensor_rt_inference, npp_filter, orsi_format_converter, orsi_segmentation_postprocessor, orsi_segmentation_preprocessor, orsi_visualizer, qt_video, and tool_tracking_postprocessor operators to use the new `holoscan/utils/cuda_stream_handler.hpp` header and the new function names with underscores.

The changes include:

1. Replace the include path of the cuda_stream_handler.hpp header from `../utils/cuda_stream_handler.hpp` to `holoscan/utils/cuda_stream_handler.hpp`
2. Replace the function names of the CudaStreamHandler class with the new ones using underscores, such as `defineParams` to `define_params`, `fromMessage` to `from_message`, `getCudaStream` to `get_cuda_stream`, and `toMessage` to `to_message`.
3. These changes improve the consistency and readability of the CUDA stream handler usage in the operators and align with the new naming conventions of the `holoscan/utils/cuda_stream_handler.hpp` header.
