### PR TITLE
App: Update data path environment variable

### DIFF
--- a/applications/body_pose_estimation/body_pose_estimation.py
+++ b/applications/body_pose_estimation/body_pose_estimation.py
@@ -339,7 +339,7 @@ class BodyPoseEstimationApp(Application):
 
         if data == "none":
             data = os.path.join(
-                os.environ.get("HOLOSCAN_DATA_PATH", "../data"), "body_pose_estimation"
+                os.environ.get("HOLOHUB_DATA_PATH", "../data"), "body_pose_estimation"
             )
 
         self.sample_data_path = data

--- a/applications/colonoscopy_segmentation/colonoscopy_segmentation.py
+++ b/applications/colonoscopy_segmentation/colonoscopy_segmentation.py
@@ -49,7 +49,7 @@ class ColonoscopyApp(Application):
         self.source = source
 
         if data == "none":
-            data = os.environ.get("HOLOSCAN_DATA_PATH", "../data")
+            data = os.environ.get("HOLOHUB_DATA_PATH", "../data")
 
         self.sample_data_path = data
 

--- a/applications/cvcuda_basic/python/cvcuda_basic.py
+++ b/applications/cvcuda_basic/python/cvcuda_basic.py
@@ -86,7 +86,7 @@ class MyVideoProcessingApp(Application):
         super().__init__(*args, **kwargs)
 
         if data == "none":
-            data = os.path.join(os.environ.get("HOLOSCAN_DATA_PATH", "../data"), "endoscopy")
+            data = os.path.join(os.environ.get("HOLOHUB_DATA_PATH", "../data"), "endoscopy")
 
         self.sample_data_path = data
         self.count = count

--- a/applications/endoscopy_depth_estimation/endoscopy_depth_estimation.py
+++ b/applications/endoscopy_depth_estimation/endoscopy_depth_estimation.py
@@ -200,7 +200,7 @@ class DepthApp(Application):
         # set name
         self.name = "Depth App"
 
-        data = os.environ.get("HOLOSCAN_DATA_PATH", "../data") if data is None else data
+        data = os.environ.get("HOLOHUB_DATA_PATH", "../data") if data is None else data
         model = data if model is None else model
 
         self.data_path = data

--- a/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py
+++ b/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py
@@ -65,7 +65,7 @@ class EndoscopyApp(Application):
         self.source = source
 
         if data == "none":
-            data = os.environ.get("HOLOSCAN_DATA_PATH", "../data")
+            data = os.environ.get("HOLOHUB_DATA_PATH", "../data")
 
         self.sample_data_path = data
 

--- a/applications/hyperspectral_segmentation/hyperspectral_segmentation.py
+++ b/applications/hyperspectral_segmentation/hyperspectral_segmentation.py
@@ -178,7 +178,7 @@ class HSApp(Application):
     def __init__(self, data=None, model=None, output_folder=None, count=-1):
         """Hyperspectral segmentation application"""
         super().__init__()
-        data = os.environ.get("HOLOSCAN_DATA_PATH", "../data") if data is None else data
+        data = os.environ.get("HOLOHUB_DATA_PATH", "../data") if data is None else data
         model = data if model is None else model
 
         self.count = count

--- a/applications/monai_endoscopic_tool_seg/tool_segmentation.py
+++ b/applications/monai_endoscopic_tool_seg/tool_segmentation.py
@@ -49,7 +49,7 @@ class EndoToolSegApp(Application):
         self.source = source
 
         if data == "none":
-            data = os.environ.get("HOLOSCAN_DATA_PATH", "../data")
+            data = os.environ.get("HOLOHUB_DATA_PATH", "../data")
 
         self.sample_data_path = data
 

--- a/applications/multiai_endoscopy/python/multi_ai.py
+++ b/applications/multiai_endoscopy/python/multi_ai.py
@@ -127,7 +127,7 @@ class MultiAIDetectionSegmentation(Application):
         super().__init__()
 
         if data == "none":
-            data = os.environ.get("HOLOSCAN_DATA_PATH", "../data")
+            data = os.environ.get("HOLOHUB_DATA_PATH", "../data")
 
         # set name
         self.name = "Multi AI App"

--- a/applications/multiai_ultrasound/python/multiai_ultrasound.py
+++ b/applications/multiai_ultrasound/python/multiai_ultrasound.py
@@ -35,7 +35,7 @@ class MultiAIICardio(Application):
         super().__init__()
 
         if data == "none":
-            data = os.environ.get("HOLOSCAN_DATA_PATH", "../data")
+            data = os.environ.get("HOLOHUB_DATA_PATH", "../data")
 
         # set name
         self.name = "Ultrasound App"

