### PR TITLE
App: Update endoscopy_depth_estimation to work with latest Holoscan SDK v2.0.0

### DIFF
--- a/applications/endoscopy_depth_estimation/Dockerfile
+++ b/applications/endoscopy_depth_estimation/Dockerfile
@@ -1,41 +1,55 @@
-FROM nvcr.io/nvidia/clara-holoscan/holoscan:v0.6.0-dgpu
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as base
+
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Set default shell to /bin/bash
 SHELL ["/bin/bash", "-cu"]
 
-RUN apt-get update && apt-get install -y build-essential cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev && apt-get install -y libjpeg-dev libpng-dev libtiff5-dev libdc1394-22-dev libeigen3-dev libtheora-dev libvorbis-dev libxvidcore-dev libx264-dev sphinx-common libtbb-dev yasm libfaac-dev libopencore-amrnb-dev libopencore-amrwb-dev libopenexr-dev libgstreamer-plugins-base1.0-dev libavutil-dev libavfilter-dev libavresample-dev && apt-get install -y libjsoncpp-dev && apt-get clean
 
-RUN chmod +rwx /usr/bin/python3.8
+RUN apt-get update && apt-get install -y build-essential cmake git \
+    libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev \
+    libjpeg-dev libpng-dev libtiff5-dev libdc1394-dev libeigen3-dev libtheora-dev \
+    libvorbis-dev libxvidcore-dev libx264-dev sphinx-common libtbb-dev yasm \
+    libfaac-dev libopencore-amrnb-dev libopencore-amrwb-dev libopenexr-dev \
+    libgstreamer-plugins-base1.0-dev libavutil-dev libavfilter-dev libjsoncpp-dev ffmpeg \
+     && apt-get clean
+
+RUN chmod +rwx /usr/bin/python3.10
 
 # Install OpenCV
 RUN git clone https://github.com/opencv/opencv.git && git clone https://github.com/opencv/opencv_contrib.git && \
- 	cd opencv && mkdir -p build && cd build && \
- 	cmake -D CMAKE_BUILD_TYPE=RELEASE \
-	-D CMAKE_INSTALL_PREFIX=/usr/local \
-	-D WITH_TBB=ON \
-	-D ENABLE_FAST_MATH=1 \
-	-D CUDA_FAST_MATH=1 \
-	-D WITH_CUBLAS=1 \
-	-D WITH_CUDA=ON \
-	-D BUILD_opencv_cudacodec=OFF \
-	-D WITH_CUDNN=ON \
-	-D OPENCV_DNN_CUDA=ON \
-	-D CUDA_ARCH_BIN=8.6 \
-	-D WITH_V4L=ON \
-	-D WITH_QT=OFF \
-	-D WITH_OPENGL=ON \
-	-D WITH_GSTREAMER=ON \
-	-D OPENCV_GENERATE_PKGCONFIG=ON \
-	-D OPENCV_PC_FILE_NAME=opencv.pc \
-	-D OPENCV_ENABLE_NONFREE=ON \
-	-D PYTHON3_PACKAGES_PATH=/usr/lib/python3.8/dist-packages \
-	-D PYTHON_EXECUTABLE=/usr/bin/python \
-	-D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib/modules \
-	-D INSTALL_PYTHON_EXAMPLES=OFF \
-	-D INSTALL_C_EXAMPLES=OFF \
-	-D BUILD_EXAMPLES=OFF .. && \
-	make -j8 && \
-	make install && \
-	ldconfig
+    cd opencv && mkdir -p build && cd build && \
+    cmake -D CMAKE_BUILD_TYPE=RELEASE \
+    -D CMAKE_INSTALL_PREFIX=/usr/local \
+    -D BUILD_TESTS=OFF \
+    -D BUILD_PERF_TESTS=OFF \
+    -D BUILD_opencv_apps=OFF \
+    -D BUILD_EXAMPLES=OFF \
+    -D BUILD_DOCS=OFF \
+    -D INSTALL_PYTHON_EXAMPLES=OFF \
+    -D INSTALL_C_EXAMPLES=OFF \
+    -D WITH_TBB=ON \
+    -D ENABLE_FAST_MATH=1 \
+    -D CUDA_FAST_MATH=1 \
+    -D WITH_CUBLAS=1 \
+    -D WITH_CUDA=ON \
+    -D BUILD_opencv_cudacodec=OFF \
+    -D WITH_CUDNN=ON \
+    -D OPENCV_DNN_CUDA=ON \
+    -D CUDA_ARCH_BIN=8.6,8.7,8.9 \
+    -D WITH_V4L=ON \
+    -D WITH_QT=OFF \
+    -D WITH_OPENGL=ON \
+    -D WITH_GSTREAMER=ON \
+    -D OPENCV_GENERATE_PKGCONFIG=ON \
+    -D OPENCV_PC_FILE_NAME=opencv.pc \
+    -D OPENCV_ENABLE_NONFREE=ON \
+    -D PYTHON3_PACKAGES_PATH=/usr/lib/python3.10/dist-packages \
+    -D PYTHON_EXECUTABLE=/usr/bin/python \
+    -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib/modules \
+    .. && \
+    make -j8 && \
+    make install && \
+    ldconfig

