### PR TITLE
App: Update `volume_rendering_xr` for `build_and_run` compatibility

### DIFF
--- a/applications/volume_rendering_xr/README.md
+++ b/applications/volume_rendering_xr/README.md
@@ -32,37 +32,15 @@ Refer to the Magic Leap 2 documentation for more information:
 - [Updating your device with Magic Leap Hub](https://www.magicleap.care/hc/en-us/articles/5341445649805-Updating-Your-Device);
 - [Installing `.apk` packages with Magic Leap Hub](https://developer-docs.magicleap.cloud/docs/guides/developer-tools/ml-hub/ml-hub-package-manager/)
 
-## Building the Application
+## Quick Start
 
-Run the following commands to build and enter the interactive container environment:
+Run the following command in the top-level HoloHub folder to build and run the host application:
+
 ```bash
-./dev_container build --img holohub:volume_rendering_xr --docker_file ./applications/volume_rendering_xr/Dockerfile # Build the dev container
-./dev_container launch --docker_opts "-v $(pwd)/tmp:/home/$(whoami)" --img holohub:volume_rendering_xr # Launch the container
-```
-
-Then, inside the container environment, build the application:
-```bash
-./run build volume_rendering_xr # Build the application
-```
-
-## Running the Application
-
-### Setting Up Your Device
-
-Inside the container environment, start the Windrunner OpenXR backend and generate a pairing code:
-```bash
-ml_start.sh <debug>
-ml_pair.sh
+./dev_container build_and_run volume_rendering_xr
 ```
 
 A QR code will be visible in the console log. Refer to Magic Leap 2 [Remote Rendering Setup documentation](https://developer-docs.magicleap.cloud/docs/guides/remote-rendering/remote-rendering/#:~:text=Put%20on%20the%20Magic%20Leap,headset%20by%20looking%20at%20it.&text=The%20QR%20code%20launches%20a,Click%20Continue.) to pair the host and device in preparation for remote viewing. Refer to the [Remote Viewer](#starting-the-magic-leap-2-remote-viewer) section to regenerate the QR code as needed, or to use the local debugger GUI in place of a physical device.
-
-### Launching the Application
-
-Run the following command inside the development container to start the XR volume rendering application:
-```bash
-./run launch volume_rendering_xr
-```
 
 The application supports the following hand or controller interactions by default:
 - **Translate**: Reach and grab inside the volume with your hand or with the controller trigger to move the volume.
@@ -70,7 +48,39 @@ The application supports the following hand or controller interactions by defaul
 - **Rotate**: Grab any edge of the bounding box and move your hand or controller to rotate the volume.
 - **Crop**: Grab any vertex of the bounding box and move your hand or controller to translate the cropping planes.
 
-## Deploying as a Standalone Application
+## Advanced Setup
+
+You can use the `--dryrun` option to see the individual commands run by the quick start option above:
+```
+./dev_container build_and_run volume_rendering_xr --dryrun
+```
+
+Alternatively, follow the steps below to set up the interactive container session.
+
+### Build the Container
+
+Run the following commands to build and enter the interactive container environment:
+```bash
+./dev_container build --img holohub:volume_rendering_xr --docker_file ./applications/volume_rendering_xr/Dockerfile # Build the dev container
+./dev_container launch --img holohub:volume_rendering_xr # Launch the container
+```
+
+### Build the Application
+
+Inside the container environment, build the application:
+```bash
+./run build volume_rendering_xr # Build the application
+```
+
+### Run the Application
+
+Inside the container environment, start the application:
+```bash
+export ML_START_OPTIONS=<""/"debug"> # Defaults to "debug" to run XR device simulator GUI
+./run launch volume_rendering_xr
+```
+
+### Deploying as a Standalone Application
 
 `volume_rendering_xr` can be packaged in a self-contained release container with datasets and binaries.
 

--- a/applications/volume_rendering_xr/metadata.json
+++ b/applications/volume_rendering_xr/metadata.json
@@ -80,7 +80,7 @@
 		]
 	},
 	"run": {
-		"command": "<holohub_app_bin>/volume_rendering_xr --config <holohub_app_source>/configs/ctnv_bb_er.json --density <holohub_data_dir>/volume_rendering_xr/highResCT.mhd --mask <holohub_data_dir>/volume_rendering_xr/smoothmasks.seg.mhd",
+		"command": "if [ -v ML_START_OPTIONS ]; then ml_start.sh ${ML_START_OPTIONS}; else ml_start.sh debug; fi && ml_pair.sh && <holohub_app_bin>/volume_rendering_xr --config <holohub_app_source>/configs/ctnv_bb_er.json --density <holohub_data_dir>/volume_rendering_xr/highResCT.mhd --mask <holohub_data_dir>/volume_rendering_xr/smoothmasks.seg.mhd",
 		"workdir": "<holohub_app_bin>"
 	}
   }

