### PR TITLE
Infra: Set default `dev_container` directory as HOME

### DIFF
--- a/dev_container
+++ b/dev_container
@@ -703,6 +703,7 @@ launch() {
         --cap-add CAP_SYS_PTRACE \
         --ipc=host \
         -e NVIDIA_DRIVER_CAPABILITIES=graphics,video,compute,utility,display \
+        -e HOME=/workspace/holohub \
         -v /tmp/.X11-unix:/tmp/.X11-unix \
         ${additional_volumes} \
         ${mount_device_opt} \


### PR DESCRIPTION
Sets the `HOME` environment variable to the default `/workspace/holohub` directory entrypoint in the HoloHub container.

This change intends to improve the developer experience for dealing with applications and libraries that rely on paths relative to the `HOME` directory, such as those that define resources at `~/.cache`.