### PR TITLE
Infra: Workaround for `docker build` failure for older Holoscan SDK (0.6.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,5 +64,8 @@ RUN apt update \
     libgtk-3-dev \
     libcanberra-gtk-module \
     graphviz
+RUN if ! grep -q "VERSION_ID=\"22.04\"" /etc/os-release; then \
+        pip install setuptools; \
+    fi
 COPY benchmarks/holoscan_flow_benchmarking/requirements.txt /tmp/benchmarking_requirements.txt
 RUN pip install -r /tmp/benchmarking_requirements.txt


### PR DESCRIPTION
Implements a workaround to address an observed `docker build` failure for the Holoscan SDK v0.6.0 base container image.

@grelee reported an issue where the `dev_container` command would fail to build if the 0.6.0 container image was used:

```sh
./dev_container build --base_img nvcr.io/nvidia/clara-holoscan/holoscan:v0.6.0-dgpu
```

That command would fail to install `xdot` and indicated that `setuptools` was not found. As a workaround we can install `setuptools` in advance conditionally if we are building on an older Ubuntu version.

The resulting `xdot` appears to not be usable and more work is required to fully address the issue. But, this workaround allows the container build to succeed so that the user can continue with HoloHub usage as normal.