--- a/applications/endoscopy_depth_estimation/README.md
+++ b/applications/endoscopy_depth_estimation/README.md
@@ -129,7 +129,7 @@ cd <HOLOHUB_SOURCE_DIR>
 #### Launch container
 
 ```bash
-./dev_container  launch   --as_root  --img holohub:depth_estimation
+./dev_container  launch  --img holohub:depth_estimation
 ```
 
 #### Build app

--- a/applications/endoscopy_depth_estimation/README.md
+++ b/applications/endoscopy_depth_estimation/README.md
@@ -40,7 +40,7 @@ Once the `GPUMat` processing has finished, we have to convert it back to a CuPy 
 <hr/>
 
 **Important:** In order to run this application with CUDA acceleration, one must compile [OpenCV with CUDA support](https://docs.opencv.org/4.8.0/d2/dbc/cuda_intro.html).
-We provide a sample [Dockerfile](./Dockerfile) to build a container based on Holoscan v0.6.0 with the latest version of OpenCV and CUDA support.
+We provide a sample [Dockerfile](./Dockerfile) to build a container based on Holoscan v2.0.0 with the latest version of OpenCV and CUDA support.
 In case you use it, note that the variable [`CUDA_ARCH_BIN` ](./Dockerfile#L25) must be modified according to your specific GPU
 configuration. Refer to [this site](https://developer.nvidia.com/cuda-gpus) to find out your NVIDIA GPU architecture.
 
@@ -76,6 +76,8 @@ and mixed with the original video in the custom [`DepthPostProcessingOp`](./endo
 rendering with [Holoviz](https://docs.nvidia.com/clara-holoscan/sdk-user-guide/holoscan_operators_extensions.html#operators).
 
 
+
+
 ### Run Instructions
 
 To run this application, you'll need to configure your PYTHONPATH environment variable to locate the
@@ -107,3 +109,38 @@ Next, run the command to run the application:
 cd <HOLOHUB_BUILD_DIR>
 python3 <HOLOHUB_SOURCE_DIR>/applications/endoscopy_depth_estimation/endoscopy_depth_estimation.py --data=<DATA_DIR> --model=<MODEL_DIR> --clahe
 ```
+
+
+### Container Build & Rud Instructions
+
+Build container using Holoscan 2.0.0 NGC container as base image and built OpenCV with CUDA ARCH 8.6, 8.7 and 8.9 support for IGX Orin and AGX Orin iGPU and Ampere and Ada Lovelace Architecture dGPUs.
+
+#### Change directory to Holohub source directory
+
+```bash
+cd <HOLOHUB_SOURCE_DIR>
+```
+#### Build container
+
+```bash
+./dev_container build --docker_file applications/endoscopy_depth_estimation/Dockerfile  --img  holohub:depth_estimation
+```
+
+#### Launch container
+
+```bash
+./dev_container  launch   --as_root  --img holohub:depth_estimation
+```
+
+#### Build app
+
+```bash
+./run build endoscopy_depth_estimation
+```
+
+#### Launch app
+
+```bash
+python3 applications/endoscopy_depth_estimation/endoscopy_depth_estimation.py  --data=data/endoscopy --model=data/endoscopy_depth/
+```
+


### PR DESCRIPTION
Changes: 

Dockerfile: Update to work with latest Holoscan SDK v2.0.0. 
Update dependency packages for Ubuntu 22.04 based container. 
OpenCV build enables CUDA ARCH 8.6 (Ampere dGPU), 8.7 (Orin iGPU) and 8.9 (Ada Lovelace dGPU)

README: Added simple step by step instructions from building container to launch app. S

Tested on x86, Ubuntu 22.04 with RTX A4000 and RTX 6000 ADA 