### PR TITLE
App: Bump `volume_rendering_xr` firmware requirement

### DIFF
--- a/applications/volume_rendering_xr/README.md
+++ b/applications/volume_rendering_xr/README.md
@@ -23,7 +23,7 @@ The following packages and applications are required to run remote rendering wit
 | Requirement | Platform | Version | Source |
 |--|------|---------|--|
 | Magic Leap Hub | Windows or macOS PC | latest | [Magic Leap Website](https://ml2-developer.magicleap.com/downloads) |
-| Headset Firmware | Magic Leap 2 | v1.5.0 | Magic Leap Hub |
+| Headset Firmware | Magic Leap 2 | v1.6.0 | Magic Leap Hub |
 | Headset Remote Rendering Viewer (.apk) | Magic Leap 2 | [1.9.192](https://thelab.magicleap.cloud/packages_mlhub/artifacts/com.magicleap.remote_render/1.9.192/ml_remote_viewer.apk) | Magic Leap Download Link |
 | Windrunner OpenXR Backend | HoloHub Container | 1.9.194 | Included in Container |
 | Magic Leap 2 Pro License | | | Magic Leap |


### PR DESCRIPTION
Bump the documented Magic Leap 2 device firmware requirement to v1.6.0.

Follows local testing where the remote rendering application could not connect on firmware v1.5.0, but connected without issue when bumped to the latest firmware (v1.6.0).

Other software requirements are unaffected.