### PR TITLE
Benchmark: Fix URL in `model_benchmarking` README

### DIFF
--- a/benchmarks/model_benchmarking/README.md
+++ b/benchmarks/model_benchmarking/README.md
@@ -8,7 +8,7 @@ model for inferencing. Then, the results are visualized after postprocessing.
 ## Usage
 
 As this application is, by default, set to use the 
-[ultrasound segmentation](../ultrasound_segmentation/) example, you can build and run the ultrasound
+[ultrasound segmentation](../../applications/ultrasound_segmentation/) example, you can build and run the ultrasound
 segmentation example first, and then try running this benchmarking application.
 
 Build and run the ultrasound segmentation application:


### PR DESCRIPTION
Update stale URL in `model_benchmarking` following its migration from the `applications` folder to the `benchmarks` folder.

Addresses CI failure: http://cdash.nvidia.com/test/272737