### PR TITLE
Infra: Relax select `dev_container` arg parse restrictions

### DIFF
--- a/dev_container
+++ b/dev_container
@@ -390,6 +390,7 @@ Usage: ./dev_container launch [options]
     --add-volume : Mount additional volume
     --as_root  : Run the container with root permissions
     --docker_opts : Additional options to pass to the Docker launch
+    -- : Any trailing arguments after "--" are forwarded to `docker run`
     '
 }
 launch() {
@@ -473,7 +474,7 @@ launch() {
                 fi
                 ;;
             --docker_opts)
-                if [[ -n "$2" && ! "$2" =~ ^-- ]]; then
+                if [[ -n "$2" ]]; then
                     docker_opts="$2"
                     shift 2
                 else
@@ -481,6 +482,11 @@ launch() {
                     launch_desc
                     exit 1
                 fi
+                ;;
+            --)
+                # Any trailing arguments after "--" are forwarded to `docker run`
+                shift
+                break
                 ;;
             *)
                 echo "Error: Invalid argument '$1'"
@@ -776,7 +782,7 @@ build_and_run() {
                 shift
                 ;;
             --run_args)
-                if [[ -n "$2" && ! "$2" =~ ^-- ]]; then
+                if [[ -n "$2" ]]; then
                     extra_run_args="--extra_args '$2'"
                     shift 2
                 else
@@ -837,9 +843,9 @@ build_and_run() {
 
     run_command ${SCRIPT_DIR}/dev_container build $container_build_args
     if [[ $build_app == 1 ]]; then
-        run_command ${SCRIPT_DIR}/dev_container launch $container_launch_args -c "./run build $app_name"
+        run_command ${SCRIPT_DIR}/dev_container launch $container_launch_args -- ./run build $app_name
     fi
-    run_command ${SCRIPT_DIR}/dev_container launch $container_launch_args -c "./run launch $app_name $app_language $extra_run_args"
+    run_command ${SCRIPT_DIR}/dev_container launch $container_launch_args -- ./run launch $app_name $app_language $extra_run_args
 }
 
 


### PR DESCRIPTION
The recent commit 4b4243f0b tightened restrictions on argument parsing in `dev_container` functions with the goal of highlighting erroneous script input. This change relaxes those restrictions on a small subset of arguments to allow argument forwarding to proceed without errors.

Changes:
- Forward trailing arguments to `dev_container launch` after `--` to the container shell. This mimics behavior prior to 4b4243f0b where trailing arguments were forwarded to the container, but with the added restriction that `--` must be explicitly specified to prevent unintended argument forwarding.
- Allow values following `--docker_opts` and `--run_args` flags to start with `--`. It is reasonable for those values to contain additional flags that will be forwarded to the appropriate `docker run` or `run launch` command.
- Fix an issue with string parsing for commands forwarded to the container with `dev_container build_and_run`.

Validated with HoloHub apps:
- `dev_container build_and_run body_pose_estimation`
- `dev_container build_and_run volume_rendering`