### PR TITLE
Doc: `VolumeRendererOp` and `VolumeLoaderOp` updates

### DIFF
--- a/applications/volume_rendering/README.md
+++ b/applications/volume_rendering/README.md
@@ -10,6 +10,7 @@ The application uses the `VolumeLoaderOp` operator to load the medical volume da
 
 You can find CT scan datasets for use with this application from [embodi3d](https://www.embodi3d.com/).
 
+Datasets are bundled with a default ClaraViz JSON configuration file for volume rendering. See [`VolumeRendererOp` documentation](../../operators/volume_renderer/README.md#configuration) for details on configuration schema.
 
 ## Build Instructions
 

--- a/applications/volume_rendering_xr/README.md
+++ b/applications/volume_rendering_xr/README.md
@@ -81,7 +81,7 @@ The following medical dataset formats are supported:
 
 ### Launch Options
 
-Use the `--extra-args` to see all options, including how to specify a different dataset or transfer function to use.
+Use the `--extra-args` to see all options, including how to specify a different dataset or configuration file to use.
 ```bash
 ./run launch volume_rendering_xr --extra_args --help
 ...
@@ -142,3 +142,11 @@ command, which will bring up a QR code that has to be scanned using the __QR Cod
 ### Developing with a Different OpenXR Backend
 
 `volume_renderer_xr` is an OpenXR compatible application. The Magic Leap Remote Rendering runtime is installed in the application container by default, but a compatible runtime can be used if appropriate to your use case. See [https://www.khronos.org/openxr/](https://www.khronos.org/openxr/) for more information on conformant OpenXR runtimes.
+
+### Volume Rendering
+
+The application carries out volume rendering via the HoloHub [`volume_renderer`](../../operators/volume_renderer/) operator,
+which in turn wraps the NVIDIA [ClaraViz](https://github.com/NVIDIA/clara-viz) rendering project. ClaraViz JSON configurations provided in the [config folder](./configs/) are available for specifying default scene parameters.
+
+See [`volume_renderer` Configuration section](../../operators/volume_renderer/README.md#configuration) for details on
+manipulating configuration values, along with [how to create a new configuration file](../../operators/volume_renderer/README.md#creating-a-configuration-file) to fit custom data.

--- a/operators/volume_loader/README.md
+++ b/operators/volume_loader/README.md
@@ -3,9 +3,11 @@
 The `volume_loader` operator reads 3D volumes from the specified input file.
 
 The operator supports these file formats:
-* MHD https://itk.org/Wiki/ITK/MetaIO/Documentation
-* NIFTI https://nifti.nimh.nih.gov/
-* NRRD https://teem.sourceforge.net/nrrd/format.html
+* [MHD (MetaImage)](https://itk.org/Wiki/ITK/MetaIO/Documentation)
+  * Detached-header format only (`.mhd` + `.raw`)
+* [NIFTI](https://nifti.nimh.nih.gov/)
+* [NRRD (Nearly Raw Raster Data)](https://teem.sourceforge.net/nrrd/format.html)
+  * [Detached-header format](https://teem.sourceforge.net/nrrd/format.html#detached) only
 
 #### `holoscan::ops::VolumeLoaderOp`
 


### PR DESCRIPTION
Update `VolumeRendererOp` and consuming app documentation to provide an overview and details for the ClaraViz JSON configuration file approach, including how to create a config file for new datasets.

Update `VolumeLoaderOp` documentation to indicate that only detached-header volume formats are currently supported.

Note: we plan to eventually expand upstream API documentation in ClaraViz to reflect config parameter settings. In the meantime we've pointed at ClaraViz gRPC sources with inline comments to help understand what each configuration field means. (thank you @AndreasHeumann )

Closes https://github.com/nvidia-holoscan/holohub/issues/302
Supports discussion in https://github.com/nvidia-holoscan/holohub/issues/301
Supports discussion in https://github.com/NVIDIA/clara-viz/issues/47