### PR TITLE
Fix typo in basic CV-CUDA example

### DIFF
--- a/applications/cvcuda_basic/python/cvcuda_basic.py
+++ b/applications/cvcuda_basic/python/cvcuda_basic.py
@@ -111,15 +111,15 @@ class MyVideoProcessingApp(Application):
         image_processing = ImageProcessingOp(self, name="image_processing")
 
         visualizer = HolovizOp(
-            app,
+            self,
             name="holoviz",
             width=width,
             height=height,
             tensors=[dict(name="image", type="color", opacity=1.0, priority=0)],
         )
 
-        app.add_flow(source, image_processing)
-        app.add_flow(image_processing, visualizer, {("output_tensor", "receivers")})
+        self.add_flow(source, image_processing)
+        self.add_flow(image_processing, visualizer, {("output_tensor", "receivers")})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This MR fixes a typo in the `compose` method of the CV-CUDA app where the concrete "app" variable defined in `__main__` was being used instead of `self`. This happened to work, but would lead to the application breaking if the variable  in `__main__` was renamed.

I did a `grep` of other applications and fortunately did not find other instances of this mistake.
