### PR TITLE
Update GXF ENC/DEC support to GXF 4.0

### DIFF
--- a/applications/h264/h264_endoscopy_tool_tracking/main.cpp
+++ b/applications/h264/h264_endoscopy_tool_tracking/main.cpp
@@ -57,14 +57,12 @@ class App : public holoscan::Application {
     auto video_decoder_request = make_operator<ops::VideoDecoderRequestOp>(
         "video_decoder_request",
         from_config("video_decoder_request"),
-        request_condition,
         Arg("async_scheduling_term") = request_condition,
         Arg("videodecoder_context") = video_decoder_context);
 
     auto video_decoder_response = make_operator<ops::VideoDecoderResponseOp>(
         "video_decoder_response",
         from_config("video_decoder_response"),
-        response_condition,
         Arg("pool") =
             make_resource<BlockMemoryPool>("pool", 1, source_block_size, source_num_blocks),
         Arg("videodecoder_context") = video_decoder_context);
@@ -138,7 +136,6 @@ class App : public holoscan::Application {
       auto video_encoder_response = make_operator<ops::VideoEncoderResponseOp>(
           "video_encoder_response",
           from_config("video_encoder_response"),
-          encoder_async_condition,
           Arg("pool") =
               make_resource<BlockMemoryPool>("pool", 1, source_block_size, source_num_blocks),
           Arg("videoencoder_context") = video_encoder_context);

--- a/applications/h264/h264_endoscopy_tool_tracking/metadata.json
+++ b/applications/h264/h264_endoscopy_tool_tracking/metadata.json
@@ -8,14 +8,15 @@
 			}
 		],
 		"language": "C++",
-		"version": "1.0",
+		"version": "2.0",
 		"changelog": {
-			"1.0": "Initial Release"
+			"1.0": "Initial Release",
+			"2.0": "Upgrade to GXF 4.0"
 		},
 		"holoscan_sdk": {
-			"minimum_required_version": "1.0.0",
+			"minimum_required_version": "2.0.0",
 			"tested_versions": [
-				"1.0.0"
+				"2.0.0"
 			]
 		},
 		"platforms": [
@@ -32,12 +33,21 @@
 			"operators": [
 				{
 					"name": "videodecoder",
-					"version": "1.0"
+					"version": "1.2.0"
 				},
 				{
+                                        "name": "videodecoderio",
+                                        "version": "1.2.0"
+                                },
+				{
 					"name": "videoencoder",
-					"version": "1.0"
-				}
+					"version": "1.2.0"
+				},
+                                {
+                                        "name": "videoencoderio",
+                                        "version": "1.2.0"
+                                }
+
 			]
 		},
 		"run": {

--- a/applications/h264/h264_video_decode/main.cpp
+++ b/applications/h264/h264_video_decode/main.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,14 +58,12 @@ class App : public holoscan::Application {
     auto video_decoder_request = make_operator<ops::VideoDecoderRequestOp>(
         "video_decoder_request",
         from_config("video_decoder_request"),
-        request_condition,
         Arg("async_scheduling_term") = request_condition,
         Arg("videodecoder_context") = video_decoder_context);
 
     auto video_decoder_response = make_operator<ops::VideoDecoderResponseOp>(
         "video_decoder_response",
         from_config("video_decoder_response"),
-        response_condition,
         Arg("pool") =
             make_resource<BlockMemoryPool>(
                 "pool", 1, source_block_size, source_num_blocks),

--- a/applications/h264/h264_video_decode/metadata.json
+++ b/applications/h264/h264_video_decode/metadata.json
@@ -8,14 +8,15 @@
 			}
 		],
 		"language": "C++",
-		"version": "1.0",
+		"version": "2.0",
 		"changelog": {
-			"1.0": "Initial Release"
+			"1.0": "Initial Release",
+			"2.0": "Upgrade to GXF 4.0"
 		},
 		"holoscan_sdk": {
-			"minimum_required_version": "1.0.0",
+			"minimum_required_version": "2.0.0",
 			"tested_versions": [
-				"1.0.0"
+				"2.0.0"
 			]
 		},
 		"platforms": [
@@ -31,11 +32,11 @@
 			"operators": [
 				{
 					"name": "videodecoder",
-					"version": "1.0"
+					"version": "1.2.0"
 				},
 				{
 					"name": "videodecoderio",
-					"version": "1.0"
+					"version": "1.2.0"
 				}
 			]
 		},

--- a/applications/h264/install_dependencies.sh
+++ b/applications/h264/install_dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@
 # required for H264 Encode / Decode applications.
 
 # URL of the DeepStream dependencies required for gxf-mm extensions above
-DS_DEPS_URL="https://api.ngc.nvidia.com/v2/resources/org/nvidia/gxf_and_gc/3.1.0/files?redirect=true&path=nvv4l2_x86_ds-6.4.deb"
+DS_DEPS_URL="https://api.ngc.nvidia.com/v2/resources/org/nvidia/gxf_and_gc/4.0.0/files?redirect=true&path=nvv4l2_x86_ds-7.0.deb"
 
 ARCH=$(arch)
 HOLOSCAN_LIBS_DIR=/opt/nvidia/holoscan/lib/
@@ -41,9 +41,9 @@ mkdir -p ${HOLOSCAN_LIBS_DIR}
 CUDA_VERSION=12.2
 for extension in "${!gxf_mm_extensions[@]}"; do
   if [[ $extension == "decoderio" ]] || [[ $extension == "encoderio" ]]; then
-    extension_url="https://api.ngc.nvidia.com/v2/resources/org/nvidia/team/graph-composer/video${extension}extension/1.1.0-linux-${ARCH}-ubuntu_22.04/files?redirect=true&path=${gxf_mm_extensions[${extension}]}.tar.gz"
+    extension_url="https://api.ngc.nvidia.com/v2/resources/org/nvidia/team/graph-composer/video${extension}extension/1.2.0-linux-${ARCH}-ubuntu_22.04/files?redirect=true&path=${gxf_mm_extensions[${extension}]}.tar.gz"
   else
-    extension_url="https://api.ngc.nvidia.com/v2/resources/org/nvidia/team/graph-composer/video${extension}extension/1.1.0-linux-${ARCH}-ubuntu_22.04-cuda-${CUDA_VERSION}/files?redirect=true&path=${gxf_mm_extensions[${extension}]}.tar.gz"
+    extension_url="https://api.ngc.nvidia.com/v2/resources/org/nvidia/team/graph-composer/video${extension}extension/1.2.0-linux-${ARCH}-ubuntu_22.04-cuda-${CUDA_VERSION}/files?redirect=true&path=${gxf_mm_extensions[${extension}]}.tar.gz"
   fi
   extension_tar=${gxf_mm_extensions[$extension]}.tar.gz
   wget --content-disposition ${extension_url} -O ${extension_tar}

--- a/operators/video_decoder/video_decoder_context/video_decoder_context.cpp
+++ b/operators/video_decoder/video_decoder_context/video_decoder_context.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,11 @@ void VideoDecoderContext::setup(ComponentSpec& spec) {
              "async_scheduling_term",
              "Asynchronous Scheduling Condition",
              "Asynchronous Scheduling Condition");
+  spec.param(device_id_,
+             "device_id",
+             "Cuda device id",
+             "A valid device id, range is 0 to (cudaGetDeviceCount() - 1)",
+             0);
 }
 
