### PR TITLE
App: Fix for data pollution among volume rendering apps

### DIFF
--- a/applications/volume_rendering_xr/CMakeLists.txt
+++ b/applications/volume_rendering_xr/CMakeLists.txt
@@ -68,13 +68,13 @@ add_dependencies(volume_rendering_xr volume_rendering_xr_config_yaml)
 option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
-  holoscan_download_data(volume_rendering
+  holoscan_download_data(volume_rendering_xr
     URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_volume_rendering_sample_data/versions/20230816/zip
     DOWNLOAD_NAME holoscan_volume_rendering_sample_data_20230816.zip
     URL_MD5 cf5602f1dba90f2e50b1d4eefbf8081e
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
   )
-  add_dependencies(volume_rendering_xr volume_rendering_data)
+  add_dependencies(volume_rendering_xr volume_rendering_xr_data)
 endif()
 
 add_subdirectory(testing)

--- a/applications/volume_rendering_xr/metadata.json
+++ b/applications/volume_rendering_xr/metadata.json
@@ -84,7 +84,7 @@
 		]
 	},
 	"run": {
-		"command": "<holohub_app_bin>/volume_rendering_xr --config <holohub_data_dir>/volume_rendering/config.json --density <holohub_data_dir>/volume_rendering/highResCT.mhd --mask <holohub_data_dir>/volume_rendering/smoothmasks.seg.mhd",
+		"command": "<holohub_app_bin>/volume_rendering_xr --config <holohub_data_dir>/volume_rendering_xr/config.json --density <holohub_data_dir>/volume_rendering_xr/highResCT.mhd --mask <holohub_data_dir>/volume_rendering_xr/smoothmasks.seg.mhd",
 		"workdir": "holohub_bin"
 	}
   }


### PR DESCRIPTION
## Description

Updates `volume_rendering_xr` to avoid data path conflicts with `volume_rendering`.

Under previous behavior `volume_rendering` and `volume_rendering_xr` both downloaded sample data to the `volume_rendering` data folder. The sample data for each app respectively included mono or stereoscopic view configurations. As a result, when one app was built first, and then the other app was built and run, the wrong configuration could be used, leading to unexpected visual data representations without an obvious immediate cause.

The data folder could not be cleared out with `./run clear_cache` as typically recommended for debugging, and the issue appeared to lie in app behavior when in fact it was due to configuration data pollution.

Under updated behavior `volume_rendering_xr` checks and downloads to its own dedicated folder, which significantly reduces the risk of data pollution and consequent rendering misbehavior.

## Previous Behavior

If `volume_rendering` was built before `volume_rendering_xr`, the latter app would attempt to render the volume (but not the bounding box) for a monoscopic view.

![Screenshot from 2024-04-22 18-20-28](https://github.com/nvidia-holoscan/holohub/assets/40648863/ea7759bc-83ee-490c-acb7-26b103289f29)

If `volume_rendering_xr` was built before `volume_rendering`, the latter app would render stereoscopically with a visual divide among the top and bottom halves of the viewport.

## Updated Behavior

`volume_rendering_xr` data downloads into its own data folder and renders appropriately.

![Screenshot from 2024-04-18 12-46-07](https://github.com/nvidia-holoscan/holohub/assets/40648863/643180e8-7993-4d77-9429-deb837b6f6be)