### PR TITLE
Fixing CAGX tests

### DIFF
--- a/applications/h264/h264_endoscopy_tool_tracking/CMakeLists.txt
+++ b/applications/h264/h264_endoscopy_tool_tracking/CMakeLists.txt
@@ -71,6 +71,6 @@ if(BUILD_TESTING)
   # For aarch64 LD_LIBRARY_PATH needs to be set
   if(CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
     set_tests_properties(h264_endoscopy_tool_tracking_cpp_test PROPERTIES ENVIRONMENT
-                    "LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu/tegra/")
+                    "LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:/usr/lib/aarch64-linux-gnu/tegra/")
   endif()
 endif()

--- a/applications/h264/h264_video_decode/CMakeLists.txt
+++ b/applications/h264/h264_video_decode/CMakeLists.txt
@@ -65,6 +65,6 @@ if(BUILD_TESTING)
   # For aarch64 LD_LIBRARY_PATH needs to be set
   if(CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
     set_tests_properties(h264_video_decode_cpp_test PROPERTIES ENVIRONMENT
-                    "LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu/tegra/")
+                    "LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:/usr/lib/aarch64-linux-gnu/tegra/")
   endif()
 endif()

--- a/applications/ultrasound_segmentation/cpp/CMakeLists.txt
+++ b/applications/ultrasound_segmentation/cpp/CMakeLists.txt
@@ -95,7 +95,7 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   set_tests_properties(ultrasound_segmentation_cpp_test PROPERTIES
                        ENVIRONMENT "LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:${CMAKE_BINARY_DIR}/gxf_extensions"
-                       TIMEOUT 900
+                       TIMEOUT 1500
                        PASS_REGULAR_EXPRESSION "Reach end of file or playback count reaches to the limit. Stop ticking."
                        FAIL_REGULAR_EXPRESSION "[^a-z]Error;ERROR;Failed")
 

--- a/applications/ultrasound_segmentation/python/CMakeLists.txt
+++ b/applications/ultrasound_segmentation/python/CMakeLists.txt
@@ -54,8 +54,9 @@ if(BUILD_TESTING)
                "PYTHONPATH=${GXF_LIB_DIR}/../python/lib")
 
   set_tests_properties(ultrasound_segmentation_python_test
-                PROPERTIES PASS_REGULAR_EXPRESSION "Reach end of file or playback count reaches to the limit. Stop ticking.;"
-                FAIL_REGULAR_EXPRESSION "[^a-z]Error;ERROR;Failed")
+                 PROPERTIES PASS_REGULAR_EXPRESSION "Reach end of file or playback count reaches to the limit. Stop ticking.;"
+                 FAIL_REGULAR_EXPRESSION "[^a-z]Error;ERROR;Failed"
+                 TIMEOUT 1500)
 
   # Add a test to check the validity of the frames
   add_test(NAME ultrasound_segmentation_python_render_test


### PR DESCRIPTION
- Increasing ultrasound test timeout to 1500s to allow for generation of TRT engine file
- Fix environment variables for H264