### PR TITLE
Enable DOCA GPUNetIO in network radar app

### DIFF
--- a/applications/network_radar_pipeline/cpp/CMakeLists.txt
+++ b/applications/network_radar_pipeline/cpp/CMakeLists.txt
@@ -73,4 +73,13 @@ add_custom_target(process_yaml
   COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/process.yaml" ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/process.yaml"
 )
-add_dependencies(network_radar_pipeline source_yaml process_yaml)
+
+add_custom_target(source_doca_yaml
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/source_doca.yaml" ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source_doca.yaml"
+)
+add_custom_target(process_doca_yaml
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/process_doca.yaml" ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/process_doca.yaml"
+)
+add_dependencies(network_radar_pipeline source_yaml process_yaml source_doca_yaml process_doca_yaml)

--- a/applications/network_radar_pipeline/cpp/README.md
+++ b/applications/network_radar_pipeline/cpp/README.md
@@ -5,6 +5,8 @@ Using the GPUDirect capabilities afforded by the Advanced Network Operator, this
 
 The motivation for building this application is to demonstrate how data arrays can be assembled from packet data in real-time for low-latency, high-throughput sensor processing applications. The main components of this work are defining a message format and writing code connecting the network operators to the signal processing operators.
 
+This application uses the Advanced Network Operator DPDK and DOCA GPUNetIO transport layers.
+
 ## Prerequisites
 See the README for the Advanced Network Operator for requirements and system tuning needed to enable high-throughput GPUDirect capabilities.
 
@@ -15,9 +17,13 @@ Note: Dockerfile should be cross-compatible, but has only been tested on x86. Ne
 Please refer to the top level Holohub README.md file for information on how to build this application: `./run build network_radar_pipeline`.
 
 ## Run
-Note: must properly configure YAML files before running.
+Note: must properly configure YAML files before running. To run with DPDK as ANO transport layer:
 - On Tx machine: `./build/applications/network_radar_pipeline/cpp/network_radar_pipeline source.yaml`
 - On Rx machine: `./build/applications/network_radar_pipeline/cpp/network_radar_pipeline process.yaml`
+
+To run with DOCA GPUNetIO as ANO transport layer:
+- On Tx machine: `./build/applications/network_radar_pipeline/cpp/network_radar_pipeline source_doca.yaml`
+- On Rx machine: `./build/applications/network_radar_pipeline/cpp/network_radar_pipeline process_doca.yaml`
 
 ## Network Operator Connectors
 See each operators' README before using / for more detailed information.

