### PR TITLE
Infra: Detect custom Dockerfile in `build_and_run` command

### DIFF
--- a/applications/README.md
+++ b/applications/README.md
@@ -7,3 +7,51 @@ metadata.json and/or README.md for each application.
 # Contributing to HoloHub Applications
 
 Please review the [CONTRIBUTING.md file](https://github.com/nvidia-holoscan/holohub/blob/main/CONTRIBUTING.md) guidelines to contribute applications.
+
+# HoloHub Application Organization Conventions
+
+## Required Conventions
+
+We expect that an application contributed to HoloHub conforms to the following organization:
+
+- Each project must provide a `metadata.json` file reflecting several key components such as the application name and description, authors, dependencies, and the primary project language. 
+- Each project must provide a `README` or `README.md` file.
+- Each project must be organized in its own subfolder under `holohub/applications/`.
+
+See the [HoloHub application template](./template/) for example `README` and `metadata.json` documents to get started.
+
+## Recommended Conventions
+
+Contributors may additionally opt to lay out their project structure in a way that conforms to HoloHub conventions in order to enable common infrastructure for their project, including streamlined build and run support in the [`dev_container`](../dev_container) and [`run`](../run) scripts and search support on the HoloHub landing page.
+
+If your code does not adhere to these conventions, please set the field `manual_setup` to `true` in your project `metadata.json` file to opt out and indicate that your project is not eligible for streamlined infrastructure support.
+
+HoloHub recommended application convention is as follows:
+- Languages
+  - Project is either C++ or Python language
+  - If multiple language implementations are provided, each must be added to its own language subfolder as follows:
+```
+applications/
+  └── my_project/
+        ├── cpp/
+        │     ├── ...
+        │     └── ...
+        └── python/
+              ├── ...
+              └── ...
+```
+
+- Container Environment
+  - Project may provide its own container environment or opt to use the default HoloHub environment
+  - If the project specifies its own container:
+    - Default project environment must be named `Dockerfile`
+    - Project `Dockerfile` must be located at either:
+      - The same directory as `metadata.json`, or
+      - If the project defines a language directory (`cpp`, `python`), may provide at the project folder one level above, or
+      - The project may provide an alternative default Dockerfile path in `metadata.json`
+  - If the project does not specify a `Dockerfile` then the [default HoloHub `Dockerfile`](../Dockerfile) will be used
+
+- Build and Run Instructions
+  - Must provide a run command in `metadata.json` for `./run launch` to reference
+  - Must otherwise comply with `./dev_container build_and_run` command options for the default use case
+  - Advanced instructions may also be specified in the project README

--- a/applications/metadata.schema.json
+++ b/applications/metadata.schema.json
@@ -36,6 +36,9 @@
         "dependencies": {
           "$ref": "holohub/project/v1#/$defs/dependencies"
         },
+        "dockerfile": {
+          "type": "string"
+        },
         "run": {
           "$ref": "holohub/project/v1#/$defs/run_command"
         }

--- a/dev_container
+++ b/dev_container
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -277,7 +277,7 @@ get_default_img() {
 
 build_desc() { c_echo 'Build dev image
     --base_img : Fully qualified base image name, e.g. holoscan-sdk-dev:latest
-    --docker_file :  path to Dockerfile to use for building container
+    --docker_file :  path to Dockerfile to use for building container.
     --img : Specify fully qualified container name
     --verbose : Print variables passed to docker build command
     '
@@ -654,12 +654,16 @@ build_and_run_desc() { c_echo 'Build and run a requested application in a Docker
     Options:
         --base_img : Fully qualified base image name, e.g. holoscan-sdk-dev:latest
         --docker_file : Path to Dockerfile to use for building container.
+            Defaults to:
+            - Application-provided "Dockerfile", if it exists;
+            - Otherwise the top-level HoloHub "Dockerfile"
             If `--img` is not specified then a custom image tag will be defined.
         --img : Specify fully qualified output container name
         --language : Specify the app language implementation to run.
                      Some applications provide both `cpp` and `python` implementations.
         --no_build : Launch the app without attempting to build it first
         --verbose : Print extra output to console
+        --dryrun : View build and run commands without doing anything
     '
 }
 
@@ -682,14 +686,13 @@ build_and_run() {
            container_build_args+=" --base_img ${ARGS[i+1]}"
         elif [ "$arg" = "--docker_file" ]; then
             docker_file="${ARGS[i+1]}"
-            container_build_args+=" --docker_file $docker_file"
         elif [ "$arg" = "--img" ]; then
             image_name="${ARGS[i+1]}"
         elif [ "$arg" = "--no_build" ]; then
             build_app=0
         elif [ "$arg" = "--verbose" ]; then
-           container_build_args+=" --verbose"
-           container_launch_args+=" --verbose"
+            container_build_args+=" --verbose"
+            container_launch_args+=" --verbose"
         elif [ "$arg" = "--language" ]; then
             app_language="${ARGS[i+1]}"
         elif [ -z "${app_name}" ]; then
@@ -701,9 +704,14 @@ build_and_run() {
         fatal "Must specify a HoloHub application to build and run."
     fi
 
-    if [ -z "$image_name" ]; then
-        if [ -n "$docker_file" ]; then
-            image_name="holohub:${app_name}";
+    if [[ -z "${docker_file}" ]]; then
+        docker_file=$(./run get_app_dockerfile ${app_name} ${app_language:-cpp})
+    fi
+
+    if [[ -z "$image_name" ]]; then
+        if [[ -n "${docker_file}" ]] && [[ "${docker_file}" != "${SCRIPT_DIR}/Dockerfile" ]]; then
+            image_name="holohub:${app_name}"
+            container_build_args+=" --docker_file $docker_file";
         else
             image_name=$(get_default_img);
         fi
@@ -712,11 +720,11 @@ build_and_run() {
     container_build_args+=" --img $image_name"
     container_launch_args+=" --img $image_name"
 
-    build $container_build_args
+    run_command ${SCRIPT_DIR}/dev_container build $container_build_args
     if [[ $build_app == 1 ]]; then
-        launch $container_launch_args -c "./run build $app_name"
+        run_command ${SCRIPT_DIR}/dev_container launch $container_launch_args -c "./run build $app_name"
     fi
-    launch $container_launch_args -c "./run launch $app_name $app_language"
+    run_command ${SCRIPT_DIR}/dev_container launch $container_launch_args -c "./run launch $app_name $app_language"
 }
 
 

--- a/run
+++ b/run
@@ -641,7 +641,7 @@ build() {
   cmake_extra_args="--no-warn-unused-cli -DPython3_EXECUTABLE=${HOLOHUB_PY_EXE} -DPython3_ROOT_DIR=${HOLOHUB_PY_LIB}"
 
   # We set the data directory to be outside the build directory
-  cmake_extra_args="$cmake_extra_args $configure_args -DHOLOHUB_DATA_DIR=${SCRIPT_DIR}/data"
+  cmake_extra_args="$cmake_extra_args $configure_args -DHOLOHUB_DATA_DIR:PATH=${SCRIPT_DIR}/data"
 
   # Sets the default path for cuda
   export PATH=$PATH:/usr/local/cuda/bin

--- a/run
+++ b/run
@@ -707,8 +707,6 @@ launch() {
    local holoscan_sdk_install=$(grep -Po '^holoscan_DIR:PATH=\K[^ ]*' build/CMakeCache.txt)
    local holohub_data_dir=$(grep -Po '^HOLOHUB_DATA_DIR:PATH=\K[^ ]*' build/CMakeCache.txt)
 
-   local holohub_app_bin="${holohub_build_dir}/applications/${appname}"
-
    if [[ -z "${language}" ]]; then
      language=$(get_app_default_language "${appname}")
      language=${language:-cpp}
@@ -724,11 +722,6 @@ launch() {
      exit 1
    fi
 
-   # Checks if the application is organized in a language subfolder
-   if [[ "${holohub_app_source}" =~ .*${language}$ ]]; then
-     holohub_app_bin="${holohub_build_dir}/applications/${appname}/${language}"
-   fi
-
    # Check if the metadata file exists
    local metadata_file="${holohub_app_source}/metadata.json"
    if [ ! -f "$metadata_file" ]; then
@@ -738,6 +731,7 @@ launch() {
      exit 1
    fi
 
+   holohub_app_bin="${holohub_build_dir}/${holohub_app_source#"$SCRIPT_DIR/"}"
    # Check if the build directory exists (for C++ apps)
    if [ ! -d "$holohub_app_bin" ] &&  [ "$2" == "cpp" ]; then
      print_error "The build directory for this application does not exist."

--- a/run
+++ b/run
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -108,6 +108,95 @@ get_buildtype_str() {
     esac
 
     echo -n "${build_type_str}"
+}
+
+
+get_app_source_root_dir() {
+  # Get source path for a given application according to HoloHub convention.
+  # Usage: ./run get_app_source_root_dir <app_name>
+  local appname="$1"
+  if [[ -z "${appname}" ]]; then
+    echo "Missing app name argument for get_app_source_root_dir"
+    exit 1
+  fi
+
+  holohub_app_source="${SCRIPT_DIR}/applications/${appname}"
+
+  # Check if the application is in a subdirectory
+  if [ ! -d "$holohub_app_source" ]; then
+    sub_app_path=$(find ${SCRIPT_DIR}/applications -type d -name "${appname}")
+    app_rel_path=${sub_app_path#"${SCRIPT_DIR}/applications/"}
+    if [[ -n "$app_rel_path" ]]; then
+      holohub_app_source="${SCRIPT_DIR}/applications/${app_rel_path}"
+    else
+      echo "Could not find subproject ${appname}"
+      exit 1
+    fi
+  fi
+
+  echo -n "${holohub_app_source}"
+}
+
+get_app_source_lang_dir() {
+  # Get source path for a given application language implementation according to HoloHub convention.
+  # If a project defines more than one language implementation it must define one subfolder per language,
+  # otherwise the implementation may be provided at the top level or in a subfolder at the contributor's discretion.
+  # Usage: ./run get_app_source_lang_dir <app_name> <language>
+  local appname="$1"
+  local language="$2"
+
+  local holohub_app_source=$(get_app_source_root_dir "${appname}")
+  if [[ -n "${holohub_app_source}" ]] && [[ -d "${holohub_app_source}/${language}" ]]; then
+    holohub_app_source="${holohub_app_source}/${language}"
+  fi
+
+  echo -n "${holohub_app_source}"
+}
+
+get_app_dockerfile() {
+  # Parse the path to a custom application Dockerfile, if provided.
+  # Follows the HoloHub convention:
+  # 1. Check the metadata.json file for a "dockerfile" entry.
+  # 2. Check for a Dockerfile in the application language implementation directory.
+  # 3. Check for a Dockerfile in the root application directory.
+  # 4. Use the default Dockerfile provided at the top level of the HoloHub repository.
+  # Usage: ./run get_app_dockerfile <app_name> <language>
+  local appname="$1"
+  local language="$2"
+  local dockerfile_path=""
+
+  local app_source_root_path=$(get_app_source_root_dir ${appname})
+  local app_source_lang_path=$(get_app_source_lang_dir ${appname} ${language})
+
+  local dockerfile_entry=$(cat "${app_source_lang_path}/metadata.json" | grep "dockerfile")
+  if [[ -n "${dockerfile_entry}" ]]; then
+    pattern="s#<holohub_app_source>#${app_source_lang_path}#g"
+    dockerfile_path=$(echo "${dockerfile_entry}" | awk -F'["]' '{ print $4 }' | sed -E ${pattern})
+  elif [[ -f "${app_source_lang_path}/Dockerfile" ]]; then
+    dockerfile_path="${app_source_lang_path}/Dockerfile"
+  elif [[ -f "${app_source_root_path}/Dockerfile" ]]; then
+    dockerfile_path="${app_source_root_path}/Dockerfile"
+  else
+    dockerfile_path="${SCRIPT_DIR}/Dockerfile"
+  fi
+
+  echo -n "${dockerfile_path}"
+}
+
+get_app_default_language() {
+  # If a language was not provided but multiple are available, auto-select
+  # the first language matching the app name from the "./run list" command.
+  # Yields an empty string if a language folder is not specified.
+  # Example `list` string:
+  # ultrasound_segmentation (cpp) [Sample Application]
+  # Usage: ./run get_app_default_language <app_name>
+  appname="$1"
+
+  if [ -z "${language}" ]; then
+    language=$(list | grep -m 1 ${appname} | awk -F'[\\(\\)]' '{print $2}')
+  fi
+
+  echo -e "${language}"
 }
 
 
@@ -617,39 +706,31 @@ launch() {
 
    local holoscan_sdk_install=$(grep -Po '^holoscan_DIR:PATH=\K[^ ]*' build/CMakeCache.txt)
    local holohub_data_dir=$(grep -Po '^HOLOHUB_DATA_DIR:PATH=\K[^ ]*' build/CMakeCache.txt)
-   local holohub_app_source="${SCRIPT_DIR}/applications/${appname}"
-
-   # Check if the application is in a subdirectory
-   if [ ! -d "$holohub_app_source" ]; then
-     sub_app=$(find ${SCRIPT_DIR}/applications -type d -name "${appname}")
-     appname=${sub_app#"${SCRIPT_DIR}/applications/"}
-     if [[ "$appname" != "" ]]; then
-       holohub_app_source="${SCRIPT_DIR}/applications/${appname}"
-     fi
-   fi
 
    local holohub_app_bin="${holohub_build_dir}/applications/${appname}"
-   local metadata_file="${holohub_app_source}/metadata.json"
 
-   # If a language was not provided but multiple are available, auto-select
-   # the first language matching the app name from the "./run list" command.
-   # Yields an empty string if a language folder is not specified.
-   # Example `list` string:
-   # ultrasound_segmentation (cpp) [Sample Application]
-   if [ -z "${language}" ]; then
-     language=$(list | grep -m 1 ${appname} | awk -F'[\\(\\)]' '{print $2}')
-     if [[ "${language}" ]]; then
+   if [[ -z "${language}" ]]; then
+     language=$(get_app_default_language "${appname}")
+     language=${language:-cpp}
+     if [[ -n "${language}" ]]; then
        echo "Default language for ${appname} selected: ${language}"
      fi
    fi
 
-   if [[ "${language}" ]]; then
-     metadata_file="${holohub_app_source}/${language}/metadata.json"
+   holohub_app_source=$(get_app_source_lang_dir "${appname}" "${language}")
+   if [[ -z "${holohub_app_source}" ]]; then
+     print_error "Could not find app source directory for ${appname} ${language}."
+     launch_desc
+     exit 1
+   fi
+
+   # Checks if the application is organized in a language subfolder
+   if [[ "${holohub_app_source}" =~ .*${language}$ ]]; then
      holohub_app_bin="${holohub_build_dir}/applications/${appname}/${language}"
-     holohub_app_source="${SCRIPT_DIR}/applications/${appname}/${language}"
    fi
 
    # Check if the metadata file exists
+   local metadata_file="${holohub_app_source}/metadata.json"
    if [ ! -f "$metadata_file" ]; then
      print_error "The metadata file for this application does not exist."
      echo "File: ${metadata_file} not found"


### PR DESCRIPTION
Updates the `./dev_container build_and_run` command to detect and use a
custom Dockerfile provided by the application if one is available.

The motivation for this change is to increase the projects that can be
covered by the `build_and_run` command with minimal extra arguments on
the command line. The eventual goal of this work is to provide
build-and-run coverage for a maximum subset of HoloHub projects via the
HoloHub landing page.

Under previous behavior `build_and_run` supported using a custom docker
file only if explicitly passed as a command line argument and did not
enforce a discovery convention.

Under updated behavior `build_and_run` defines the following heuristics
to find a custom Dockerfile for a HoloHub application, in order of
priority:
1. Use a Dockerfile provided on the command line;
2. Use a Dockerfile provided in `metadata.json`;
3. Use a Dockerfile in the same folder as `metadata.json`;
4. If `metadata.json` is in a language subfolder, use a Dockerfile in
   the one-level-up project directory;
5. If none of the conditions above are satisfied, use the default
   HoloHub Dockerfile.

Additional changes:
- Fix `HOLOHUB_DATA_DIR` initialization in `run` script
- Fix build directory variable in `run` script
- Add README to applications folder to discuss required/optional HoloHub conventions