### PR TITLE
Doc: Update `volume_loader` format docs

### DIFF
--- a/applications/volume_rendering/README.md
+++ b/applications/volume_rendering/README.md
@@ -10,7 +10,9 @@ The application uses the `VolumeLoaderOp` operator to load the medical volume da
 
 You can find CT scan datasets for use with this application from [embodi3d](https://www.embodi3d.com/).
 
-Datasets are bundled with a default ClaraViz JSON configuration file for volume rendering. See [`VolumeRendererOp` documentation](../../operators/volume_renderer/README.md#configuration) for details on configuration schema.
+Datasets are bundled with a default ClaraViz JSON configuration file for volume rendering. See [`VolumeRendererOp` documentation](/operators/volume_renderer/README.md#configuration) for details on configuration schema.
+
+See [`VolumeLoaderOp` documentation](/operators/volume_loader/README.md#supported-formats) for supported volume formats.
 
 ## Build Instructions
 

--- a/applications/volume_rendering_xr/README.md
+++ b/applications/volume_rendering_xr/README.md
@@ -74,10 +74,7 @@ The application supports the following hand or controller interactions by defaul
 
 ### Supported Formats
 
-The following medical dataset formats are supported:
-* [MHD](https://itk.org/Wiki/ITK/MetaIO/Documentation)
-* [NIFTI](https://nifti.nimh.nih.gov/)
-* [NRRD](https://teem.sourceforge.net/nrrd/format.html)
+This application loads static volume files from the local disk. See HoloHub [`VolumeLoaderOp`](/operators/volume_loader/README.md#supported-formats) documentation for supported volume formats and file conversion tools.
 
 ### Launch Options
 

--- a/operators/volume_loader/README.md
+++ b/operators/volume_loader/README.md
@@ -1,13 +1,27 @@
-### Volume Loader
+# Volume Loader
 
 The `volume_loader` operator reads 3D volumes from the specified input file.
 
-The operator supports these file formats:
+## Supported Formats
+
+The operator supports these medical volume file formats:
 * [MHD (MetaImage)](https://itk.org/Wiki/ITK/MetaIO/Documentation)
   * Detached-header format only (`.mhd` + `.raw`)
 * [NIFTI](https://nifti.nimh.nih.gov/)
 * [NRRD (Nearly Raw Raster Data)](https://teem.sourceforge.net/nrrd/format.html)
-  * [Detached-header format](https://teem.sourceforge.net/nrrd/format.html#detached) only
+  * [Detached-header format](https://teem.sourceforge.net/nrrd/format.html#detached) only (`.nhdr` + `.raw`)
+
+You must convert your data to one of these formats to load it with `VolumeLoaderOp`. Some third party open source
+tools for volume file format conversion include:
+- Command Line Tools
+  - the [Insight Toolkit (ITK)](https://itk.org/) ([PyPI](https://pypi.org/project/itk/), [Image IO Examples](https://examples.itk.org/src/io/imagebase/))
+  - [SimpleITK](https://simpleitk.org/) ([PyPI](https://pypi.org/project/SimpleITK/))
+  - [Utah NRRD Utilities (unu)](https://teem.sourceforge.net/unrrdu/)
+- GUI Applications
+  - [3D Slicer](https://www.slicer.org/)
+  - [ImageJ](https://imagej.net/)
+
+## API
 
 #### `holoscan::ops::VolumeLoaderOp`
 


### PR DESCRIPTION
Changes in response to partner feedback:
- Reference OSS software for medical volume file format conversions in `volume_loader` documentation
- Link to file format docs from applications using `volume_loader`