### PR TITLE
Doc: Fix broken URL link in lidar operator README

### DIFF
--- a/operators/velodyne_lidar/cpp/README.md
+++ b/operators/velodyne_lidar/cpp/README.md
@@ -29,7 +29,7 @@ Hardware requirements:
 
 ## Example Usage
 
-See the [HoloHub Lidar Sample Application](../../applications/velodyne_lidar_app) to get started.
+See the [HoloHub Lidar Sample Application](../../../applications/velodyne_lidar_app/cpp/) to get started.
 
 ## Acknowledgements
 


### PR DESCRIPTION
Fix broken URL link to address CI failure.

http://cdash.nvidia.com/test/284172