### PR TITLE
App: Fix default config file argument to `volume_rendering_xr`

### DIFF
--- a/applications/volume_rendering_xr/metadata.json
+++ b/applications/volume_rendering_xr/metadata.json
@@ -80,7 +80,7 @@
 		]
 	},
 	"run": {
-		"command": "<holohub_app_bin>/volume_rendering_xr --config <holohub_data_dir>/volume_rendering_xr/config.json --density <holohub_data_dir>/volume_rendering_xr/highResCT.mhd --mask <holohub_data_dir>/volume_rendering_xr/smoothmasks.seg.mhd",
+		"command": "<holohub_app_bin>/volume_rendering_xr --config <holohub_app_source>/configs/ctnv_bb_er.json --density <holohub_data_dir>/volume_rendering_xr/highResCT.mhd --mask <holohub_data_dir>/volume_rendering_xr/smoothmasks.seg.mhd",
 		"workdir": "<holohub_app_bin>"
 	}
   }


### PR DESCRIPTION
Update the `volume_rendering_xr` default `run` command to point to the recently updated "ctnv_bb_er.json` ClaraViz config file.

Previously "config.json" was downloaded to the HoloHub data directory and used to set scene parameters for `volume_rendering-xr`. The only difference between `config.json` and the new `ctnv_bb_er.json` is that the latter file provides transfer function labels for `volume_rendering_xr` to render as labels for 2D sliders.

```
$ diff ./ctnv_bb_er.json ~/repos/holohub-internal/data/volume_rendering_xr/config.json 
109d108
<                 "name": "Bone Outside",
154d152
<                 "name": "Bone Inside",
199d196
<                 "name": "Lungs 1",
244d240
<                 "name": "Lungs 2",
289d284
<                 "name": "Lungs 3",
```

Updated behavior shows text labels on UI window (previous appeared as "Unnamed").

![image copy](https://github.com/nvidia-holoscan/holohub/assets/40648863/7a977592-9fdf-4007-a598-7d853b793b5e)
