### PR TITLE
Fixing tests on CAGX

### DIFF
--- a/applications/h264/h264_endoscopy_tool_tracking/CMakeLists.txt
+++ b/applications/h264/h264_endoscopy_tool_tracking/CMakeLists.txt
@@ -67,4 +67,10 @@ if(BUILD_TESTING)
   set_tests_properties(h264_endoscopy_tool_tracking_cpp_test PROPERTIES
                        PASS_REGULAR_EXPRESSION "Deactivating Graph"
                        FAIL_REGULAR_EXPRESSION "[^a-z]Error;ERROR;Failed")
+
+  # For aarch64 LD_LIBRARY_PATH needs to be set
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
+    set_tests_properties(h264_endoscopy_tool_tracking_cpp_test PROPERTIES ENVIRONMENT
+                    "LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu/tegra/")
+  endif()
 endif()

--- a/applications/h264/h264_video_decode/CMakeLists.txt
+++ b/applications/h264/h264_video_decode/CMakeLists.txt
@@ -61,4 +61,10 @@ if(BUILD_TESTING)
   set_tests_properties(h264_video_decode_cpp_test PROPERTIES
                        PASS_REGULAR_EXPRESSION "Waiting for completion"
                        FAIL_REGULAR_EXPRESSION "[^a-z]Error;ERROR;Failed")
+
+  # For aarch64 LD_LIBRARY_PATH needs to be set
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
+    set_tests_properties(h264_video_decode_cpp_test PROPERTIES ENVIRONMENT
+                    "LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu/tegra/")
+  endif()
 endif()

--- a/applications/ultrasound_segmentation/cpp/CMakeLists.txt
+++ b/applications/ultrasound_segmentation/cpp/CMakeLists.txt
@@ -95,6 +95,7 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   set_tests_properties(ultrasound_segmentation_cpp_test PROPERTIES
                        ENVIRONMENT "LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${CMAKE_BINARY_DIR}/gxf_extensions"
+                       TIMEOUT 900
                        PASS_REGULAR_EXPRESSION "Reach end of file or playback count reaches to the limit. Stop ticking."
                        FAIL_REGULAR_EXPRESSION "[^a-z]Error;ERROR;Failed")
 


### PR DESCRIPTION
- CAGX takes a little bit longer to generate TRT files -> Increase the timeout to 900 (it takes a little bit more than 12 minutes).
- The LD_LIBRARY_PATH environment needs to be set for h264 applications