### PR TITLE
Op: Fix HoloHub compatibility breakage from DDS operators

### DIFF
--- a/operators/dds/base/CMakeLists.txt
+++ b/operators/dds/base/CMakeLists.txt
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.24)
-project(dds_operator_base)
-
-find_package(holoscan 2.0 REQUIRED CONFIG
-             PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
-
 option("LIB_dds_operator_base" "Build the DDS Operator Base library" ${BUILD_ALL})
 if(${LIB_dds_operator_base})
+  cmake_minimum_required(VERSION 3.24)
+  project(dds_operator_base)
+
+  find_package(holoscan 2.0 REQUIRED CONFIG
+              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+
   include(RTIConnextDDS)
   add_library(dds_operator_base SHARED dds_operator_base.cpp dds_operator_base.hpp)
   target_include_directories(dds_operator_base PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/operators/dds/shapes/CMakeLists.txt
+++ b/operators/dds/shapes/CMakeLists.txt
@@ -14,14 +14,14 @@
 # limitations under the License.
 
 cmake_minimum_required(VERSION 3.24)
-project(dds_shapes_operators)
-
-find_package(holoscan 2.0 REQUIRED CONFIG
-             PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
 # Subscriber Operator
 option("OP_dds_shapes_subscriber" "Build the DDS Shapes Subscriber operator" ${BUILD_ALL})
 if(${OP_dds_shapes_subscriber})
+  project(dds_shapes_operators)
+
+  find_package(holoscan 2.0 REQUIRED CONFIG
+              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
   add_library(dds_shapes_subscriber SHARED subscriber.cpp subscriber.hpp)
   add_library(holoscan::ops::dds_shapes_subscriber ALIAS dds_shapes_subscriber)
   target_link_libraries(dds_shapes_subscriber PUBLIC

--- a/operators/dds/video/CMakeLists.txt
+++ b/operators/dds/video/CMakeLists.txt
@@ -14,14 +14,14 @@
 # limitations under the License.
 
 cmake_minimum_required(VERSION 3.24)
-project(dds_video_operators)
-
-find_package(holoscan 2.0 REQUIRED CONFIG
-             PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
 # Publisher Operator
 option("OP_dds_video_publisher" "Build the DDS Video Publisher operator" ${BUILD_ALL})
 if(${OP_dds_video_publisher})
+  project(dds_video_operators)
+
+  find_package(holoscan 2.0 REQUIRED CONFIG
+              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
   add_library(dds_video_publisher SHARED publisher.cpp publisher.hpp)
   add_library(holoscan::ops::dds_video_publisher ALIAS dds_video_publisher)
   target_link_libraries(dds_video_publisher PUBLIC


### PR DESCRIPTION
Issue: DDS operators provide custom flags to enable or disable DDS sources, so that DDS operators do not always build with other HoloHub apps unless requested. However, the `find_package(holoscan 2.0)` calls in DDS operator subdirectories previously existed outside of these if/endif blocks. As a result, HoloHub always tried to find holoscan 2.0 when building any application, and failed if it was not found.

Workaround: This small fix moves `find_package(holoscan 2.0)` calls inside of if/endif blocks so that DDS operators do not impact building other HoloHub apps if DDS is not turned on.

A more complete fix will be pursued in
https://github.com/nvidia-holoscan/holohub/pull/339 to align DDS operators to standard HoloHub CMake build infrastructure.

Tested and verified by building and running `dds_video` with HSDK 2.0 (bare metal, x86_64) and by building `endoscopy_tool_tracking` with an HSDK 1.0.3 internal branch.