--- a/applications/openigtlink_3dslicer/python/openigtlink_3dslicer.py
+++ b/applications/openigtlink_3dslicer/python/openigtlink_3dslicer.py
@@ -42,7 +42,7 @@ class OpenIGTLinkApp(Application):
         self.name = "Endoscopy App"
 
         self.sample_data_path = os.environ.get(
-            "HOLOSCAN_DATA_PATH", "../data/colonoscopy_segmentation"
+            "HOLOHUB_DATA_PATH", "../data/colonoscopy_segmentation"
         )
 
         self.model_path_map = {

--- a/applications/orsi/orsi_in_out_body/python/orsi_in_out_body.py
+++ b/applications/orsi/orsi_in_out_body/python/orsi_in_out_body.py
@@ -30,7 +30,7 @@ class OrsiInOutBodyApp(Application):
     def __init__(self):
         super().__init__()
         self.name = "OrsiInOutBodyApp"
-        self.data_path = os.environ.get("HOLOSCAN_DATA_PATH", "../data/orsi")
+        self.data_path = os.environ.get("HOLOHUB_DATA_PATH", "../data/orsi")
 
     def compose(self):
         allocator = UnboundedAllocator(self, name="allocator")

--- a/applications/orsi/orsi_multi_ai_ar/python/orsi_multi_ai_ar.py
+++ b/applications/orsi/orsi_multi_ai_ar/python/orsi_multi_ai_ar.py
@@ -31,7 +31,7 @@ class OrsiMultiAIARApp(Application):
     def __init__(self):
         super().__init__()
         self.name = "OrsiMultiAIAR"
-        self.data_path = os.path.abspath(os.environ.get("HOLOSCAN_DATA_PATH", "../data/orsi"))
+        self.data_path = os.path.abspath(os.environ.get("HOLOHUB_DATA_PATH", "../data/orsi"))
 
     def compose(self):
         allocator = UnboundedAllocator(self, name="allocator")

--- a/applications/orsi/orsi_segmentation_ar/python/orsi_segmentation_ar.py
+++ b/applications/orsi/orsi_segmentation_ar/python/orsi_segmentation_ar.py
@@ -32,7 +32,7 @@ class OrsiSegmentationARApp(Application):
     def __init__(self):
         super().__init__()
         self.name = "OrsiSegmentationAR"
-        self.data_path = os.path.abspath(os.environ.get("HOLOSCAN_DATA_PATH", "../data/orsi"))
+        self.data_path = os.path.abspath(os.environ.get("HOLOHUB_DATA_PATH", "../data/orsi"))
 
     def compose(self):
         allocator = UnboundedAllocator(self, name="allocator")

--- a/applications/ultrasound_segmentation/python/ultrasound_segmentation.py
+++ b/applications/ultrasound_segmentation/python/ultrasound_segmentation.py
@@ -49,7 +49,7 @@ class UltrasoundApp(Application):
         self.source = source
 
         if data == "none":
-            data = os.environ.get("HOLOSCAN_DATA_PATH", "../data")
+            data = os.environ.get("HOLOHUB_DATA_PATH", "../data")
 
         self.sample_data_path = data
 

--- a/applications/webrtc_video_server/webrtc_server.py
+++ b/applications/webrtc_video_server/webrtc_server.py
@@ -144,7 +144,7 @@ class WebRTCServerApp(holoscan.core.Application):
         self._cmdline_args = cmdline_args
 
     def compose(self):
-        data = os.environ.get("HOLOSCAN_DATA_PATH", "../data")
+        data = os.environ.get("HOLOHUB_DATA_PATH", "../data")
         video_replayer = holoscan.operators.VideoStreamReplayerOp(
             self,
             name="video_replayer",

--- a/applications/yolo_model_deployment/yolo_detection.py
+++ b/applications/yolo_model_deployment/yolo_detection.py
@@ -104,7 +104,7 @@ class YoloDetApp(Application):
         self.source = source
 
         if data == "none":
-            data = os.environ.get("HOLOSCAN_DATA_PATH", "./")
+            data = os.environ.get("HOLOHUB_DATA_PATH", "./")
 
         self.model_path_map = {"yolo_det": os.path.join(data, "yolov8-nms-update.onnx")}
 

--- a/run
+++ b/run
@@ -815,8 +815,8 @@ for k, v in obj["application"]["run"].items():
       workdir="cd ${holohub_build_dir}"
    fi
 
-   local environment="export PYTHONPATH=\${PYTHONPATH}:${holoscan_sdk_install}/../../../python/lib:${holohub_build_dir}/python/lib:${SCRIPT_DIR}"
-   local reset_environment="export PYTHONPATH=${PYTHONPATH}"
+   local environment="export PYTHONPATH=\${PYTHONPATH}:${holoscan_sdk_install}/../../../python/lib:${holohub_build_dir}/python/lib:${SCRIPT_DIR} && export HOLOHUB_DATA_PATH=${holohub_data_dir}"
+   local reset_environment="export PYTHONPATH=${PYTHONPATH} && export HOLOHUB_DATA_PATH=\"${HOLOHUB_DATA_PATH}\""
 
    if [ ${verbose} ]; then
     echo "Run environment: $environment"

--- a/tutorials/creating-multi-node-applications/scenario1/multi_ai.py
+++ b/tutorials/creating-multi-node-applications/scenario1/multi_ai.py
@@ -268,7 +268,7 @@ class MultiAIDetectionSegmentation(Application):
         super().__init__()
 
         if data == "none":
-            data = os.environ.get("HOLOSCAN_DATA_PATH", "../data")
+            data = os.environ.get("HOLOHUB_DATA_PATH", "../data")
 
         # set name
         self.name = "Multi AI App"

--- a/tutorials/creating-multi-node-applications/scenario2/endoscopy_distributed_app.py
+++ b/tutorials/creating-multi-node-applications/scenario2/endoscopy_distributed_app.py
@@ -303,7 +303,7 @@ class EndoscopyDistributedApp(Application):
         self.source = source
 
         if data == "none":
-            data = os.environ.get("HOLOSCAN_DATA_PATH", "../data")
+            data = os.environ.get("HOLOHUB_DATA_PATH", "../data")
 
         self.sample_data_path = data
 


### PR DESCRIPTION
Updates HoloHub apps as follows:
- Use `HOLOHUB_DATA_PATH` instead of `HOLOSCAN_DATA_PATH`, which is not set in HoloHub
- Update `run` script to set `HOLOHUB_DATA_PATH` as an environment variable at runtime. The script already parses the data path from `CMakeCache.txt` , but previously did not set the corresponding environment variable.

Fixes https://github.com/nvidia-holoscan/holohub/issues/323