### PR TITLE
Fix version number in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ holohub                                  ngc-v0.6.0-dgpu   b6d86bccdcac   9 seco
 nvcr.io/nvidia/clara-holoscan/holoscan   v0.6.0-dgpu       1b4df7733d5b   5 weeks ago     8.04GB
 ```
 
-***Note:*** The development container script ```dev_container``` will by default detect if the system is using an iGPU (integrated GPU) or a dGPU (discrete GPU) and use [NGC's Holoscan SDK container](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/clara-holoscan/containers/holoscan) **`v1.0`** for the [Container build](#container-build-recommended). See [Advanced Container Build Options](#advanced-build-options-container) if you would like to use an older version of the SDK as a custom base image.
+***Note:*** The development container script ```dev_container``` will by default detect if the system is using an iGPU (integrated GPU) or a dGPU (discrete GPU) and use [NGC's Holoscan SDK container](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/clara-holoscan/containers/holoscan) **`v2.0`** for the [Container build](#container-build-recommended). See [Advanced Container Build Options](#advanced-build-options-container) if you would like to use an older version of the SDK as a custom base image.
 
 See also: [Advanced Build Options](./doc/developer.md#advanced-build-options-container)
 


### PR DESCRIPTION
Currently, the README.md mentions the `dev_container` script uses the Holoscan SDK container v1.0, but a recent commit (8894dd4) bumped the version used to v2.0.

Update this reference in the README.md.