### PR TITLE
App: Fixups for Holochat local run

### DIFF
--- a/applications/holochat/build_holoscan_db.py
+++ b/applications/holochat/build_holoscan_db.py
@@ -15,6 +15,7 @@
 
 import os
 import re
+from types import SimpleNamespace
 
 import yaml
 from langchain.docstore.document import Document

--- a/applications/holochat/metadata.json
+++ b/applications/holochat/metadata.json
@@ -34,7 +34,7 @@
 			   ]
 			},
 			"run": {
-				"command": "<holohub_app_source>/holochat.sh --local",
+				"command": "<holohub_app_source>/holochat.sh",
 				"workdir": "holohub_app_source"
 			}
 		}

--- a/applications/holochat/metadata.json
+++ b/applications/holochat/metadata.json
@@ -35,7 +35,7 @@
 			},
 			"run": {
 				"command": "<holohub_app_source>/holochat.sh --local",
-				"workdir": "holohub_bin"
+				"workdir": "holohub_app_source"
 			}
 		}
 	}


### PR DESCRIPTION
Address minor Holochat issues encountered when running locally.

Fixes issues encountered on first HoloChat local run:

```
python3: can't open file '/workspace/holohub/build/holochat/build_holoscan_db.py': [Errno 2] No such file or directory
```

```
NameError: name 'SimpleNamespace' is not defined
```

With these fixes applied the DB build stage appears to complete. However, I can't fully confirm whether the local run is successful after that stage as my GPU does not meet hardware requirements.