--- a/applications/volume_rendering_xr/metadata.json
+++ b/applications/volume_rendering_xr/metadata.json
@@ -1,87 +1,98 @@
-{ 
- "application": {
-	"name": "Medical Image viewer in XR",
-	"authors": [
-		{
-			"name": "Andreas Heumann",
-			"affiliation": "NVIDIA"
-		},
-		{
-			"name": "Connor Smith",
-			"affiliation": "NVIDIA"
-		},
-		{
-			"name": "Cristiana Dinea",
-			"affiliation": "NVIDIA"
-		},
-		{
-			"name": "Tom Birdsong",
-			"affiliation": "NVIDIA"
-		},
-		{
-			"name": "Antonio Ospite",
-			"affiliation": "Magic Leap"
-		},
-		{
-			"name": "Jiwen Cai",
-			"affiliation": "Magic Leap"
-		},
-		{
-			"name": "Jochen Stier",
-			"affiliation": "Magic Leap"
-		},
-		{
-			"name": "Korcan Hussein",
-			"affiliation": "Magic Leap"
-		},
-		{
-			"name": "Robbie Bridgewater",
-			"affiliation": "Magic Leap"
-		}
-	],
-	"language": "C++",
-	"version": "1.0",
-	"changelog": {
-		"0.0": "Initial release",
-		"0.1": "Update for Magic Leap 2 firmware v1.5.0",
-		"0.2": "Update for Magic Leap 2 firmware v1.6.0",
-		"1.0": "Enhance interactivity and update for Holoscan SDK v2.0.0 deployment stack"
-	},
-	"holoscan_sdk": {
-		"minimum_required_version": "2.0.0",
-		"tested_versions": [
-			"2.0.0"
-		]
-	},
-	"platforms": ["amd64", "arm64"],
-	"tags": ["Volume", "Rendering", "OpenXR","Mixed","Reality","XR"],
-	"ranking": 2,
-	"dependencies": {
-		"hardware": [
+{
+	"application": {
+		"name": "Medical Image viewer in XR",
+		"authors": [
 			{
-				"name": "Magic Leap 2",
-				"description": "Magic Leap 2 mixed reality headset",
-				"url": "https://www.magicleap.com/magic-leap-2"
+				"name": "Andreas Heumann",
+				"affiliation": "NVIDIA"
+			},
+			{
+				"name": "Connor Smith",
+				"affiliation": "NVIDIA"
+			},
+			{
+				"name": "Cristiana Dinea",
+				"affiliation": "NVIDIA"
+			},
+			{
+				"name": "Tom Birdsong",
+				"affiliation": "NVIDIA"
+			},
+			{
+				"name": "Antonio Ospite",
+				"affiliation": "Magic Leap"
+			},
+			{
+				"name": "Jiwen Cai",
+				"affiliation": "Magic Leap"
+			},
+			{
+				"name": "Jochen Stier",
+				"affiliation": "Magic Leap"
+			},
+			{
+				"name": "Korcan Hussein",
+				"affiliation": "Magic Leap"
+			},
+			{
+				"name": "Robbie Bridgewater",
+				"affiliation": "Magic Leap"
 			}
 		],
-		"libraries": [
-			{
-			"name": "windrunner",
-			"description": "Magic Leap OpenXR native backend",
-			"version": "1.11.73",
-			"license": "Magic Leap 2 Software Agreement",
-			"license-url": "https://www.magicleap.com/software-license-agreement-ml2"
-			},
-			{	"name": "Magic Leap Remote Viewer apk",
-				"version": "1.11.64",
-				"license": "Magic Leap 2 Software Agreement",
-				"license-url": "https://www.magicleap.com/software-license-agreement-ml2"
-			}
-		]
-	},
-	"run": {
-		"command": "if [ -v ML_START_OPTIONS ]; then ml_start.sh ${ML_START_OPTIONS}; else ml_start.sh debug; fi && ml_pair.sh && <holohub_app_bin>/volume_rendering_xr --config <holohub_app_source>/configs/ctnv_bb_er.json --density <holohub_data_dir>/volume_rendering_xr/highResCT.mhd --mask <holohub_data_dir>/volume_rendering_xr/smoothmasks.seg.mhd",
-		"workdir": "<holohub_app_bin>"
+		"language": "C++",
+		"version": "1.0",
+		"changelog": {
+			"0.0": "Initial release",
+			"0.1": "Update for Magic Leap 2 firmware v1.5.0",
+			"0.2": "Update for Magic Leap 2 firmware v1.6.0",
+			"1.0": "Enhance interactivity and update for Holoscan SDK v2.0.0 deployment stack"
+		},
+		"holoscan_sdk": {
+			"minimum_required_version": "2.0.0",
+			"tested_versions": [
+				"2.0.0"
+			]
+		},
+		"platforms": [
+			"amd64",
+			"arm64"
+		],
+		"tags": [
+			"Volume",
+			"Rendering",
+			"OpenXR",
+			"Mixed",
+			"Reality",
+			"XR"
+		],
+		"ranking": 2,
+		"dependencies": {
+			"hardware": [
+				{
+					"name": "Magic Leap 2",
+					"description": "Magic Leap 2 mixed reality headset",
+					"url": "https://www.magicleap.com/magic-leap-2"
+				}
+			],
+			"libraries": [
+				{
+					"name": "windrunner",
+					"description": "Magic Leap OpenXR native backend",
+					"version": "1.11.73",
+					"license": "Magic Leap 2 Software Agreement",
+					"license-url": "https://www.magicleap.com/software-license-agreement-ml2"
+				},
+				{
+					"name": "Magic Leap Remote Viewer apk",
+					"version": "1.11.64",
+					"license": "Magic Leap 2 Software Agreement",
+					"license-url": "https://www.magicleap.com/software-license-agreement-ml2"
+				}
+			]
+		},
+		"run": {
+			"command": "if [ -v ML_START_OPTIONS ]; then ml_start.sh ${ML_START_OPTIONS}; else ml_start.sh debug; fi && ml_pair.sh && <holohub_app_bin>/volume_rendering_xr --config <holohub_app_source>/configs/ctnv_bb_er.json --density <holohub_data_dir>/volume_rendering_xr/highResCT.mhd --mask <holohub_data_dir>/volume_rendering_xr/smoothmasks.seg.mhd",
+			"workdir": "<holohub_app_bin>"
+		}
 	}
-  }
 }


### PR DESCRIPTION
Updates the `volume_rendering_xr` application so that new users can
build and launch the XR application with a single command.

Changes:
- `volume_rendering_xr` can now be launched with a single `dev_container build_and_run` command. The command builds the container and application, starts the Windrunner backend, generates a pairing code, and starts the application.
- `./run launch volume_rendering_xr` now starts with the debug UI by  default. This behavior allows users without a ML2 headset to try out  the application, while still generating a pairing code for users with  a ML2 headset to use. The debug UI can be disabled with the  `ML_START_OPTIONS` environment variable.

Also fixes `metadata.json` formatting. Verified on x86_64.