### PR TITLE
Doc: Fix URL references from CDash reporting

### DIFF
--- a/tutorials/cuda_mps/README.md
+++ b/tutorials/cuda_mps/README.md
@@ -75,5 +75,5 @@ without CUDA MPS. The experiment demonstrates up to 36% improvement with CUDA MP
 
 ![Alt text](image.png)
 
-Such experiments can easily be conducted with [Holoscan Flow Benchmarking](../holoscan_flow_benchmarking) to retrieve
+Such experiments can easily be conducted with [Holoscan Flow Benchmarking](../../benchmarks/holoscan_flow_benchmarking) to retrieve
 various end-to-end latency performance metrics.

--- a/tutorials/pretrained_foundational_models/self_supervised_training/README.md
+++ b/tutorials/pretrained_foundational_models/self_supervised_training/README.md
@@ -50,7 +50,7 @@ docker run -it --gpus="device=1" \
     surg_video_ssl_2202 jupyter lab
 ```
 
-For environment dependencies refer to the [Dockerfile](Docker/Dockerile)
+For environment dependencies refer to the [Dockerfile](Docker/Dockerfile)
 
 ## Launch Training
 


### PR DESCRIPTION
Changes:
- Fix URL reference to the `holoscan_flow_benchmarking` tutorial as referenced from the `cuda_mps` tutorial README.
- Fix URL spelling in `pretrained_foundational_models`

Error reported: http://cdash.nvidia.com/test/269299