### PR TITLE
App: Add runtime container procedure for `volume_rendering_xr`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ CTestConfig.cmake
 
 # Utilities
 aggregate_metadata.json
+/dist/
+/install/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 
 # Set the default data directory
 set(HOLOHUB_DATA_DIR "${CMAKE_BINARY_DIR}/data" CACHE PATH "Data Download directory")
+set(CMAKE_INSTALL_RPATH "\$ORIGIN/../lib:/opt/nvidia/holoscan/lib/")
 
 # Build the applications
 add_subdirectory(applications)

--- a/applications/volume_rendering_xr/CMakeLists.txt
+++ b/applications/volume_rendering_xr/CMakeLists.txt
@@ -59,6 +59,11 @@ target_link_libraries(volume_rendering_xr
   holoscan::ops::holoviz
 )
 
+set_target_properties(volume_rendering_xr
+  PROPERTIES
+  INSTALL_RPATH "\$ORIGIN:\$ORIGIN/../lib:/opt/nvidia/holoscan/lib/"
+)
+
 # Copy config file to the build tree
 add_custom_target(volume_rendering_xr_config_yaml
     COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/app_config.yaml" ${CMAKE_CURRENT_BINARY_DIR}
@@ -77,8 +82,14 @@ if(HOLOHUB_DOWNLOAD_DATASETS)
   add_dependencies(volume_rendering_xr volume_rendering_xr_data)
 endif()
 
-add_subdirectory(testing)
+# install binaries
+install(TARGETS volume_rendering_xr
+  COMPONENT holoscan-apps
+)
+
+
 #if(BUILD_TESTING)
+# add_subdirectory(testing)
   # Add test
 #  add_test(NAME xr_volume_rendering_test
 #           COMMAND xr_volume_rendering --count=100

--- a/applications/volume_rendering_xr/Dockerfile
+++ b/applications/volume_rendering_xr/Dockerfile
@@ -21,16 +21,11 @@ ARG VULKAN_SDK_VERSION=1.3.216.0
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as base
 
-ENV CMAKE_GENERATOR=Ninja
-
-# Install Vulkan dependencies
-#  libvulkan1 - Vulkan loader
-#  libegl1 - to run headless Vulkan apps
-RUN apt update \
-    && apt install --no-install-recommends -y \
-        libvulkan1 \
-        libegl1 \
-    && rm -rf /var/lib/apt/lists/*
+COPY /applications/volume_rendering_xr/scripts/base-setup.sh \
+    /tmp/base-setup.sh
+COPY applications/volume_rendering_xr/thirdparty/magicleap/MagicLeapRemoteRendering.gpg \
+    /usr/local/share/keyrings/magicleap/MagicLeapRemoteRendering.gpg
+RUN /tmp/base-setup.sh
 
 ############################################################
 # Vulkan SDK
@@ -44,6 +39,7 @@ FROM base as vulkansdk-builder
 ARG VULKAN_SDK_VERSION
 
 WORKDIR /opt/vulkansdk
+ENV CMAKE_GENERATOR=Ninja
 
 # Note there is no aarch64 binary version to download, therefore for aarch64 we also download the x86_64 version which
 # includes the source. Then remove the binaries and build the aarch64 version from source.
@@ -67,7 +63,6 @@ RUN if [ $(uname -m) = "aarch64" ]; then \
 FROM base as dev
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG WINDRUNNER_VERSION=1.11.74-5b8fe25-1~20240426ubuntu2204
 
 # Install OpenXR dev dependencies, can remove when using libopenxr-dev package instead of building OpenXR from source
 RUN apt update \
@@ -84,53 +79,13 @@ RUN apt update \
         mesa-common-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt update \
-    && apt install --no-install-recommends -y \
-        libopenxr-loader1 libopenxr-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install Magic Leap OpenXR runtime and set it as the default active runtime
-COPY applications/volume_rendering_xr/thirdparty/magicleap/MagicLeapRemoteRendering.gpg \
-    /usr/local/share/keyrings/magicleap/MagicLeapRemoteRendering.gpg
-RUN LIST_FILE=/etc/apt/sources.list.d/MagicLeapRemoteRendering.list \
-    && chmod -R 755 "/usr/local/share/keyrings/magicleap/" \
-    && CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME") \
-    && echo "deb [signed-by=/usr/local/share/keyrings/magicleap/MagicLeapRemoteRendering.gpg] https://apt.magicleap.cloud/Stable/ $CODENAME main" \
-        | tee "$LIST_FILE" \
-    && chmod a+r "$LIST_FILE" \
-    && apt update \
-    && echo "debconf-set-selections windrunner/accept_eula boolean true" | debconf-set-selections \
-    && apt install --no-install-recommends -y \
-        net-tools \
-        windrunner-service=${WINDRUNNER_VERSION} \
-        libopenxr1-windrunner=${WINDRUNNER_VERSION} \
-        libnvidia-compute-510- \
-        libnvidia-encode-510- \
-    && printf '\
-    Package: windrunner-service\n\
-    Pin: version %s\n\
-    Pin-Priority: 1337\n\
-    \n\
-    Package: libopenxr1-windrunner\n\
-    Pin: version %s\n\
-    Pin-Priority: 1337\n' ${WINDRUNNER_VERSION} ${WINDRUNNER_VERSION} > /etc/apt/preferences.d/pin-windrunner \
-    && update-alternatives --set openxr1-active-runtime /usr/share/openxr/1/openxr_windrunner.json
-
-ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/windrunner/lib"
-ENV LR_TRANSPORT_CERT_PATH=/opt/windrunner/share/windrunner/server.crt
-ENV LR_TRANSPORT_PKEY_PATH=/opt/windrunner/share/windrunner/server.key
-ENV WINDRUNNER_ENABLE_AUDIO=0
-ENV PATH="${PATH}:/opt/windrunner/bin"
-
-# setup Magic Leap CLI
-ENV PATH="${PATH}:/workspace/holohub/applications/volume_rendering_xr/thirdparty/magicleap"
-
 # Copy vulkan sdk
 # NOTE: It's all in x86_64 even if that's not the target platform
 # (Vulkan SDK cmake scripting issue)
 ARG VULKAN_SDK_VERSION
 ENV VULKAN_SDK=/opt/vulkansdk/${VULKAN_SDK_VERSION}
 COPY --from=vulkansdk-builder ${VULKAN_SDK}/x86_64/ ${VULKAN_SDK}
+
 # We need to use the headers and shader compiler of the SDK but want to link against the
 # Vulkan loader provided by the Ubuntu package. Therefore create a link in the SDK directory
 # pointing to the system Vulkan loader library.
@@ -138,6 +93,19 @@ RUN rm -f ${VULKAN_SDK}/lib/libvulkan.so* \
     && ln -s /lib/$(uname -m)-linux-gnu/libvulkan.so.1 ${VULKAN_SDK}/lib/libvulkan.so
 ENV PATH="${PATH}:${VULKAN_SDK}/bin"
 ENV CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:${VULKAN_SDK}"
+
+############################################################
+# Environment variables
+############################################################
+# Magic Leap Windrunner environment variables
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/windrunner/lib"
+ENV LR_TRANSPORT_CERT_PATH=/opt/windrunner/share/windrunner/server.crt
+ENV LR_TRANSPORT_PKEY_PATH=/opt/windrunner/share/windrunner/server.key
+ENV WINDRUNNER_ENABLE_AUDIO=0
+ENV PATH="${PATH}:/opt/windrunner/bin"
+
+# Setup Magic Leap CLI
+ENV PATH="${PATH}:/workspace/holohub/applications/volume_rendering_xr/thirdparty/magicleap"
 
 # Set JIT compilation cache paths
 #  https://developer.nvidia.com/blog/cuda-pro-tip-understand-fat-binaries-jit-caching/
@@ -147,7 +115,3 @@ ENV CUDA_CACHE_PATH="/workspace/holohub/.cache/ComputeCache"
 ENV OPTIX_CACHE_PATH="/workspace/holohub/.cache/OptixCache"
 #  https://download.nvidia.com/XFree86/Linux-x86_64/460.67/README/openglenvvariables.html
 ENV __GL_SHADER_DISK_CACHE_PATH="/workspace/holohub/.cache/GLCache"
-
-# all NVIDIA devices are visible, also use all driver capabilities
-ENV NVIDIA_VISIBLE_DEVICES="all"
-ENV NVIDIA_DRIVER_CAPABILITIES="all"

--- a/applications/volume_rendering_xr/README.md
+++ b/applications/volume_rendering_xr/README.md
@@ -36,8 +36,8 @@ Refer to the Magic Leap 2 documentation for more information:
 
 Run the following commands to build and enter the interactive container environment:
 ```bash
-./dev_container build --img holohub:openxr --docker_file ./applications/volume_rendering_xr/Dockerfile # Build the dev container
-./dev_container launch --docker_opts "-v $(pwd)/tmp:/home/$(whoami)" --img holohub:openxr # Launch the container
+./dev_container build --img holohub:volume_rendering_xr --docker_file ./applications/volume_rendering_xr/Dockerfile # Build the dev container
+./dev_container launch --docker_opts "-v $(pwd)/tmp:/home/$(whoami)" --img holohub:volume_rendering_xr # Launch the container
 ```
 
 Then, inside the container environment, build the application:
@@ -69,6 +69,38 @@ The application supports the following hand or controller interactions by defaul
 - **Scale**: Grab any face of the bounding box and move your hand or controller to scale the volume.
 - **Rotate**: Grab any edge of the bounding box and move your hand or controller to rotate the volume.
 - **Crop**: Grab any vertex of the bounding box and move your hand or controller to translate the cropping planes.
+
+## Deploying as a Standalone Application
+
+`volume_rendering_xr` can be packaged in a self-contained release container with datasets and binaries.
+
+To build the release container:
+```bash
+# Generate HoloHub `volume_rendering_xr` installation in the "holohub/install" folder
+./dev_container launch --img holohub:volume_rendering_xr -c ./run build volume_rendering_xr --configure-args "-DCMAKE_INSTALL_PREFIX:PATH=/workspace/holohub/install"
+./dev_container launch --img holohub:volume_rendering_xr -c cmake --build ./build --target install
+
+# Copy files into a release container
+./dev_container build --img holohub:volume_rendering_xr_rel --docker_file ./applications/volume_rendering_xr/scripts/Dockerfile.rel --base_img nvcr.io/nvidia/cuda:12.4.1-runtime-ubuntu22.04
+```
+
+To run the release container, first create the container startup script:
+```bash
+docker run --rm holohub:volume_rendering_xr_rel > ./render-volume-xr
+chmod +x ./render-volume-xr
+```
+
+Then execute the script to start the Windrunner service and the app:
+```bash
+./render-volume-xr
+```
+
+For more options, e.g. list available datasets or to select a different dataset, type
+```bash
+./render-volume-xr --help
+```
+
+Options not recognized by the render-volume-xr script are forwarded to the application.
 
 ## Additional Notes
 

--- a/applications/volume_rendering_xr/main.cpp
+++ b/applications/volume_rendering_xr/main.cpp
@@ -292,9 +292,10 @@ class App : public holoscan::Application {
 };
 
 int main(int argc, char** argv) {
-  const std::string render_config_file_default("configs/ctnv_bb_er.json");
-  const std::string density_volume_file_default("data/ctnv_bb_er/highResCT.mhd");
-  const std::string mask_volume_file_default("data/ctnv_bb_er/smoothmasks.seg.mhd");
+  // Default paths in the HoloHub development container
+  const std::string render_config_file_default("/workspace/holohub/applications/volume_rendering_xr/configs/ctnv_bb_er.json");
+  const std::string density_volume_file_default("/workspace/holohub/data/volume_rendering_xr/highResCT.mhd");
+  const std::string mask_volume_file_default("/workspace/holohub/data/volume_rendering_xr/smoothmasks.seg.mhd");
 
   std::string render_config_file(render_config_file_default);
   std::string write_config_file;

--- a/applications/volume_rendering_xr/main.cpp
+++ b/applications/volume_rendering_xr/main.cpp
@@ -293,9 +293,12 @@ class App : public holoscan::Application {
 
 int main(int argc, char** argv) {
   // Default paths in the HoloHub development container
-  const std::string render_config_file_default("/workspace/holohub/applications/volume_rendering_xr/configs/ctnv_bb_er.json");
-  const std::string density_volume_file_default("/workspace/holohub/data/volume_rendering_xr/highResCT.mhd");
-  const std::string mask_volume_file_default("/workspace/holohub/data/volume_rendering_xr/smoothmasks.seg.mhd");
+  const std::string render_config_file_default(
+      "/workspace/holohub/applications/volume_rendering_xr/configs/ctnv_bb_er.json");
+  const std::string density_volume_file_default(
+      "/workspace/holohub/data/volume_rendering_xr/highResCT.mhd");
+  const std::string mask_volume_file_default(
+      "/workspace/holohub/data/volume_rendering_xr/smoothmasks.seg.mhd");
 
   std::string render_config_file(render_config_file_default);
   std::string write_config_file;
@@ -323,8 +326,8 @@ int main(int argc, char** argv) {
     switch (c) {
       case 'h':
         std::cout
-            << "Holoscan OpenXR volume renderer."
-            << "Usage: " << argv[0] << " [options]" << std::endl
+            << "Holoscan OpenXR volume renderer." << "Usage: " << argv[0] << " [options]"
+            << std::endl
             << "Options:" << std::endl
             << "  -h, --help                            Display this information" << std::endl
             << "  -c <FILENAME>, --config <FILENAME>    Name of the renderer JSON "

--- a/applications/volume_rendering_xr/scripts/Dockerfile.rel
+++ b/applications/volume_rendering_xr/scripts/Dockerfile.rel
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+ARG BASE_IMAGE=nvcr.io/nvidia/cuda:12.4.1-runtime-ubuntu22.04
+FROM ${BASE_IMAGE} as base
+
+# Perform base setup shared with build container
+COPY /applications/volume_rendering_xr/scripts/base-setup.sh \
+    /tmp/base-setup.sh
+COPY applications/volume_rendering_xr/thirdparty/magicleap/MagicLeapRemoteRendering.gpg \
+    /usr/local/share/keyrings/magicleap/MagicLeapRemoteRendering.gpg
+RUN /tmp/base-setup.sh
+
+# Install runtime container packages
+RUN apt update && \
+    apt install --no-install-recommends -y pulseaudio
+RUN if [ -z "$(find /opt/nvidia/holoscan -name 'libholoscan_core*' -print -quit)" ]; then \
+        apt update && \
+        apt install --no-install-recommends -y holoscan; \
+    fi
+
+# copy binaries and data
+WORKDIR /workspace/holohub
+COPY /install install
+COPY /data/volume_rendering_xr data/volume_rendering_xr
+COPY /applications/volume_rendering_xr/configs configs
+COPY /applications/volume_rendering_xr/scripts/docker-entrypoint.sh /scripts/docker-entrypoint.sh
+COPY /applications/volume_rendering_xr/scripts/docker-run-release.sh /scripts/docker-run-release.sh
+COPY /applications/volume_rendering_xr/thirdparty/magicleap /scripts
+
+ENV PATH=${PATH}:/scripts
+
+ENTRYPOINT ["/scripts/docker-entrypoint.sh"]

--- a/applications/volume_rendering_xr/scripts/base-setup.sh
+++ b/applications/volume_rendering_xr/scripts/base-setup.sh
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+WINDRUNNER_VERSION=${WINDRUNNER_VERSION:-1.11.74-5b8fe25-1~20240426ubuntu2204}
+
+if [ ! -e /usr/local/share/keyrings/magicleap/MagicLeapRemoteRendering.gpg ]; then
+    echo "Could not find MagicLeapRemoteRendering.gpg"
+    ls /usr/local/share/keyrings/magicleap
+    exit 1
+fi
+
+apt update
+
+# Install dependencies
+#  libvulkan1 - Vulkan loader
+#  libegl1 - to run headless Vulkan apps
+apt install --no-install-recommends -y \
+    libopenxr-loader1 \
+    libopenxr-dev \
+    libvulkan1 \
+    libegl1 \
+    net-tools
+rm -rf /var/lib/apt/lists/*
+
+# Install Magic Leap Windrunner OpenXR backend
+LIST_FILE=/etc/apt/sources.list.d/MagicLeapRemoteRendering.list
+chmod -R 755 "/usr/local/share/keyrings/magicleap/"
+CODENAME=$(. /etc/os-release && echo "$VERSION_CODENAME")
+echo "deb [signed-by=/usr/local/share/keyrings/magicleap/MagicLeapRemoteRendering.gpg] https://apt.magicleap.cloud/Stable/ $CODENAME main" \
+        | tee "$LIST_FILE"
+chmod a+r "$LIST_FILE"
+apt update
+echo "debconf-set-selections windrunner/accept_eula boolean true" | debconf-set-selections
+apt install --no-install-recommends -y \
+        windrunner-service=${WINDRUNNER_VERSION} \
+        libopenxr1-windrunner=${WINDRUNNER_VERSION}
+rm -rf /var/lib/apt/lists/*
+
+printf 'Package: windrunner-service
+Pin: version %s
+Pin-Priority: 1337
+
+Package: libopenxr1-windrunner
+Pin: version %s
+Pin-Priority: 1337
+' ${WINDRUNNER_VERSION} ${WINDRUNNER_VERSION} > /etc/apt/preferences.d/pin-windrunner
+update-alternatives --set openxr1-active-runtime /usr/share/openxr/1/openxr_windrunner.json
+
+#  https://developer.nvidia.com/blog/cuda-pro-tip-understand-fat-binaries-jit-caching/
+mkdir -p "/workspace/holohub/.cache/ComputeCache"
+#  https://raytracing-docs.nvidia.com/optix7/api/optix__host_8h.html#a59a60f5f600df0f9321b0a0b1090d76b
+mkdir -p "/workspace/holohub/.cache/OptixCache"
+# https://download.nvidia.com/XFree86/Linux-x86_64/460.67/README/openglenvvariables.html
+mkdir -p "/workspace/holohub/.cache/GLCache"

--- a/applications/volume_rendering_xr/scripts/docker-entrypoint.sh
+++ b/applications/volume_rendering_xr/scripts/docker-entrypoint.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is the entrypoint file for the docker release container. Executed in container at runtime.
+
+if [ $# == 0 ] && [ "$STARTED_FROM_SCRIPT" != "1" ]; then
+    # the image has been run directly help the user to get started by outputting the render_volume_xr script.
+    cat /scripts/docker-run-release.sh
+    echo ""
+    echo "##############################################################################"
+    echo "# Please redirect this output to a script and use the script to execute the app"
+    echo "#   $ docker run --rm holoscan-openxr > ./render-volume-xr"
+    echo "#   $ chmod +x ./render-volume-xr"
+    echo "# Run app with default dataset"
+    echo "#   $ ./render-volume-xr"
+    echo "# List datasets"
+    echo "#   $ ./render-volume-xr --list"
+    echo "# Run app with dataset"
+    echo "#   $ ./render-volume-xr --dataset DATASET_NAME"
+    echo "##############################################################################"
+    exit 0
+fi
+
+# arguments for each dataset
+declare -A datasets
+datasets[highResCT]="-c configs/ctnv_bb_er.json -d data/volume_rendering_xr/highResCT.mhd -m data/volume_rendering_xr/smoothmasks.seg.mhd"
+# developers may manually add more datasets here for local packaging:
+# datasets[name]="..."
+
+# Parse arguments
+ARGS=("$@")
+dataset="highResCT"
+SKIP_NEXT=0
+for i in "${!ARGS[@]}"; do
+    arg="${ARGS[i]}"
+    if [ "${SKIP_NEXT}" = "1" ]; then
+        continue
+    elif [ "$arg" = "--help" ]; then
+        echo "Holoscan OpenXR demo release container entrypoint"
+        echo ""
+        echo "Arguments:"
+        echo "  --help : print this help message"
+        echo "  --list : list available datasets"
+        echo "  --dataset <dataset> : use the specified dataset"
+        echo ""
+        echo "Remaining arguments are passed to the app. Additional options:"
+        echo ""
+        /workspace/holohub/install/bin/volume_rendering_xr --help
+        exit 0
+    elif [ "$arg" = "--list" ]; then
+        echo "Available datasets"
+        echo ${!datasets[@]}
+        exit 0
+    elif [ "$arg" = "--dataset" ]; then
+        dataset="${ARGS[i+1]}"
+        SKIP_NEXT="1"
+    else
+        arguments+=" $arg"
+    fi
+done
+
+if [[ -z $dataset ]]; then
+    echo "No dataset selected"
+    exit 1
+else 
+    if [[ ${datasets[@]} =~ $dataset ]]; then
+        arguments+="${datasets[$dataset]}"
+    else
+        echo "Dataset $dataset not found"
+        exit -1
+    fi
+fi
+
+# run the windrunner service in the background
+# Make sure sys_nice setting is accurate for the current host
+dpkg-reconfigure windrunner-service
+
+# Workaround: need to manually start pulseaudio before windrunner-service
+# in the cuda-runtime container
+pulseaudio --check
+pulseaudio -D
+
+# Workaround: need to set the HOME directory, windrunner service is expecting this to exist to write the log files
+HOME=/tmp
+XRT_SKIP_STDIN='true' windrunner-service &
+
+# display the pairing QR code
+setup_viewer --mode qr --qr_output terminal
+
+# now run the app
+echo "Running from $(pwd): /workspace/holohub/install/bin/volume_rendering_xr $arguments"
+/workspace/holohub/install/bin/volume_rendering_xr $arguments

--- a/applications/volume_rendering_xr/scripts/docker-run-release.sh
+++ b/applications/volume_rendering_xr/scripts/docker-run-release.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is the script to run the docker release container.
+IMAGE_TAG=holohub:volume_rendering_xr_rel
+
+container_runtime_version=$(nvidia-container-toolkit --version | grep -Po '(?<=version )\d.\d.')
+if [[ $(echo -e "$container_runtime_version\n1.2" | sort -V | head -n1) != "1.2" ]]; then
+    # at least version 1.2 is needed for Vulkan and EGL support without the need for manually mapping files into the container
+    echo "At least NVIDIA Container Runtime version 1.2 is required, but found $container_runtime_version"
+    echo "Please visit https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html to update."
+    exit 1
+fi
+
+# Find the nvoptix.bin file
+if [ -f "/usr/share/nvidia/nvoptix.bin" ]; then
+    mount_nvoptix_bin="-v /usr/share/nvidia/nvoptix.bin:/usr/share/nvidia/nvoptix.bin:ro"
+fi
+
+# Parse arguments
+ARGS=("$@")
+SKIP_NEXT=0
+for i in "${!ARGS[@]}"; do
+    arg="${ARGS[i]}"
+    if [ "$SKIP_NEXT" == "1" ]; then
+        SKIP_NEXT=0
+        continue
+    elif [ "$arg" = "--help" ]; then
+        echo "Holoscan OpenXR demo docker run script"
+        echo ""
+        echo "Arguments:"
+        echo "  --help : print this help message"
+        echo "  -v : pass to docker command to mount volumes (can be specified multiple times)"
+        echo ""
+        echo "Remaining arguments are passed to the release container entrypoint. Additional options:"
+        echo ""
+        # pass to docker entry point to print
+        arguments="--help"
+        break
+    elif [ "$arg" = "-v" ]; then
+        volumes+="${ARGS[i+1]}"
+        SKIP_NEXT="1"
+    else
+        arguments+=" $arg"
+    fi
+done
+
+# DOCKER PARAMETERS
+#
+# -it
+#   The container needs to be interactive to be able to interact with the X11 windows
+#
+# --rm
+#   Deletes the container after the command runs
+#
+# --runtime=nvidia \
+#   Enable GPU acceleration
+#
+# -v /tmp/.X11-unix:/tmp/.X11-unix
+# -e DISPLAY
+#   Enable graphical applications
+#
+# --cap-add=sys_nice
+#   Allow to change scheduling priorities, required by windrunner-service
+#
+# ${mount_nvoptix_bin}
+#   Mount Optix denoiser weights when present.
+#
+# ${volumes}
+#   User specified volumes to mount.
+#
+# -v /tmp:/shader_cache
+# -e CUDA_CACHE_PATH="/shader_cache/ComputeCache"
+# -e OPTIX_CACHE_PATH="/shader_cache/.cache/OptixCache"
+# -e __GL_SHADER_DISK_CACHE_PATH="/shader_cache//.cache/GLCache"
+#   Persistent shader disk cache
+#
+# -e STARTED_FROM_SCRIPT=1
+#   Indicates to entry point that the container had been started by a script
+#
+docker run --rm -it \
+    --net host \
+    -u $(id -u):$(id -g) \
+    -e HOME=/tmp \
+    --runtime=nvidia \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -e DISPLAY \
+    -e NVIDIA_DRIVER_CAPABILITIES=graphics,video,compute,utility,display \
+    --cap-add=sys_nice \
+    ${mount_nvoptix_bin} \
+    ${volumes} \
+    -v /tmp/.cache:/tmp/.cache \
+    -e CUDA_CACHE_PATH="/tmp/.cache/ComputeCache" \
+    -e OPTIX_CACHE_PATH="/tmp/.cache/OptixCache" \
+    -e __GL_SHADER_DISK_CACHE_PATH="/tmp/.cache/GLCache" \
+    -e STARTED_FROM_SCRIPT=1 \
+    ${IMAGE_TAG} $arguments

--- a/operators/XrFrameOp/CMakeLists.txt
+++ b/operators/XrFrameOp/CMakeLists.txt
@@ -84,5 +84,8 @@ target_include_directories(frame_op INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/conver
 target_include_directories(frame_op INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/begin_frame)
 target_include_directories(frame_op INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/end_frame)
 
-
+install(
+  TARGETS frame_op
+  EXPORT holoscan-ops
+)
 

--- a/operators/XrTransformOp/CMakeLists.txt
+++ b/operators/XrTransformOp/CMakeLists.txt
@@ -89,3 +89,8 @@ target_include_directories(xr_transform_op INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}
 target_include_directories(xr_transform_op INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/XrTransformRenderOp)
 target_include_directories(xr_transform_op INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/XrTransformControlOp)
 target_include_directories(xr_transform_op INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/ux)
+
+install(
+  TARGETS xr_transform_op
+  EXPORT holoscan-ops
+)

--- a/operators/volume_loader/CMakeLists.txt
+++ b/operators/volume_loader/CMakeLists.txt
@@ -64,3 +64,7 @@ target_link_libraries(volume_loader
 target_include_directories(volume_loader INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_definitions(volume_loader PRIVATE HOLOSCAN_MAJOR_VERSION=${holoscan_VERSION_MAJOR})
 target_compile_definitions(volume_loader PRIVATE HOLOSCAN_MINOR_VERSION=${holoscan_VERSION_MINOR})
+
+install(TARGETS volume_loader
+  COMPONENT holoscan-ops
+)

--- a/operators/volume_renderer/CMakeLists.txt
+++ b/operators/volume_renderer/CMakeLists.txt
@@ -64,6 +64,9 @@ set(FETCHCONTENT_QUIET ON)
 set(CLARA_VIZ_PUBLIC_CMAKE_TOOLS_DIR "${claraviz_SOURCE_DIR}/cmake")
 
 find_package(clara_viz_renderer REQUIRED HINTS ${claraviz_SOURCE_DIR}/cmake)
+install(IMPORTED_RUNTIME_ARTIFACTS clara::viz::renderer
+  COMPONENT "volume_renderer"
+)
 
 add_library(volume_renderer SHARED
   dataset.cpp
@@ -86,3 +89,8 @@ target_link_libraries(volume_renderer
 target_include_directories(volume_renderer INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_definitions(volume_renderer PRIVATE HOLOSCAN_MAJOR_VERSION=${holoscan_VERSION_MAJOR})
 target_compile_definitions(volume_renderer PRIVATE HOLOSCAN_MINOR_VERSION=${holoscan_VERSION_MINOR})
+
+install(
+  TARGETS volume_renderer
+  EXPORT holoscan-ops
+)

--- a/operators/volume_renderer/volume_renderer.cpp
+++ b/operators/volume_renderer/volume_renderer.cpp
@@ -1,5 +1,5 @@
-/* SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
+/* SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ static clara::viz::Vector2f toTangentX(const nvidia::gxf::CameraModel& camera_mo
 
 static clara::viz::Vector2f toTangentY(const nvidia::gxf::CameraModel& camera_model) {
   return clara::viz::Vector2f(
-       camera_model.principal_point.y / camera_model.focal_length.y,
+      camera_model.principal_point.y / camera_model.focal_length.y,
       -(camera_model.dimensions.y - camera_model.principal_point.y) / camera_model.focal_length.y);
 }
 
@@ -302,7 +302,8 @@ void VolumeRendererOp::start() {
     // setup renderer by reading settings from the configuration file
     std::ifstream input_file_stream(impl_->config_file_.get());
     if (!input_file_stream) {
-      throw std::runtime_error("Could not open configuration " + impl_->config_file_.get() + " for reading");
+      throw std::runtime_error("Could not open configuration " + impl_->config_file_.get() +
+                               " for reading");
     }
 
     const nlohmann::json settings = nlohmann::json::parse(input_file_stream);

--- a/operators/volume_renderer/volume_renderer.cpp
+++ b/operators/volume_renderer/volume_renderer.cpp
@@ -302,7 +302,7 @@ void VolumeRendererOp::start() {
     // setup renderer by reading settings from the configuration file
     std::ifstream input_file_stream(impl_->config_file_.get());
     if (!input_file_stream) {
-      throw std::runtime_error("Could not open configuration for reading");
+      throw std::runtime_error("Could not open configuration " + impl_->config_file_.get() + " for reading");
     }
 
     const nlohmann::json settings = nlohmann::json::parse(input_file_stream);


### PR DESCRIPTION
Adds custom Dockerfile, scripts, and documentation to support releasing
`volume_rendering_xr` in a standalone, self-contained container with a
command line interface.

The primary advantage of packaging a release container is to allow
sharing a built `volume_rendering_xr` application with another machine
or another user with minimum setup. After following the README to build
the container, the release container can then be shared as a compressed
file or from a container registry.

The `volume_rendering_xr` release container is based on the
`nvidia-cuda-runtime` container publicly available from NGC. The release
container is approximately 3GB in size, while the build container is
approximately 10GB in size.

Currently only one volume dataset is currently available for packaging. Other
datasets could be added locally before packaging is carried out.

This work is based on prior development in collaboration between the
NVIDIA Holoscan and Magic Leap teams. Verified on x86_64 and IGX (aarch64) platforms.