### PR TITLE
Homepage: Add "Run Locally" button to each application card

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -349,6 +349,14 @@ const App = () => {
                               )}
                             </>
                           )}
+                          {selectedData.build_and_run && (
+                            <div>
+                              <p className="font-semibold">Build and Run Command:</p>
+                              <pre className="bg-gray-100 p-2 rounded text-sm break-words">
+                                {selectedData.build_and_run}
+                              </pre>
+                            </div>
+                          )}
                         </div>
                       </section>
                       <div className="border-t border-gray-300 my-6" />

--- a/src/Card.jsx
+++ b/src/Card.jsx
@@ -52,12 +52,28 @@ const Card = ({ data, openModal }) => {
           {readme}
         </ReactMarkdown>
       </div>
-      <button
-        onClick={() => openModal(data)}
-        className="bg-lime-500 text-white px-4 py-2 mt-2 rounded hover:bg-lime-600"
-      >
-        View Details
-      </button>
+      <div>
+        <button
+          onClick={() => openModal(data)}
+          className="bg-lime-500 text-white px-4 py-2 mt-2 rounded hover:bg-lime-600"
+        >
+          View Details
+        </button>
+        {data.build_and_run && (
+        <button
+          onClick={() => {
+            if (data.build_and_run) {
+              navigator.clipboard.writeText(data.build_and_run);
+            } else {
+              console.error('Build and run command text not found for ' + data.application_name);
+            }
+          }}
+          className="ml-3 bg-lime-500 text-white px-4 py-2 mt-2 rounded hover:bg-lime-600 active:bg-lime-700"
+        >
+          Run Locally ⧉
+        </button>
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Changes:
- Add a button to each project card to copy the corresponding "build and run" command (if it exists) to the user's clipboard.
- Add a metadata field in the application detail page to provide the "build and run" command for user inspection.

Example application card:

![image](https://github.com/nvidia-holoscan/holohub/assets/40648863/0e5e6c09-bb9f-42f7-821a-d713b70c4427)

Example operator/tutorial card (unchanged):

![image](https://github.com/nvidia-holoscan/holohub/assets/40648863/7dc8581d-1c43-409e-ad5a-5ff3dccca944)

Example application details:

![image](https://github.com/nvidia-holoscan/holohub/assets/40648863/903a40c5-5dcb-4ada-8f59-c85e86f4a5bf)

Tested locally: `npm run dev`
