### PR TITLE
Support passing Condition and Resource arguments as a positional argument to all provided Python operators

### DIFF
--- a/operators/advanced_network/python/adv_network_rx_pybind.cpp
+++ b/operators/advanced_network/python/adv_network_rx_pybind.cpp
@@ -31,7 +31,6 @@
 #include <holoscan/core/operator_spec.hpp>
 #include <holoscan/core/resources/gxf/allocator.hpp>
 
-
 using std::string_literals::operator""s;
 using pybind11::literals::operator""_a;
 
@@ -86,14 +85,9 @@ PYBIND11_MODULE(_advanced_network_rx, m) {
   m.attr("__version__") = "dev";
 #endif
 
-  py::class_<AdvNetworkOpRx,
-             PyAdvNetworkOpRx,
-             Operator,
-             std::shared_ptr<AdvNetworkOpRx>>(
+  py::class_<AdvNetworkOpRx, PyAdvNetworkOpRx, Operator, std::shared_ptr<AdvNetworkOpRx>>(
       m, "AdvNetworkOpRx", doc::AdvNetworkOpRx::doc_AdvNetworkOpRx)
-      .def(py::init<Fragment*,
-                    const py::args&,
-                    const std::string&>(),
+      .def(py::init<Fragment*, const py::args&, const std::string&>(),
            "fragment"_a,
            "name"_a = "advanced_network_rx"s,
            doc::AdvNetworkOpRx::doc_AdvNetworkOpRx_python)

--- a/operators/advanced_network/python/adv_network_rx_pybind.cpp
+++ b/operators/advanced_network/python/adv_network_rx_pybind.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 
+#include "../../operator_util.hpp"
 #include <holoscan/core/fragment.hpp>
 #include <holoscan/core/gxf/gxf_operator.hpp>
 #include <holoscan/core/operator_spec.hpp>
@@ -57,9 +58,10 @@ class PyAdvNetworkOpRx : public AdvNetworkOpRx {
   using AdvNetworkOpRx::AdvNetworkOpRx;
 
   // Define a constructor that fully initializes the object.
-  PyAdvNetworkOpRx(Fragment* fragment,
-                        const std::string& name = "advanced_network_rx") {
+  PyAdvNetworkOpRx(Fragment* fragment, const py::args& args,
+                   const std::string& name = "advanced_network_rx") {
     this->add_arg(fragment->from_config("advanced_network"));
+    add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;
     spec_ = std::make_shared<OperatorSpec>(fragment);
@@ -90,6 +92,7 @@ PYBIND11_MODULE(_advanced_network_rx, m) {
              std::shared_ptr<AdvNetworkOpRx>>(
       m, "AdvNetworkOpRx", doc::AdvNetworkOpRx::doc_AdvNetworkOpRx)
       .def(py::init<Fragment*,
+                    const py::args&,
                     const std::string&>(),
            "fragment"_a,
            "name"_a = "advanced_network_rx"s,

--- a/operators/advanced_network/python/adv_network_tx_pybind.cpp
+++ b/operators/advanced_network/python/adv_network_tx_pybind.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 
+#include "../../operator_util.hpp"
 #include <holoscan/core/fragment.hpp>
 #include <holoscan/core/gxf/gxf_operator.hpp>
 #include <holoscan/core/operator_spec.hpp>
@@ -57,9 +58,10 @@ class PyAdvNetworkOpTx : public AdvNetworkOpTx {
   using AdvNetworkOpTx::AdvNetworkOpTx;
 
   // Define a constructor that fully initializes the object.
-  PyAdvNetworkOpTx(Fragment* fragment,
-                        const std::string& name = "advanced_network_tx") {
+  PyAdvNetworkOpTx(Fragment* fragment, const py::args& args,
+                   const std::string& name = "advanced_network_tx") {
     this->add_arg(fragment->from_config("advanced_network"));
+    add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;
     spec_ = std::make_shared<OperatorSpec>(fragment);
@@ -90,6 +92,7 @@ PYBIND11_MODULE(_advanced_network_tx, m) {
              std::shared_ptr<AdvNetworkOpTx>>(
       m, "AdvNetworkOpTx", doc::AdvNetworkOpTx::doc_AdvNetworkOpTx)
       .def(py::init<Fragment*,
+                    const py::args&,
                     const std::string&>(),
            "fragment"_a,
            "name"_a = "advanced_network_tx"s,

--- a/operators/advanced_network/python/adv_network_tx_pybind.cpp
+++ b/operators/advanced_network/python/adv_network_tx_pybind.cpp
@@ -31,7 +31,6 @@
 #include <holoscan/core/operator_spec.hpp>
 #include <holoscan/core/resources/gxf/allocator.hpp>
 
-
 using std::string_literals::operator""s;
 using pybind11::literals::operator""_a;
 
@@ -86,14 +85,9 @@ PYBIND11_MODULE(_advanced_network_tx, m) {
   m.attr("__version__") = "dev";
 #endif
 
-  py::class_<AdvNetworkOpTx,
-             PyAdvNetworkOpTx,
-             Operator,
-             std::shared_ptr<AdvNetworkOpTx>>(
+  py::class_<AdvNetworkOpTx, PyAdvNetworkOpTx, Operator, std::shared_ptr<AdvNetworkOpTx>>(
       m, "AdvNetworkOpTx", doc::AdvNetworkOpTx::doc_AdvNetworkOpTx)
-      .def(py::init<Fragment*,
-                    const py::args&,
-                    const std::string&>(),
+      .def(py::init<Fragment*, const py::args&, const std::string&>(),
            "fragment"_a,
            "name"_a = "advanced_network_tx"s,
            doc::AdvNetworkOpTx::doc_AdvNetworkOpTx_python)

--- a/operators/emergent_source/python/emergent_source.cpp
+++ b/operators/emergent_source/python/emergent_source.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 
+#include "../../operator_util.hpp"
 #include <holoscan/core/fragment.hpp>
 #include "holoscan/core/gxf/gxf_operator.hpp"
 #include <holoscan/core/operator_spec.hpp>
@@ -55,7 +56,7 @@ class PyEmergentSourceOp : public EmergentSourceOp {
   using EmergentSourceOp::EmergentSourceOp;
 
   // Define a constructor that fully initializes the object.
-  PyEmergentSourceOp(Fragment* fragment,
+  PyEmergentSourceOp(Fragment* fragment, const py::args& args,
                      // defaults here should match constexpr values in EmergentSourceOp::Setup
                      uint32_t width = 4200, uint32_t height = 2160, uint32_t framerate = 240,
                      bool rdma = false, const std::string& name = "emergent_source")
@@ -63,6 +64,7 @@ class PyEmergentSourceOp : public EmergentSourceOp {
                                  Arg{"height", height},
                                  Arg{"framerate", framerate},
                                  Arg{"rdma", rdma}}) {
+    add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;
     spec_ = std::make_shared<OperatorSpec>(fragment);
@@ -89,7 +91,7 @@ PYBIND11_MODULE(_emergent_source, m) {
 
   py::class_<EmergentSourceOp, PyEmergentSourceOp, GXFOperator, std::shared_ptr<EmergentSourceOp>>(
       m, "EmergentSourceOp", doc::EmergentSourceOp::doc_EmergentSourceOp)
-      .def(py::init<Fragment*, uint32_t, uint32_t, uint32_t, bool, const std::string&>(),
+      .def(py::init<Fragment*, const py::args&, uint32_t, uint32_t, uint32_t, bool, const std::string&>(),
            "fragment"_a,
            // defaults values here should match constexpr values in C++ EmergentSourceOp::Setup
            "width"_a = 4200,

--- a/operators/emergent_source/python/emergent_source.cpp
+++ b/operators/emergent_source/python/emergent_source.cpp
@@ -91,7 +91,13 @@ PYBIND11_MODULE(_emergent_source, m) {
 
   py::class_<EmergentSourceOp, PyEmergentSourceOp, GXFOperator, std::shared_ptr<EmergentSourceOp>>(
       m, "EmergentSourceOp", doc::EmergentSourceOp::doc_EmergentSourceOp)
-      .def(py::init<Fragment*, const py::args&, uint32_t, uint32_t, uint32_t, bool, const std::string&>(),
+      .def(py::init<Fragment*,
+                    const py::args&,
+                    uint32_t,
+                    uint32_t,
+                    uint32_t,
+                    bool,
+                    const std::string&>(),
            "fragment"_a,
            // defaults values here should match constexpr values in C++ EmergentSourceOp::Setup
            "width"_a = 4200,

--- a/operators/lstm_tensor_rt_inference/python/lstm_tensor_rt_inference.cpp
+++ b/operators/lstm_tensor_rt_inference/python/lstm_tensor_rt_inference.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 
+#include "../../operator_util.hpp"
 #include <holoscan/core/fragment.hpp>
 #include <holoscan/core/operator.hpp>
 #include <holoscan/core/operator_spec.hpp>
@@ -58,7 +59,7 @@ class PyLSTMTensorRTInferenceOp : public LSTMTensorRTInferenceOp {
 
   // Define a constructor that fully initializes the object.
   PyLSTMTensorRTInferenceOp(
-      Fragment* fragment, const std::vector<std::string>& input_tensor_names,
+      Fragment* fragment, const py::args& args, const std::vector<std::string>& input_tensor_names,
       const std::vector<std::string>& output_tensor_names,
       const std::vector<std::string>& input_binding_names,
       const std::vector<std::string>& output_binding_names, const std::string& model_file_path,
@@ -92,6 +93,7 @@ class PyLSTMTensorRTInferenceOp : public LSTMTensorRTInferenceOp {
                                         Arg{"relaxed_dimension_check", relaxed_dimension_check},
                                         Arg{"max_workspace_size", max_workspace_size},
                                         Arg{"max_batch_size", max_batch_size}}) {
+    add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;
     spec_ = std::make_shared<OperatorSpec>(fragment);
@@ -123,6 +125,7 @@ PYBIND11_MODULE(_lstm_tensor_rt_inference, m) {
              std::shared_ptr<LSTMTensorRTInferenceOp>>(
       m, "LSTMTensorRTInferenceOp", doc::LSTMTensorRTInferenceOp::doc_LSTMTensorRTInferenceOp)
       .def(py::init<Fragment*,
+                    const py::args&,
                     const std::vector<std::string>&,
                     const std::vector<std::string>&,
                     const std::vector<std::string>&,

--- a/operators/lstm_tensor_rt_inference/python/lstm_tensor_rt_inference.cpp
+++ b/operators/lstm_tensor_rt_inference/python/lstm_tensor_rt_inference.cpp
@@ -101,7 +101,6 @@ class PyLSTMTensorRTInferenceOp : public LSTMTensorRTInferenceOp {
   }
 };
 
-
 PYBIND11_MODULE(_lstm_tensor_rt_inference, m) {
   m.doc() = R"pbdoc(
         Holoscan SDK Python Bindings

--- a/operators/openigtlink/python/openigtlink_rx.cpp
+++ b/operators/openigtlink/python/openigtlink_rx.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 
+#include "../../operator_util.hpp"
 #include <holoscan/core/fragment.hpp>
 #include <holoscan/core/operator.hpp>
 #include <holoscan/core/operator_spec.hpp>
@@ -46,7 +47,7 @@ class PyOpenIGTLinkRxOp : public OpenIGTLinkRxOp {
 
   // Define a constructor that fully initializes the object.
   PyOpenIGTLinkRxOp(
-      Fragment* fragment,
+      Fragment* fragment, const py::args& args,
       std::shared_ptr<Allocator> allocator,
       int port = 0,
       const std::string& out_tensor_name = std::string(""),
@@ -56,6 +57,7 @@ class PyOpenIGTLinkRxOp : public OpenIGTLinkRxOp {
                                 Arg{"port", port},
                                 Arg{"out_tensor_name", out_tensor_name},
                                 Arg{"flip_width_height", flip_width_height}}) {
+    add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;
     spec_ = std::make_shared<OperatorSpec>(fragment);
@@ -89,6 +91,7 @@ PYBIND11_MODULE(_openigtlink_rx, m) {
       "OpenIGTLinkRxOp",
       doc::OpenIGTLinkRxOp::doc_OpenIGTLinkRxOp)
       .def(py::init<Fragment*,
+                    const py::args&,
                     std::shared_ptr<Allocator>,
                     int,
                     const std::string&,

--- a/operators/openigtlink/python/openigtlink_rx.cpp
+++ b/operators/openigtlink/python/openigtlink_rx.cpp
@@ -46,13 +46,9 @@ class PyOpenIGTLinkRxOp : public OpenIGTLinkRxOp {
   using OpenIGTLinkRxOp::OpenIGTLinkRxOp;
 
   // Define a constructor that fully initializes the object.
-  PyOpenIGTLinkRxOp(
-      Fragment* fragment, const py::args& args,
-      std::shared_ptr<Allocator> allocator,
-      int port = 0,
-      const std::string& out_tensor_name = std::string(""),
-      bool flip_width_height = true,
-      const std::string& name = "openigtlink_rx")
+  PyOpenIGTLinkRxOp(Fragment* fragment, const py::args& args, std::shared_ptr<Allocator> allocator,
+                    int port = 0, const std::string& out_tensor_name = std::string(""),
+                    bool flip_width_height = true, const std::string& name = "openigtlink_rx")
       : OpenIGTLinkRxOp(ArgList{Arg{"allocator", allocator},
                                 Arg{"port", port},
                                 Arg{"out_tensor_name", out_tensor_name},
@@ -64,7 +60,6 @@ class PyOpenIGTLinkRxOp : public OpenIGTLinkRxOp {
     setup(*spec_.get());
   }
 };
-
 
 PYBIND11_MODULE(_openigtlink_rx, m) {
   m.doc() = R"pbdoc(
@@ -83,13 +78,8 @@ PYBIND11_MODULE(_openigtlink_rx, m) {
   m.attr("__version__") = "dev";
 #endif
 
-  py::class_<OpenIGTLinkRxOp,
-             PyOpenIGTLinkRxOp,
-             Operator,
-             std::shared_ptr<OpenIGTLinkRxOp>>(
-      m,
-      "OpenIGTLinkRxOp",
-      doc::OpenIGTLinkRxOp::doc_OpenIGTLinkRxOp)
+  py::class_<OpenIGTLinkRxOp, PyOpenIGTLinkRxOp, Operator, std::shared_ptr<OpenIGTLinkRxOp>>(
+      m, "OpenIGTLinkRxOp", doc::OpenIGTLinkRxOp::doc_OpenIGTLinkRxOp)
       .def(py::init<Fragment*,
                     const py::args&,
                     std::shared_ptr<Allocator>,
@@ -104,10 +94,7 @@ PYBIND11_MODULE(_openigtlink_rx, m) {
            "flip_width_height"_a = true,
            "name"_a = "openigtlink_rx"s,
            doc::OpenIGTLinkRxOp::doc_OpenIGTLinkRxOp_python)
-      .def("setup",
-           &OpenIGTLinkRxOp::setup,
-           "spec"_a,
-           doc::OpenIGTLinkRxOp::doc_setup);
+      .def("setup", &OpenIGTLinkRxOp::setup, "spec"_a, doc::OpenIGTLinkRxOp::doc_setup);
 }  // PYBIND11_MODULE NOLINT
 
 }  // namespace holoscan::ops

--- a/operators/openigtlink/python/openigtlink_tx.cpp
+++ b/operators/openigtlink/python/openigtlink_tx.cpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 
+#include "../../operator_util.hpp"
 #include <holoscan/core/fragment.hpp>
 #include <holoscan/core/operator.hpp>
 #include <holoscan/core/operator_spec.hpp>
@@ -46,7 +47,7 @@ class PyOpenIGTLinkTxOp : public OpenIGTLinkTxOp {
 
   // Define a constructor that fully initializes the object.
   PyOpenIGTLinkTxOp(
-      Fragment* fragment,
+      Fragment* fragment, const py::args& args,
       std::vector<holoscan::IOSpec*> receivers = std::vector<holoscan::IOSpec*>(),
       const std::string& host_name = std::string(""),
       int port = 0,
@@ -58,6 +59,7 @@ class PyOpenIGTLinkTxOp : public OpenIGTLinkTxOp {
                                 Arg{"device_name", device_name},
                                 Arg{"input_names", input_names}}) {
     if (receivers.size() > 0) { this->add_arg(Arg{"receivers", receivers}); }
+    add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;
     spec_ = std::make_shared<OperatorSpec>(fragment);
@@ -91,6 +93,7 @@ PYBIND11_MODULE(_openigtlink_tx, m) {
       "OpenIGTLinkTxOp",
       doc::OpenIGTLinkTxOp::doc_OpenIGTLinkTxOp)
       .def(py::init<Fragment*,
+                    const py::args&,
                     std::vector<holoscan::IOSpec*>,
                     const std::string&,
                     int,

--- a/operators/openigtlink/python/openigtlink_tx.cpp
+++ b/operators/openigtlink/python/openigtlink_tx.cpp
@@ -46,14 +46,12 @@ class PyOpenIGTLinkTxOp : public OpenIGTLinkTxOp {
   using OpenIGTLinkTxOp::OpenIGTLinkTxOp;
 
   // Define a constructor that fully initializes the object.
-  PyOpenIGTLinkTxOp(
-      Fragment* fragment, const py::args& args,
-      std::vector<holoscan::IOSpec*> receivers = std::vector<holoscan::IOSpec*>(),
-      const std::string& host_name = std::string(""),
-      int port = 0,
-      const std::string& device_name = std::string("Holoscan"),
-      const std::vector<std::string>& input_names = std::vector<std::string>{},
-      const std::string& name = "openigtlink_tx")
+  PyOpenIGTLinkTxOp(Fragment* fragment, const py::args& args,
+                    std::vector<holoscan::IOSpec*> receivers = std::vector<holoscan::IOSpec*>(),
+                    const std::string& host_name = std::string(""), int port = 0,
+                    const std::string& device_name = std::string("Holoscan"),
+                    const std::vector<std::string>& input_names = std::vector<std::string>{},
+                    const std::string& name = "openigtlink_tx")
       : OpenIGTLinkTxOp(ArgList{Arg{"host_name", host_name},
                                 Arg{"port", port},
                                 Arg{"device_name", device_name},
@@ -66,7 +64,6 @@ class PyOpenIGTLinkTxOp : public OpenIGTLinkTxOp {
     setup(*spec_.get());
   }
 };
-
 
 PYBIND11_MODULE(_openigtlink_tx, m) {
   m.doc() = R"pbdoc(
@@ -85,13 +82,8 @@ PYBIND11_MODULE(_openigtlink_tx, m) {
   m.attr("__version__") = "dev";
 #endif
 
-  py::class_<OpenIGTLinkTxOp,
-             PyOpenIGTLinkTxOp,
-             Operator,
-             std::shared_ptr<OpenIGTLinkTxOp>>(
-      m,
-      "OpenIGTLinkTxOp",
-      doc::OpenIGTLinkTxOp::doc_OpenIGTLinkTxOp)
+  py::class_<OpenIGTLinkTxOp, PyOpenIGTLinkTxOp, Operator, std::shared_ptr<OpenIGTLinkTxOp>>(
+      m, "OpenIGTLinkTxOp", doc::OpenIGTLinkTxOp::doc_OpenIGTLinkTxOp)
       .def(py::init<Fragment*,
                     const py::args&,
                     std::vector<holoscan::IOSpec*>,
@@ -108,10 +100,7 @@ PYBIND11_MODULE(_openigtlink_tx, m) {
            "input_names"_a = std::vector<std::string>{},
            "name"_a = "openigtlink_tx"s,
            doc::OpenIGTLinkTxOp::doc_OpenIGTLinkTxOp_python)
-      .def("setup",
-           &OpenIGTLinkTxOp::setup,
-           "spec"_a,
-           doc::OpenIGTLinkTxOp::doc_setup);
+      .def("setup", &OpenIGTLinkTxOp::setup, "spec"_a, doc::OpenIGTLinkTxOp::doc_setup);
 }  // PYBIND11_MODULE NOLINT
 
 }  // namespace holoscan::ops

--- a/operators/operator_util.hpp
+++ b/operators/operator_util.hpp
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef PYHOLOHUB_OPERATORS_OPERATOR_UTIL_HPP
+#define PYHOLOHUB_OPERATORS_OPERATOR_UTIL_HPP
+
+#include <pybind11/pybind11.h>
+
+#include <memory>
+
+#include "holoscan/core/condition.hpp"
+#include "holoscan/core/operator.hpp"
+#include "holoscan/core/resource.hpp"
+
+namespace py = pybind11;
+
+namespace holoscan {
+
+void add_positional_condition_and_resource_args(Operator* op, const py::args& args) {
+  for (auto it = args.begin(); it != args.end(); ++it) {
+    if (py::isinstance<Condition>(*it)) {
+      op->add_arg(it->cast<std::shared_ptr<Condition>>());
+    } else if (py::isinstance<Resource>(*it)) {
+      op->add_arg(it->cast<std::shared_ptr<Resource>>());
+    } else {
+      HOLOSCAN_LOG_WARN(
+          "Unhandled positional argument detected (only Condition and Resource objects can be "
+          "parsed positionally)");
+    }
+  }
+}
+
+}  // namespace holoscan
+
+#endif /* PYHOLOHUB_OPERATORS_OPERATOR_UTIL_HPP */

--- a/operators/orsi/orsi_format_converter/python/format_converter.cpp
+++ b/operators/orsi/orsi_format_converter/python/format_converter.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@
 
 #include "./pydoc.hpp"
 
+#include "../../operator_util.hpp"
 #include "holoscan/core/fragment.hpp"
 #include "holoscan/core/operator.hpp"
 #include "holoscan/core/operator_spec.hpp"
@@ -60,7 +61,8 @@ class PyOrsiFormatConverterOp : public orsi::FormatConverterOp {
   using orsi::FormatConverterOp::FormatConverterOp;
 
   // Define a constructor that fully initializes the object.
-  PyOrsiFormatConverterOp(Fragment* fragment, std::shared_ptr<holoscan::Allocator> allocator,
+  PyOrsiFormatConverterOp(Fragment* fragment, const py::args& args,
+                          std::shared_ptr<holoscan::Allocator> allocator,
                           const std::string& out_dtype, const std::string& in_dtype = "",
                           const std::string& in_tensor_name = "",
                           const std::string& out_tensor_name = "", float scale_min = 0.f,
@@ -85,6 +87,7 @@ class PyOrsiFormatConverterOp : public orsi::FormatConverterOp {
                                         Arg{"output_img_size", output_img_size},
                                         Arg{"allocator", allocator}}) {
     if (cuda_stream_pool) { this->add_arg(Arg{"cuda_stream_pool", cuda_stream_pool}); }
+    add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;
     spec_ = std::make_shared<OperatorSpec>(fragment);
@@ -117,6 +120,7 @@ PYBIND11_MODULE(_orsi_format_converter, m) {
              std::shared_ptr<orsi::FormatConverterOp>>(
       m, "OrsiFormatConverterOp", doc::OrsiFormatConverterOp::doc_OrsiFormatConverterOp)
       .def(py::init<Fragment*,
+                    const py::args&,
                     std::shared_ptr<holoscan::Allocator>,
                     const std::string&,
                     const std::string&,

--- a/operators/orsi/orsi_segmentation_postprocessor/python/segmentation_postprocessor.cpp
+++ b/operators/orsi/orsi_segmentation_postprocessor/python/segmentation_postprocessor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@
 
 #include "./pydoc.hpp"
 
+#include "../../operator_util.hpp"
 #include "holoscan/core/fragment.hpp"
 #include "holoscan/core/operator.hpp"
 #include "holoscan/core/operator_spec.hpp"
@@ -60,7 +61,7 @@ class PyOrsiSegmentationPostprocessorOp : public orsi::SegmentationPostprocessor
 
   // Define a constructor that fully initializes the object.
   PyOrsiSegmentationPostprocessorOp(
-      Fragment* fragment, std::shared_ptr<::holoscan::Allocator> allocator,
+      Fragment* fragment, const py::args& args, std::shared_ptr<::holoscan::Allocator> allocator,
       const std::string& in_tensor_name = "", const std::string& network_output_type = "softmax"s,
       const std::string& data_format = "hwc"s, const std::string& out_tensor_name = ""s,
       const std::vector<int32_t> output_roi_rect = {},
@@ -75,7 +76,7 @@ class PyOrsiSegmentationPostprocessorOp : public orsi::SegmentationPostprocessor
                                                   Arg{"output_img_size", output_img_size},
                                                   Arg{"allocator", allocator}}) {
     if (cuda_stream_pool) { this->add_arg(Arg{"cuda_stream_pool", cuda_stream_pool}); }
-
+    add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;
     spec_ = std::make_shared<OperatorSpec>(fragment);
@@ -110,6 +111,7 @@ PYBIND11_MODULE(_orsi_segmentation_postprocessor, m) {
       "OrsiSegmentationPostprocessorOp",
       doc::OrsiSegmentationPostprocessorOp::doc_OrsiSegmentationPostprocessorOp)
       .def(py::init<Fragment*,
+                    const py::args&,
                     std::shared_ptr<::holoscan::Allocator>,
                     const std::string&,
                     const std::string&,

--- a/operators/orsi/orsi_segmentation_preprocessor/python/segmentation_preprocessor.cpp
+++ b/operators/orsi/orsi_segmentation_preprocessor/python/segmentation_preprocessor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +26,7 @@
 
 #include "./pydoc.hpp"
 
+#include "../../operator_util.hpp"
 #include "holoscan/core/fragment.hpp"
 #include "holoscan/core/operator.hpp"
 #include "holoscan/core/operator_spec.hpp"
@@ -61,7 +62,7 @@ class PyOrsiSegmentationPreprocessorOp : public orsi::SegmentationPreprocessorOp
 
   // Define a constructor that fully initializes the object.
   PyOrsiSegmentationPreprocessorOp(
-      Fragment* fragment, std::shared_ptr<::holoscan::Allocator> allocator,
+      Fragment* fragment, const py::args& args, std::shared_ptr<::holoscan::Allocator> allocator,
       const std::string& in_tensor_name = "", const std::string& out_tensor_name = "",
       const std::string& network_output_type = "softmax"s, const std::string& data_format = "hwc"s,
       const std::vector<float> normalize_means = std::vector<float>{},
@@ -75,6 +76,7 @@ class PyOrsiSegmentationPreprocessorOp : public orsi::SegmentationPreprocessorOp
                                                  Arg{"normalize_stds", normalize_stds},
                                                  Arg{"allocator", allocator}}) {
     if (cuda_stream_pool) { this->add_arg(Arg{"cuda_stream_pool", cuda_stream_pool}); }
+    add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;
     spec_ = std::make_shared<OperatorSpec>(fragment);
@@ -109,6 +111,7 @@ PYBIND11_MODULE(_orsi_segmentation_preprocessor, m) {
       "OrsiSegmentationPreprocessorOp",
       doc::OrsiSegmentationPreprocessorOp::doc_OrsiSegmentationPreprocessorOp)
       .def(py::init<Fragment*,
+                    const py::args&,
                     std::shared_ptr<::holoscan::Allocator>,
                     const std::string&,
                     const std::string&,

--- a/operators/orsi/orsi_visualizer/python/orsi_visualizer.cpp
+++ b/operators/orsi/orsi_visualizer/python/orsi_visualizer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,7 @@
 
 #include "./pydoc.hpp"
 
+#include "../../operator_util.hpp"
 #include "holoscan/core/fragment.hpp"
 #include "holoscan/core/operator.hpp"
 #include "holoscan/core/operator_spec.hpp"
@@ -58,7 +59,7 @@ class PyOrsiVisualizationOp : public orsi::OrsiVisualizationOp {
   using orsi::OrsiVisualizationOp::OrsiVisualizationOp;
 
   // Define a constructor that fully initializes the object.
-  PyOrsiVisualizationOp(Fragment* fragment,
+  PyOrsiVisualizationOp(Fragment* fragment, const py::args& args,
                         std::vector<holoscan::IOSpec*> receivers = std::vector<holoscan::IOSpec*>(),
                         bool swizzle_video = false, const std::string& stl_file_path = "",
                         std::vector<std::string> stl_names = {},
@@ -73,6 +74,7 @@ class PyOrsiVisualizationOp : public orsi::OrsiVisualizationOp {
                                           Arg{"stl_colors", stl_colors},
                                           Arg{"stl_keys", stl_keys}}) {
     if (receivers.size() > 0) { this->add_arg(Arg{"receivers", receivers}); }
+    add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;
     spec_ = std::make_shared<OperatorSpec>(fragment);
@@ -105,6 +107,7 @@ PYBIND11_MODULE(_orsi_visualizer, m) {
              std::shared_ptr<orsi::OrsiVisualizationOp>>(
       m, "OrsiVisualizationOp", doc::OrsiVisualizationOp::doc_OrsiVisualizationOp)
       .def(py::init<Fragment*,
+                    const py::args&,
                     std::vector<holoscan::IOSpec*>,
                     bool,
                     const std::string&,

--- a/operators/prohawk_video_processing/python/prohawkop.cpp
+++ b/operators/prohawk_video_processing/python/prohawkop.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 
+#include "../../operator_util.hpp"
 #include <holoscan/core/fragment.hpp>
 #include <holoscan/core/operator.hpp>
 #include <holoscan/core/operator_spec.hpp>
@@ -43,8 +44,10 @@ class PyProhawkOp : public ProhawkOp {
  public:
   using ProhawkOp::ProhawkOp;
 
-  explicit PyProhawkOp(Fragment* fragment, const std::string& name = "prohawk_video_processing")
+  explicit PyProhawkOp(Fragment* fragment, const py::args& args,
+                       const std::string& name = "prohawk_video_processing")
       : ProhawkOp() {
+    add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;
     spec_ = std::make_shared<OperatorSpec>(fragment);
@@ -71,7 +74,7 @@ PYBIND11_MODULE(_prohawk_video_processing, m) {
 
   py::class_<ProhawkOp, PyProhawkOp, Operator, std::shared_ptr<ProhawkOp>>(
       m, "ProhawkOp", doc::ProhawkOp::doc_ProhawkOp)
-      .def(py::init<Fragment*, const std::string&>(),
+      .def(py::init<Fragment*, const py::args&, const std::string&>(),
            "fragment"_a,
            "name"_a = "prohawk_video_processing"s,
            doc::ProhawkOp::doc_ProhawkOp_python)

--- a/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor.cpp
+++ b/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor.cpp
@@ -91,7 +91,6 @@ class PyToolTrackingPostprocessorOp : public ToolTrackingPostprocessorOp {
   }
 };
 
-
 PYBIND11_MODULE(_tool_tracking_postprocessor, m) {
   m.doc() = R"pbdoc(
         Holoscan SDK Python Bindings

--- a/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor.cpp
+++ b/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 
+#include "../../operator_util.hpp"
 #include <holoscan/core/fragment.hpp>
 #include <holoscan/core/operator.hpp>
 #include <holoscan/core/operator_spec.hpp>
@@ -71,7 +72,7 @@ class PyToolTrackingPostprocessorOp : public ToolTrackingPostprocessorOp {
 
   // Define a constructor that fully initializes the object.
   PyToolTrackingPostprocessorOp(
-      Fragment* fragment, std::shared_ptr<Allocator> device_allocator,
+      Fragment* fragment, const py::args& args, std::shared_ptr<Allocator> device_allocator,
       std::shared_ptr<Allocator> host_allocator, float min_prob = 0.5f,
       std::vector<std::vector<float>> overlay_img_colors = VIZ_TOOL_DEFAULT_COLORS,
       std::shared_ptr<holoscan::CudaStreamPool> cuda_stream_pool =
@@ -82,6 +83,7 @@ class PyToolTrackingPostprocessorOp : public ToolTrackingPostprocessorOp {
                                             Arg{"min_prob", min_prob},
                                             Arg{"overlay_img_colors", overlay_img_colors},
                                             Arg{"cuda_stream_pool", cuda_stream_pool}}) {
+    add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;
     spec_ = std::make_shared<OperatorSpec>(fragment);
@@ -115,6 +117,7 @@ PYBIND11_MODULE(_tool_tracking_postprocessor, m) {
       "ToolTrackingPostprocessorOp",
       doc::ToolTrackingPostprocessorOp::doc_ToolTrackingPostprocessorOp)
       .def(py::init<Fragment*,
+                    const py::args&,
                     std::shared_ptr<Allocator>,
                     std::shared_ptr<Allocator>,
                     float,

--- a/operators/visualizer_icardio/python/visualizer_icardio_pybind.cpp
+++ b/operators/visualizer_icardio/python/visualizer_icardio_pybind.cpp
@@ -31,7 +31,6 @@
 #include <holoscan/core/operator_spec.hpp>
 #include <holoscan/core/resources/gxf/allocator.hpp>
 
-
 using std::string_literals::operator""s;
 using pybind11::literals::operator""_a;
 

--- a/operators/visualizer_icardio/python/visualizer_icardio_pybind.cpp
+++ b/operators/visualizer_icardio/python/visualizer_icardio_pybind.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 
+#include "../../operator_util.hpp"
 #include <holoscan/core/fragment.hpp>
 #include <holoscan/core/gxf/gxf_operator.hpp>
 #include <holoscan/core/operator_spec.hpp>
@@ -57,7 +58,8 @@ class PyVisualizerICardioOp : public VisualizerICardioOp {
   using VisualizerICardioOp::VisualizerICardioOp;
 
   // Define a constructor that fully initializes the object.
-  PyVisualizerICardioOp(Fragment* fragment, std::shared_ptr<::holoscan::Allocator> allocator,
+  PyVisualizerICardioOp(Fragment* fragment, const py::args& args,
+                        std::shared_ptr<::holoscan::Allocator> allocator,
                         const std::vector<std::string>& in_tensor_names = {std::string("")},
                         const std::vector<std::string>& out_tensor_names = {std::string("")},
                         bool input_on_cuda = false,
@@ -68,6 +70,7 @@ class PyVisualizerICardioOp : public VisualizerICardioOp {
                                     Arg{"in_tensor_names", in_tensor_names},
                                     Arg{"out_tensor_names", out_tensor_names},
                                     Arg{"input_on_cuda", input_on_cuda}}) {
+    add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;
     spec_ = std::make_shared<OperatorSpec>(fragment);
@@ -98,6 +101,7 @@ PYBIND11_MODULE(_visualizer_icardio, m) {
              std::shared_ptr<VisualizerICardioOp>>(
       m, "VisualizerICardioOp", doc::VisualizerICardioOp::doc_VisualizerICardioOp)
       .def(py::init<Fragment*,
+                    const py::args&,
                     std::shared_ptr<::holoscan::Allocator>,
                     const std::vector<std::string>&,
                     const std::vector<std::string>&,

--- a/operators/yuan_qcap/python/qcap_source.cpp
+++ b/operators/yuan_qcap/python/qcap_source.cpp
@@ -59,8 +59,8 @@ class PyQCAPSourceOp : public QCAPSourceOp {
   PyQCAPSourceOp(Fragment* fragment, const py::args& args,
                  const std::string& device = "SC0710 PCI"s, uint32_t channel = 0,
                  uint32_t width = 3840, uint32_t height = 2160, uint32_t framerate = 60,
-                 bool rdma = true, const std::string & pixel_format = "bgr24"s,
-                 const std::string & input_type = "auto"s, uint32_t mst_mode = 0,
+                 bool rdma = true, const std::string& pixel_format = "bgr24"s,
+                 const std::string& input_type = "auto"s, uint32_t mst_mode = 0,
                  uint32_t sdi12g_mode = 0, const std::string& name = "qcap_source")
       : QCAPSourceOp(ArgList{Arg{"device", device},
                              Arg{"channel", channel},
@@ -71,8 +71,7 @@ class PyQCAPSourceOp : public QCAPSourceOp {
                              Arg{"pixel_format", pixel_format},
                              Arg{"input_type", input_type},
                              Arg{"mst_mode", mst_mode},
-                             Arg{"sdi12g_mode", sdi12g_mode}
-                             }) {
+                             Arg{"sdi12g_mode", sdi12g_mode}}) {
     add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;

--- a/operators/yuan_qcap/python/qcap_source.cpp
+++ b/operators/yuan_qcap/python/qcap_source.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 YUAN High-Tech Development Co., Ltd. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 YUAN High-Tech Development Co., Ltd. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 
+#include "../../operator_util.hpp"
 #include <holoscan/core/fragment.hpp>
 #include <holoscan/core/operator_spec.hpp>
 #include "holoscan/core/gxf/gxf_operator.hpp"
@@ -55,13 +56,12 @@ class PyQCAPSourceOp : public QCAPSourceOp {
   using QCAPSourceOp::QCAPSourceOp;
 
   // Define a constructor that fully initializes the object.
-  PyQCAPSourceOp(Fragment* fragment, const std::string& device = "SC0710 PCI"s,
-                 uint32_t channel = 0, uint32_t width = 3840, uint32_t height = 2160,
-                 uint32_t framerate = 60, bool rdma = true,
-                 const std::string & pixel_format = "bgr24"s,
-                 const std::string & input_type = "auto"s,
-                 uint32_t mst_mode = 0, uint32_t sdi12g_mode = 0,
-                 const std::string& name = "qcap_source")
+  PyQCAPSourceOp(Fragment* fragment, const py::args& args,
+                 const std::string& device = "SC0710 PCI"s, uint32_t channel = 0,
+                 uint32_t width = 3840, uint32_t height = 2160, uint32_t framerate = 60,
+                 bool rdma = true, const std::string & pixel_format = "bgr24"s,
+                 const std::string & input_type = "auto"s, uint32_t mst_mode = 0,
+                 uint32_t sdi12g_mode = 0, const std::string& name = "qcap_source")
       : QCAPSourceOp(ArgList{Arg{"device", device},
                              Arg{"channel", channel},
                              Arg{"width", width},
@@ -73,6 +73,7 @@ class PyQCAPSourceOp : public QCAPSourceOp {
                              Arg{"mst_mode", mst_mode},
                              Arg{"sdi12g_mode", sdi12g_mode}
                              }) {
+    add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;
     spec_ = std::make_shared<OperatorSpec>(fragment);
@@ -101,6 +102,7 @@ PYBIND11_MODULE(_qcap_source, m) {
   py::class_<QCAPSourceOp, PyQCAPSourceOp, GXFOperator, std::shared_ptr<QCAPSourceOp>>(
       m, "QCAPSourceOp", doc::QCAPSourceOp::doc_QCAPSourceOp)
       .def(py::init<Fragment*,
+                    const py::args&,
                     const std::string&,
                     uint32_t,
                     uint32_t,


### PR DESCRIPTION
Currently there is a limitation in Python operators that wrap an underlying C++ operator that conditions like `CountCondition` or `PeriodicCondition` cannot be passed directly. This is being resolved for Holoscan SDK's built-in operators in a future release (v2.1). We can apply the same update to the operators provided here on Holohub (this approach is compatible with older releases back to at least v0.6).

For example, prior to this change, to have `EmergentSourceOp` call compute only 10 times one could add a `CountCondition` only after the operator was constructed like this:

```py
source = EmergentOp(self, name="emergent_source", **self.kwargs("emergent"))
source.add_arg(CountCondition(self, count=10))
```

but after the change made in this MR any conditions can be passed positionally to the constructor (as is currently already supported for native Python operators)
```py
source = EmergentOp(self, CountCondition(self, count=10), name="emergent_source", **self.kwargs("emergent"))
```

The operators updated in this MR are:
- AdvNetworkOpRx
- AdvNetworkOpTx
- EmergentSourceOp
- LSTMTensorRTInferenceOp
- OpenIGTLinkRxOp
- OpenIGTLinkTxOp
- orsi::FormatConverterOp
- orsi::SegmentationPreprocessorOp
- orsi::SegmentationPostprocessorOp
- orsi::OrsiVisualizationOp
- ProhawkOp
- QCAPSourceOp
- ToolTrackingPostprocessorOp
- VisualizerICardioOp
(This should be all of the Python operators that are wrapping an underlying C++ operator)
