### PR TITLE
Improve H.264 apps

### DIFF
--- a/applications/h264/h264_endoscopy_tool_tracking/README.md
+++ b/applications/h264/h264_endoscopy_tool_tracking/README.md
@@ -5,9 +5,10 @@ from the Holoscan pipeline. This application is a modified version of Endoscopy
 Tool Tracking reference application in Holoscan SDK that supports H.264
 elementary streams as the input and output.
 
-_The H.264 video decode operators do not adjust framerate as it reads the elementary
-stream input. As a result the video stream will be displayed as quickly as the decoding can be
-performed. This feature will be coming soon to a new version of the operator._
+_The H.264 video decode operators do not adjust framerate as it reads the
+elementary stream input. As a result the video stream can be displayed as
+quickly as the decoding can be performed. This application uses
+`PeriodicCondition` to play video at the same speed as the source video._
 
 ## Requirements
 

--- a/applications/h264/h264_endoscopy_tool_tracking/h264_endoscopy_tool_tracking.yaml
+++ b/applications/h264/h264_endoscopy_tool_tracking/h264_endoscopy_tool_tracking.yaml
@@ -1,5 +1,5 @@
 %YAML 1.2
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -139,7 +139,6 @@ holoviz_output_format_converter:
 encoder_input_format_converter:
   in_dtype: "rgb888"
   out_dtype: "yuv420"
-  output_video_buffer:  true
 
 tensor_to_video_buffer:
   video_format: "yuv420"

--- a/applications/h264/h264_endoscopy_tool_tracking/main.cpp
+++ b/applications/h264/h264_endoscopy_tool_tracking/main.cpp
@@ -45,7 +45,9 @@ class App : public holoscan::Application {
         "bitstream_reader",
         from_config("bitstream_reader"),
         Arg("input_file_path", datapath + "/surgical_video.264"),
-        make_condition<CountCondition>(2000),
+        make_condition<CountCondition>(750),
+        make_condition<PeriodicCondition>("periodic-condition",
+                                          Arg("recess_period") = std::string("25hz")),
         Arg("pool") =
             make_resource<BlockMemoryPool>("pool", 0, source_block_size, source_num_blocks));
 

--- a/applications/h264/h264_video_decode/README.md
+++ b/applications/h264/h264_video_decode/README.md
@@ -5,9 +5,10 @@ decode operators. This application makes use of H.264 elementary stream reader
 operator for reading H.264 elementary stream input and uses Holoviz operator
 for rendering decoded data to the native window.
 
-_The H.264 video decode operators do not adjust framerate as it reads the elementary
-stream input. As a result the video stream will be displayed as quickly as the decoding can be
-performed. This feature will be coming soon to a new version of the operator._
+_The H.264 video decode operators do not adjust framerate as it reads the
+elementary stream input. As a result the video stream can be displayed as
+quickly as the decoding can be performed. This application uses
+`PeriodicCondition` to play video at the same speed as the source video._
 
 ## Requirements
 

--- a/applications/h264/h264_video_decode/main.cpp
+++ b/applications/h264/h264_video_decode/main.cpp
@@ -43,7 +43,9 @@ class App : public holoscan::Application {
         "bitstream_reader",
         from_config("bitstream_reader"),
         Arg("input_file_path", datapath + "/surgical_video.264"),
-        make_condition<CountCondition>(2000),
+        make_condition<CountCondition>(750),
+        make_condition<PeriodicCondition>("periodic-condition",
+                                          Arg("recess_period") = std::string("25hz")),
         Arg("pool") =
             make_resource<BlockMemoryPool>(
                 "pool", 0, source_block_size, source_num_blocks));

--- a/operators/tool_tracking_postprocessor/tool_tracking_postprocessor.cpp
+++ b/operators/tool_tracking_postprocessor/tool_tracking_postprocessor.cpp
@@ -91,7 +91,7 @@ void ToolTrackingPostprocessorOp::setup(OperatorSpec& spec) {
   spec.param(host_allocator_, "host_allocator", "Allocator", "Output Allocator");
   spec.param(device_allocator_, "device_allocator", "Allocator", "Output Allocator");
 
-  cuda_stream_handler_.defineParams(spec);
+  cuda_stream_handler_.define_params(spec);
 }
 
 void ToolTrackingPostprocessorOp::compute(InputContext& op_input, OutputContext& op_output,


### PR DESCRIPTION
This patch improves H.264 applications in Holohub.

It:
- Adds a `PeriodicCondition` to both the apps so that the playback of the decoded stream is smooth. It now plays the decoded video at the speed same as the source video - 25 FPS.
- Fixes a few warnings:
  - `[warning] [component.cpp:54] Arg 'output_video_buffer' not found in spec_.params()`
  - `[warning] [cuda_stream_handler.cpp:55] CudaStreamHandler's `defineParams` method has been renamed to `define_params`. 
     The old name is deprecated and may be removed in a future release.`