### PR TITLE
App: Update run commands for per-app build folder paths

### DIFF
--- a/applications/body_pose_estimation/metadata.json
+++ b/applications/body_pose_estimation/metadata.json
@@ -42,7 +42,7 @@
 			]
 		},
 		"run": {
-			"command": "python3 ../applications/body_pose_estimation/body_pose_estimation.py",
+			"command": "python3 <holohub_app_source>/body_pose_estimation.py",
 			"workdir": "holohub_bin"
 		}
 	}

--- a/applications/tao_peoplenet/metadata.json
+++ b/applications/tao_peoplenet/metadata.json
@@ -31,7 +31,7 @@
 			"model": "https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tao/models/peoplenet"
 		},
 		"run": {
-			"command": "python3 ../applications/tao_peoplenet/tao_peoplenet.py",
+			"command": "python3 <holohub_app_source>/tao_peoplenet.py",
 			"workdir": "holohub_bin"
 		}
 	}


### PR DESCRIPTION
Update `body_pose_estimation` and `tao_peoplenet` to use HoloHub pre-defined path keywords instead of relying on relative pathing between the build and source directories.

As of 3d4100ac HoloHub now defines a new build subfolder for each project instead of using one overarching build for the entire project.

Verified with `body_pose_estimation` command:
```
dev_container build_and_run body_pose_estimation
```

EDIT: I checked that the above command launched, but not that the app ran fully. As reported below, there is still an issue with data paths that will be resolved in a subsequent PR.