### PR TITLE
Infra: Bump to Holoscan SDK v2.1.0 base container

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ holohub                                  ngc-v0.6.0-dgpu   b6d86bccdcac   9 seco
 nvcr.io/nvidia/clara-holoscan/holoscan   v0.6.0-dgpu       1b4df7733d5b   5 weeks ago     8.04GB
 ```
 
-***Note:*** The development container script ```dev_container``` will by default detect if the system is using an iGPU (integrated GPU) or a dGPU (discrete GPU) and use [NGC's Holoscan SDK container](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/clara-holoscan/containers/holoscan) **`v2.0`** for the [Container build](#container-build-recommended). See [Advanced Container Build Options](#advanced-build-options-container) if you would like to use an older version of the SDK as a custom base image.
+***Note:*** The development container script ```dev_container``` will by default detect if the system is using an iGPU (integrated GPU) or a dGPU (discrete GPU) and use [NGC's Holoscan SDK container](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/clara-holoscan/containers/holoscan) **`v2.1`** for the [Container build](#container-build-recommended). See [Advanced Container Build Options](#advanced-build-options-container) if you would like to use an older version of the SDK as a custom base image.
 
 See also: [Advanced Build Options](./doc/developer.md#advanced-build-options-container)
 

--- a/applications/endoscopy_depth_estimation/README.md
+++ b/applications/endoscopy_depth_estimation/README.md
@@ -40,7 +40,7 @@ Once the `GPUMat` processing has finished, we have to convert it back to a CuPy 
 <hr/>
 
 **Important:** In order to run this application with CUDA acceleration, one must compile [OpenCV with CUDA support](https://docs.opencv.org/4.8.0/d2/dbc/cuda_intro.html).
-We provide a sample [Dockerfile](./Dockerfile) to build a container based on Holoscan v2.0.0 with the latest version of OpenCV and CUDA support.
+We provide a sample [Dockerfile](./Dockerfile) to build a container based on Holoscan v2.1.0 with the latest version of OpenCV and CUDA support.
 In case you use it, note that the variable [`CUDA_ARCH_BIN` ](./Dockerfile#L25) must be modified according to your specific GPU
 configuration. Refer to [this site](https://developer.nvidia.com/cuda-gpus) to find out your NVIDIA GPU architecture.
 

--- a/dev_container
+++ b/dev_container
@@ -268,11 +268,11 @@ get_host_gpu() {
 
 
 get_default_base_img() {
-    echo -n "nvcr.io/nvidia/clara-holoscan/holoscan:v2.0.0-"$(get_host_gpu)
+    echo -n "nvcr.io/nvidia/clara-holoscan/holoscan:v2.1.0-"$(get_host_gpu)
 }
 
 get_default_img() {
-    echo -n "holohub:ngc-v2.0.0-"$(get_host_gpu)
+    echo -n "holohub:ngc-v2.1.0-"$(get_host_gpu)
 }
 
 # This function returns the compute capacity of the system's GPU (8.6, 8.9, etc.)


### PR DESCRIPTION
Bump to use latest Holoscan SDK release (v2.1.0) as the default base container for HoloHub applications.

Tested locally on x86_64.