--- a/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_rx.h
+++ b/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_rx.h
@@ -156,7 +156,6 @@ class AdvConnectorOpRx : public Operator {
   Parameter<bool> gpu_direct_;           // GPUDirect enabled
   Parameter<uint32_t> batch_size_;       // Batch size for one processing block
   Parameter<uint16_t> max_packet_size_;  // Maximum size of a single packet
-  Parameter<uint16_t> header_size_;      // Header size of packet
 
   // Holds burst buffers that cannot be freed yet
   struct RxMsg {

--- a/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_rx.h
+++ b/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_rx.h
@@ -152,7 +152,7 @@ class AdvConnectorOpRx : public Operator {
   Parameter<uint16_t> num_samples_;
 
   // Networking settings
-  Parameter<bool> hds_;                  // Header-data split enabled
+  Parameter<bool> split_boundary_;       // Header-data split enabled
   Parameter<bool> gpu_direct_;           // GPUDirect enabled
   Parameter<uint32_t> batch_size_;       // Batch size for one processing block
   Parameter<uint16_t> max_packet_size_;  // Maximum size of a single packet

--- a/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_tx.h
+++ b/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_tx.h
@@ -76,7 +76,6 @@ class AdvConnectorOpTx : public Operator {
   // Networking settings
   Parameter<bool> split_boundary_;
   Parameter<uint16_t> samples_per_packet_;
-  Parameter<uint16_t> header_size_;
   Parameter<uint16_t> udp_src_port_;
   Parameter<uint16_t> udp_dst_port_;
   Parameter<std::string> ip_src_addr_;

--- a/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_tx.h
+++ b/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_tx.h
@@ -74,6 +74,7 @@ class AdvConnectorOpTx : public Operator {
   Parameter<uint16_t> num_channels_;
 
   // Networking settings
+  Parameter<bool> split_boundary_;
   Parameter<uint16_t> samples_per_packet_;
   Parameter<uint16_t> header_size_;
   Parameter<uint16_t> udp_src_port_;
@@ -86,10 +87,12 @@ class AdvConnectorOpTx : public Operator {
   uint32_t batch_size_;
   int hds_;
   bool gpu_direct_;
+  std::string mgr_;
 
   uint8_t eth_dst_[6];
   uint32_t ip_src_;
   uint32_t ip_dst_;
+  void* pkt_header_;
 
   // Concurrent batch structures
   std::array<cudaStream_t, num_concurrent> streams_;

--- a/applications/network_radar_pipeline/cpp/common.h
+++ b/applications/network_radar_pipeline/cpp/common.h
@@ -20,6 +20,8 @@
 #include "holoscan/holoscan.hpp"
 #include "matx.h"
 
+#define PADDED_HDR_SIZE 64
+
 using namespace matx;
 using float_t = float;
 using complex_t = cuda::std::complex<float_t>;

--- a/applications/network_radar_pipeline/cpp/process_doca.yaml
+++ b/applications/network_radar_pipeline/cpp/process_doca.yaml
@@ -25,17 +25,11 @@ scheduler:
   stop_on_deadlock: true
   stop_on_deadlock_timeout: 500
 
-tx_params:
+rx_params:
   use_ano: true
-  split_boundary: true
-  samples_per_packet: 1024
-  header_size: 42
-  udp_src_port: 4096               # UDP source port
-  udp_dst_port: 4096               # UDP destination port
-  ip_src_addr: 192.168.1.1      # Source IP send from
-  ip_dst_addr: 192.168.1.2      # Destination IP to send to
-  eth_dst_addr: 10:70:fd:fa:77:e9  # Destination MAC to populate
-  port_id: 0
+  split_boundary: false
+  batch_size: 5120
+  max_packet_size: 9000
 
 basic_network:
   batch_size: 100            # RX message batch size
@@ -50,25 +44,43 @@ advanced_network:
   cfg:
     version: 1
     manager: "dpdk"
-    master_core: 16             # Master CPU core
-    tx:
-      - if_name: 0000:ca:00.0   # PCIe BFD of NIC
+    master_core: 16                 # Master CPU core
+    rx:
+      - if_name: 0000:ca:00.0       # PCIe BFD of NIC
+        flow_isolation: true
         queues:
-          - name: "ADC Samples"
+          - name: "Default"
             id: 0
-            gpu_direct: true
+            gpu_direct: false
+            cpu_cores: "18"
+            max_packet_size: 9000          # Maximum payload size
+            num_concurrent_batches: 32767  # Number of batches that can be used at any time
+            batch_size: 1                  # Number of packets in a batch
+            output_port: "bench_rx_out"
+          - name: "ADC Samples"
+            id: 1
             gpu_device: 0
+            gpu_direct: true
             split_boundary: 42
-            max_packet_size: 9000      # Maximum payload size
-            num_concurrent_batches: 5  # Number of batches that can be used at any time
-            batch_size: 10240          # Number of packets in a batch
-            cpu_cores: "17"            # CPU cores for transmitting
+            cpu_cores: "17"
+            max_packet_size: 9000       # Maximum payload size
+            num_concurrent_batches: 15  # Number of batches that can be used at any time
+            batch_size: 5120            # Number of packets in a batch
+            output_port: "bench_rx_out"
+        flows:
+          - name: "ADC Samples"
+            action:
+              type: queue
+              id: 1
+            match:
+              udp_src: 4096
+              udp_dst: 4096
 
 radar_pipeline:
-  is_source: true      # Defines app type (source, process)
-  data_rate: 95        # (Gbps)
-  num_transmits: 1000  # Use N-1 of num_transmits in source
+  is_source: false         # Defines app type (source, process)
+  num_transmits: 1000      # Use N-1 of num_transmits in source
   num_pulses: 128
   num_samples: 9000
   num_channels: 16
   waveform_length: 1000
+  buffer_size: 10          # Number of RF arrays to store in rx buffer

--- a/applications/network_radar_pipeline/cpp/process_doca.yaml
+++ b/applications/network_radar_pipeline/cpp/process_doca.yaml
@@ -29,7 +29,7 @@ rx_params:
   use_ano: true
   split_boundary: false
   batch_size: 5120
-  max_packet_size: 9000
+  max_packet_size: 16384
 
 basic_network:
   batch_size: 100            # RX message batch size
@@ -43,7 +43,7 @@ basic_network:
 advanced_network:
   cfg:
     version: 1
-    manager: "dpdk"
+    manager: "doca"
     master_core: 16                 # Master CPU core
     rx:
       - if_name: 0000:ca:00.0       # PCIe BFD of NIC
@@ -51,21 +51,21 @@ advanced_network:
         queues:
           - name: "Default"
             id: 0
-            gpu_direct: false
+            gpu_device: 0
+            gpu_direct: true
             cpu_cores: "18"
-            max_packet_size: 9000          # Maximum payload size
-            num_concurrent_batches: 32767  # Number of batches that can be used at any time
+            max_packet_size: 16384          # Maximum payload size
+            num_concurrent_batches: 32768  # Number of batches that can be used at any time
             batch_size: 1                  # Number of packets in a batch
             output_port: "bench_rx_out"
           - name: "ADC Samples"
             id: 1
             gpu_device: 0
             gpu_direct: true
-            split_boundary: 42
             cpu_cores: "17"
-            max_packet_size: 9000       # Maximum payload size
-            num_concurrent_batches: 15  # Number of batches that can be used at any time
-            batch_size: 5120            # Number of packets in a batch
+            max_packet_size: 16384       # Maximum payload size
+            num_concurrent_batches: 4  # Number of batches that can be used at any time
+            batch_size: 8192            # Number of packets in a batch
             output_port: "bench_rx_out"
         flows:
           - name: "ADC Samples"

--- a/applications/network_radar_pipeline/cpp/source.yaml
+++ b/applications/network_radar_pipeline/cpp/source.yaml
@@ -29,7 +29,6 @@ tx_params:
   use_ano: true
   split_boundary: true
   samples_per_packet: 1024
-  header_size: 42
   udp_src_port: 4096               # UDP source port
   udp_dst_port: 4096               # UDP destination port
   ip_src_addr: 192.168.1.1      # Source IP send from

--- a/applications/network_radar_pipeline/cpp/source_doca.yaml
+++ b/applications/network_radar_pipeline/cpp/source_doca.yaml
@@ -27,9 +27,9 @@ scheduler:
 
 tx_params:
   use_ano: true
-  split_boundary: true
+  split_boundary: false
   samples_per_packet: 1024
-  header_size: 42
+  header_size: 64 #42
   udp_src_port: 4096               # UDP source port
   udp_dst_port: 4096               # UDP destination port
   ip_src_addr: 192.168.1.1      # Source IP send from
@@ -49,7 +49,7 @@ basic_network:
 advanced_network:
   cfg:
     version: 1
-    manager: "dpdk"
+    manager: "doca"
     master_core: 16             # Master CPU core
     tx:
       - if_name: 0000:ca:00.0   # PCIe BFD of NIC
@@ -58,7 +58,7 @@ advanced_network:
             id: 0
             gpu_direct: true
             gpu_device: 0
-            split_boundary: 42
+            split_boundary: 0
             max_packet_size: 9000      # Maximum payload size
             num_concurrent_batches: 5  # Number of batches that can be used at any time
             batch_size: 10240          # Number of packets in a batch

--- a/applications/network_radar_pipeline/cpp/source_doca.yaml
+++ b/applications/network_radar_pipeline/cpp/source_doca.yaml
@@ -29,7 +29,6 @@ tx_params:
   use_ano: true
   split_boundary: false
   samples_per_packet: 1024
-  header_size: 64 #42
   udp_src_port: 4096               # UDP source port
   udp_dst_port: 4096               # UDP destination port
   ip_src_addr: 192.168.1.1      # Source IP send from

--- a/operators/advanced_network/adv_network_common.h
+++ b/operators/advanced_network/adv_network_common.h
@@ -442,6 +442,7 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
             if (input_spec.common_.mgr_ == "doca") {
               q.common_.gpu_direct_       = q_item["gpu_direct"].as<bool>();
               q.common_.gpu_dev_          = q_item["gpu_device"].as<int>();
+              q.common_.hds_              = 0;
             } else {
               q.common_.gpu_direct_       = q_item["gpu_direct"].as<bool>();
               if (q.common_.gpu_direct_) {
@@ -499,6 +500,7 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
             if (input_spec.common_.mgr_ == "doca") {
               q.common_.gpu_direct_       = q_item["gpu_direct"].as<bool>();
               q.common_.gpu_dev_          = q_item["gpu_device"].as<int>();
+              q.common_.hds_              = 0;
             } else {
               q.common_.gpu_direct_       = q_item["gpu_direct"].as<bool>();
               if (q.common_.gpu_direct_) {


### PR DESCRIPTION
Enable DOCA GPUNetIO as new transport layer for the network radar application.
Enable the GPU-only management of packets (removing the need for header/data split)