### PR TITLE
App: Ignore result output in `hyperspectral_segmentation` application

### DIFF
--- a/applications/hyperspectral_segmentation/.gitignore
+++ b/applications/hyperspectral_segmentation/.gitignore
@@ -1,0 +1,1 @@
+/result.png


### PR DESCRIPTION
Small change to ignore PNG output from the `hyperspectral_segmentation` application so that it is not committed to version control history.

Noticed while testing applications for https://github.com/nvidia-holoscan/holohub/pull/267.