### PR TITLE
Infra: Bump default base container for Holoscan SDK v2.0.0 release

### DIFF
--- a/dev_container
+++ b/dev_container
@@ -268,11 +268,11 @@ get_host_gpu() {
 
 
 get_default_base_img() {
-    echo -n "nvcr.io/nvidia/clara-holoscan/holoscan:v1.0.3-"$(get_host_gpu)
+    echo -n "nvcr.io/nvidia/clara-holoscan/holoscan:v2.0.0-"$(get_host_gpu)
 }
 
 get_default_img() {
-    echo -n "holohub:ngc-v1.0.3-"$(get_host_gpu)
+    echo -n "holohub:ngc-v2.0.0-"$(get_host_gpu)
 }
 
 build_desc() { c_echo 'Build dev image


### PR DESCRIPTION
Bumps `dev_container` to build the HoloHub container on top of the latest Holoscan SDK release (v2.0.0) by default.