### PR TITLE
Infra: Fix /dev/snd error when no sound card is present

### DIFF
--- a/dev_container
+++ b/dev_container
@@ -491,13 +491,15 @@ launch() {
         fi
     done
 
-    # Find all audio devices
-    audio_devices=$(find /dev/snd -type c)
+    if [ -d /dev/snd ]; then
+        # Find all audio devices
+        audio_devices=$(find /dev/snd -type c)
 
-    # Mount all found audio devices
-    for audio_dev in $audio_devices; do
-        mount_device_opt+=" --device $audio_dev"
-    done
+        # Mount all found audio devices
+        for audio_dev in $audio_devices; do
+            mount_device_opt+=" --device $audio_dev"
+        done
+    fi
 
     # mounts the ALSA configuration for the user running the script
     mount_device_opt+=" -v /etc/asound.conf:/etc/asound.conf"


### PR DESCRIPTION
Currently, if you run `./dev_container launch` on a system without a sound card, you get:

% ./dev_container launch
find: '/dev/snd': No such file or directory

As a sound card shouldn't be required here, let's add a check for `/dev/snd` before running that `find` command.