-}
+}  // namespace holoscan::ops

--- a/operators/video_decoder/video_decoder_context/video_decoder_context.hpp
+++ b/operators/video_decoder/video_decoder_context/video_decoder_context.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,6 +45,7 @@ class VideoDecoderContext: public holoscan::gxf::GXFResource {
  private:
   Parameter<std::shared_ptr<holoscan::AsynchronousCondition>>
       response_scheduling_term_;
+  Parameter<int32_t> device_id_;
 };
 
 }  // namespace holoscan::ops

--- a/operators/video_encoder/video_encoder_context/video_encoder_context.cpp
+++ b/operators/video_encoder/video_encoder_context/video_encoder_context.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,11 @@ void VideoEncoderContext::setup(ComponentSpec& spec) {
              "scheduling_term",
              "Asynchronous Scheduling Condition",
              "Asynchronous Scheduling Condition");
+  spec.param(device_id_,
+             "device_id",
+             "Cuda device id",
+             "A valid device id, range is 0 to (cudaGetDeviceCount() - 1)",
+             0);
 }
 
-}
+}  // namespace holoscan::ops

--- a/operators/video_encoder/video_encoder_context/video_encoder_context.hpp
+++ b/operators/video_encoder/video_encoder_context/video_encoder_context.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,6 +44,7 @@ class VideoEncoderContext: public holoscan::gxf::GXFResource {
 
  private:
   Parameter<std::shared_ptr<holoscan::AsynchronousCondition>> scheduling_term_;
+  Parameter<int32_t> device_id_;
 };
 
 }  // namespace holoscan::ops


### PR DESCRIPTION
Holoscan has been upgraded to use GXF 4.0. As a result, we see version mismatch errors while running H.264 sample apps. There was also a bug related to iGPU and dGPU detection which is now fixed with the latest version of GXF ENC / DEC and related latest DeepStream dependency.

This request updates Holoscan H.264 support to use GXF Encode / Decode extension from GXF 4.0. It also updates the DeepStream dependency to the required version.

This change is successfully tested it on IGX with dGPU and x86 with dGPU dev machine.