### PR TITLE
Remove the notion of sample applications tag in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ include(CTest)
 # Options
 option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 option(HOLOHUB_BUILD_PYTHON "Build Holoscan SDK Python Bindings" ON)
-option(BUILD_SAMPLE_APPS "Build Holoscan SDK sample applications" OFF)
 
 # Enable flow benchmarking
 option(FLOW_BENCHMARKING "Enable Flow Benchmarking" OFF)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,9 +226,6 @@ add_holohub_application(my_application DEPENDS
                         )
 ```
 
-Note that some applications have the optional ```HOLOSCAN_SAMPLE_APP``` keywords at the end of the ```add_holohub_application```
-function. This keyword should only be used for sample applications that are maintained by the Holoscan team.
-
 Refer to the [HoloHub application template folder](./applications/template/) for stub `metadata.json` and `README` files to copy
 and update for your new application.
 

--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -22,7 +22,7 @@ add_holohub_application(basic_networking_ping DEPENDS
 
 add_holohub_application(body_pose_estimation)
 
-add_holohub_application(colonoscopy_segmentation HOLOSCAN_SAMPLE_APP)
+add_holohub_application(colonoscopy_segmentation)
 
 add_holohub_application(cvcuda_basic DEPENDS OPERATORS cvcuda_holoscan_interop)
 
@@ -32,14 +32,12 @@ add_holohub_application(deltacast_transmitter DEPENDS
 
 add_holohub_application(endoscopy_depth_estimation)
 
-add_holohub_application(endoscopy_out_of_body_detection HOLOSCAN_SAMPLE_APP)
+add_holohub_application(endoscopy_out_of_body_detection)
 
 add_holohub_application(endoscopy_tool_tracking DEPENDS
                         OPERATORS lstm_tensor_rt_inference
                                   tool_tracking_postprocessor
-                                  OPTIONAL deltacast_videomaster yuan_qcap vtk_renderer
-                        HOLOSCAN_SAMPLE_APP
-                        )
+                                  OPTIONAL deltacast_videomaster yuan_qcap vtk_renderer)
 
 add_subdirectory(h264)
 
@@ -50,17 +48,16 @@ add_holohub_application(hyperspectral_segmentation)
 
 add_holohub_application(model_benchmarking)
 
-add_holohub_application(multiai_endoscopy HOLOSCAN_SAMPLE_APP)
+add_holohub_application(multiai_endoscopy)
 
 add_holohub_application(multiai_ultrasound DEPENDS
-                        OPERATORS visualizer_icardio
-                        HOLOSCAN_SAMPLE_APP)
+                        OPERATORS visualizer_icardio)
 
 add_holohub_application(simple_radar_pipeline)
 add_holohub_application(simple_pdw_pipeline DEPENDS
                         OPERATORS basic_network)
 
-add_holohub_application(object_detection_torch HOLOSCAN_SAMPLE_APP)
+add_holohub_application(object_detection_torch)
 
 add_holohub_application(openigtlink_3dslicer DEPENDS OPERATORS openigtlink)
 
@@ -74,7 +71,7 @@ add_holohub_application(network_radar_pipeline DEPENDS
                         OPERATORS basic_network
                                   advanced_network)
 
-add_holohub_application(ultrasound_segmentation HOLOSCAN_SAMPLE_APP)
+add_holohub_application(ultrasound_segmentation)
 
 add_holohub_application(velodyne_lidar_app DEPENDS
                         OPERATORS velodyne_lidar
@@ -83,8 +80,7 @@ add_holohub_application(velodyne_lidar_app DEPENDS
 
 add_holohub_application(volume_rendering DEPENDS
                         OPERATORS volume_loader
-                                  volume_renderer
-                        HOLOSCAN_SAMPLE_APP)
+                                  volume_renderer)
 
 add_holohub_application(volume_rendering_xr DEPENDS
                         OPERATORS volume_loader

--- a/cmake/HoloHubConfigHelpers.cmake
+++ b/cmake/HoloHubConfigHelpers.cmake
@@ -16,16 +16,10 @@
 # Helper function to build application and dependencies
 function(add_holohub_application NAME)
 
-  cmake_parse_arguments(APP "HOLOSCAN_SAMPLE_APP" "" "DEPENDS" ${ARGN})
+  cmake_parse_arguments(APP "" "" "DEPENDS" ${ARGN})
 
   set(appname "APP_${NAME}")
   option(${appname} "Build the ${NAME} application" ${BUILD_ALL})
-
-  # If the application is a holoscan sample application and
-  # the variable BUILD_SAMPLE_APPS is set we build this app
-  if(BUILD_SAMPLE_APPS AND APP_HOLOSCAN_SAMPLE_APP)
-    set(${appname} ON CACHE BOOL "Build the ${NAME} application" FORCE)
-  endif()
 
   if(${appname})
     add_subdirectory(${NAME})

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -211,9 +211,7 @@ cmake -S <path_to_holohub_source>            # Source directory
       -B build                               # Build directory
       -DPython3_EXECUTABLE=/usr/bin/python3  # Specifies the python executable for CMake to find the correct version
       -DHOLOHUB_DATA_DIR=$(pwd)/data         # Specifies the data directory
-      -DBUILD_SAMPLE_APPS=1                  # If you want to build the sample applications
-      or
-      -DAPP_<name_of_the_application>=1      # To build a specific application
+      -DAPP_<name_of_the_application>=1      # Specified the application to build
 
 
 # Build the application(s)

--- a/operators/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
+++ b/operators/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
@@ -809,7 +809,7 @@ void DpdkMgr::initialize() {
       add_flow(rx.port_id_, flow);
     }
   }
-}
+} // NOLINT
 
 int DpdkMgr::setup_pools_and_rings(int max_rx_batch, int max_tx_batch) {
   HOLOSCAN_LOG_DEBUG("Setting up RX ring");

--- a/run
+++ b/run
@@ -519,7 +519,7 @@ lint() {
 build_desc() {
   echo ""
   echo "Build the application(s) in HoloHub"
-  echo "Usage: ./run build <application_name | SAMPLE_APPS : default SAMPLE_APPS> [options]"
+  echo "Usage: ./run build <application_name> [options]"
   echo "Options:"
   echo "   --sdk <path_to_holoscan_SDK>  : Provide path to the SDK"
   echo "   --with <list of operators>  : Optional operators that should be built"
@@ -627,15 +627,15 @@ build() {
 
   echo "Building Holohub"
 
-  # Application(s) to build
-  application="-DBUILD_SAMPLE_APPS=1"
-
-  if [[ $app == "SAMPLE_APPS" ]] ||  [[ $app == "" ]]; then
-     echo "Building sample applications."
-  else
-    echo "building $1 application"
-    application="-DAPP_$1=1"
+  # Application to build
+  if [ "$1" == "" ]; then
+    print_error "Please specify which application to build."
+    echo "You can run ./run list for a full list of applications."
+    exit 1
   fi
+
+  echo "Building $1 application"
+  application="-DAPP_$1=1"
 
   # We define the python path to make sure we grab the right one
   cmake_extra_args="--no-warn-unused-cli -DPython3_EXECUTABLE=${HOLOHUB_PY_EXE} -DPython3_ROOT_DIR=${HOLOHUB_PY_LIB}"
@@ -827,23 +827,12 @@ list() {
       filename="${appname%/*}"
     fi
 
-    # Check in the CMakelists if the application is a sample application
-    appcmakelist="applications/CMakeLists.txt"
-    grepargs="\(${filename} \K[^)]+"
-    result_grep=$(grep -ozP "${grepargs}" $appcmakelist | tr -d '\0')
-    result=$(echo $result_grep | grep "HOLOSCAN_SAMPLE_APP")
-    sample_app=""
-    if [[ ${result} != "" ]]; then
-      sample_app="[Sample Application]"
-    fi
-
     application="${filename##*/}"
 
-    echo "- ${application} ${language} ${sample_app}"
+    echo "- ${application} ${language}"
   done
   echo ""
   echo "Run ./run build <app_name> to build a specific app."
-  echo "or ./run build SAMPLE_APPS to build the sample applications (noted [Sample Application]), other applications should be built individually."
 }
 
 # Returns the list of words for autocompletion


### PR DESCRIPTION
Currently Holohub has the notion of SAMPLE_APPS which allow to bundle initial applications into a group and build them together. In practice, users and developers only target one applicaiton at the time.