### PR TITLE
Utility: Add `build_and_run` command generation in `gather_metadata.py` script

### DIFF
--- a/utilities/gather_metadata.py
+++ b/utilities/gather_metadata.py
@@ -49,18 +49,22 @@ def extract_readme(file_path):
             return ""
 
 
-def extract_application_name(readme_path):
-    """Extract the application name from the README file path"""
-    parts = readme_path.split(os.sep)
-    if "applications" in parts:
-        index = parts.index("applications")
-        if index + 1 < len(parts):
-            return parts[index + 1]
-    elif "operators" in parts:
-        index = parts.index("operators")
-        if index + 1 < len(parts):
-            return parts[index + 1]
-    return ""
+def extract_application_name(metadata_filepath: str) -> str:
+    """Extract the application name from the README file path.
+
+    HoloHub convention is such that an application `metadata.json` file
+    must be located at either:
+    - the named application project folder; or
+    - a language subfolder one level below the application project folder.
+
+    The following are valid examples:
+    - applications/my_application/metadata.json -> my_application
+    - applications/nested/paths/my_application/cpp/metadata.json -> my_application
+    """
+    parts = metadata_filepath.split(os.sep)
+    if parts[-2] in ["cpp", "python"]:
+        return parts[-3]
+    return parts[-2]
 
 
 def generate_build_and_run_command(metadata: dict) -> str:

--- a/utilities/gather_metadata.py
+++ b/utilities/gather_metadata.py
@@ -63,6 +63,18 @@ def extract_application_name(readme_path):
     return ""
 
 
+def generate_build_and_run_command(metadata: dict) -> str:
+    """Generate the build and run command for the application"""
+    language = metadata.get("metadata", {}).get("language", "").lower()
+    if language == "python":
+        return f'./dev_container build_and_run {metadata["application_name"]} --language python'
+    elif language in ["cpp", "c++"]:
+        return f'./dev_container build_and_run {metadata["application_name"]} --language cpp'
+    else:
+        # Unknown language, use default
+        return f'./dev_container build_and_run {metadata["application_name"]}'
+
+
 def gather_metadata(repo_path) -> dict:
     """Collect project metadata from JSON files into a single dictionary"""
     SCHEMA_TYPES = ["application", "operator", "gxf_extension", "tutorial"]
@@ -86,6 +98,8 @@ def gather_metadata(repo_path) -> dict:
             data["readme"] = readme
             data["application_name"] = application_name
             data["source_folder"] = source_folder
+            if source_folder == "applications":
+                data["build_and_run"] = generate_build_and_run_command(data)
             metadata.append(data)
 
     return metadata


### PR DESCRIPTION
Updates `gather_metadata.py` to generate a `./dev_container build_and_run` command string for each application in the aggregated metadata backend.

Example output:
```json

    {
        "metadata": {
            "name": "CV-CUDA: Basic Interoperability",
            "authors": [
                {
                    "name": "Holoscan Team",
                    "affiliation": "NVIDIA"
                }
            ],
            "language": "Python",
            "version": "1.0",
            "changelog": {
                "1.0": "Initial Release"
            },
            "holoscan_sdk": {
                "minimum_required_version": "0.6.0",
                "tested_versions": [
                    "0.6.0"
                ]
            },
            "platforms": [
                "amd64",
                "arm64"
            ],
            "tags": [
                "CV-CUDA",
                "Computer Vision",
                "CV"
            ],
            "ranking": 1,
            "dependencies": {
                "data": [
                    {
                        "name": "Holoscan Sample App Data for AI-based Endoscopy Tool Tracking",
                        "description": "This resource contains the convolutional LSTM model for tool tracking in laparoscopic videos by Nwoye et. al [1], and a sample surgical video.",
                        "url": "https://catalog.ngc.nvidia.com/orgs/nvidia/teams/clara-holoscan/resources/holoscan_endoscopy_sample_data",
                        "version": "20230222"
                    }
                ],
                "libraries": [
                    {
                        "name": "cvcuda",
                        "version": "0.3.1-beta"
                    }
                ]
            },
            "run": {
                "command": "python3 <holohub_app_source>/cvcuda_basic.py --data <holohub_data_dir>/endoscopy",
                "workdir": "holohub_bin"
            }
        },
        "readme": "# Simple CV-CUDA application\n\nThis application demonstrates seamless interoperability between Holoscan tensors and CV-CUDA tensors. The image processing pipeline is just a simple flip of the video orientation.\n\nNote that the C++ version of this application currently requires extra code to handle conversion\nback and forth between CV-CUDA and Holoscan tensor types. On the Python side, the conversion is\ntrivial due to the support for the [DLPack Python\nspecification](https://dmlc.github.io/dlpack/latest/python_spec.html) in both CV-CUDA and Holoscan.\nWe provide two [operators](../../operators/cvcuda_holoscan_interop/README.md) to handle the\ninteroperability between CVCUDA and Holoscan tensors.\n\n# Using the docker file\n\nThis application requires a compiled version of [CV-CUDA](https://github.com/CVCUDA/CV-CUDA).\nFor simplicity a DockerFile is available. To generate the container run:\n\n```bash\n./dev_container build --docker_file ./applications/cvcuda_basic/Dockerfile\n```\n\nThe C++ version of the application can then be built by launching this container and using the provided `run` script.\n\n```bash\n./dev_container launch\n./run build cvcuda_basic\n```\n\n# Running the Application\n\nThis application uses the endoscopy dataset as an example. The `run build` command above will automatically download it. This application is then run inside the container.\n\n```bash\n./dev_container launch\n```\n\nThe Python version of the simple CV-CUDA pipeline example can be run via\n```\npython applications/cvcuda_basic/python/cvcuda_basic.py --data=/workspace/holohub/data/endoscopy\n```\n\nor using the run script\n\n```bash\n./run launch cvcuda_basic python\n```\n\nThe C++ version of the simple CV-CUDA pipeline example can then be run via\n```\n./build/applications/cvcuda_basic/cpp/cvcuda_basic --data=/workspace/holohub/data/endoscopy\n```\n\nor using the run script\n\n```bash\n./run launch cvcuda_basic cpp\n```\n",
        "application_name": "cvcuda_basic",
        "source_folder": "applications",
        "build_and_run": "./dev_container build_and_run cvcuda_basic --language python"
    },
```