### PR TITLE
App: Update `cuda_quantum` application for `build_and_run` compatibility

### DIFF
--- a/applications/cuda_quantum/metadata.json
+++ b/applications/cuda_quantum/metadata.json
@@ -32,8 +32,8 @@
             "cuda_quantum": "^0.4.0"
         },
         "run": {
-            "command": "python3 cuda_quantum.py",
-            "workdir": "holohub_bin"
+            "command": "pip install -r requirements.txt && python3 cuda_quantum.py",
+            "workdir": "holohub_app_source"
         }
     }
 }


### PR DESCRIPTION
Changes:
- Updates `cuda_quantum` run command to execute from the app source directory. Under previous behavior the run command failed because `cuda_quantum.py` was not in the working directory.
- Install requirements as part of the run command. We typically prefer to use a dedicated Dockerfile for HoloHub app environments, but in doing so `cuda_quantum` dependencies install with root permissions and are inaccessible when running the container as a non-superuser by default. Instead we can install dependencies each time for demonstration.

Validated on x86_64.