### PR TITLE
Modify data path to be based on build path

### DIFF
--- a/run
+++ b/run
@@ -658,6 +658,9 @@ build() {
     build_path="build/$1"
   fi
 
+  # Create data path outside build directory
+  data_path="${build_path}/../data"
+
   echo "Building $1 application"
   application="-DAPP_$1=1"
 
@@ -665,7 +668,7 @@ build() {
   cmake_extra_args="--no-warn-unused-cli -DPython3_EXECUTABLE=${HOLOHUB_PY_EXE} -DPython3_ROOT_DIR=${HOLOHUB_PY_LIB}"
 
   # We set the data directory to be outside the build directory
-  cmake_extra_args="$cmake_extra_args $configure_args -DHOLOHUB_DATA_DIR:PATH=${SCRIPT_DIR}/data"
+  cmake_extra_args="$cmake_extra_args $configure_args -DHOLOHUB_DATA_DIR:PATH=${data_path}"
 
   # Sets the default path for cuda
   export PATH=$PATH:/usr/local/cuda/bin


### PR DESCRIPTION
The run script has been updated so that the data path environment variable is based on the build_path variable.

This makes sense to me as I am developing in a container where I don't have control of the volume mount, which is a perfect use case for the `--buildpath` arg. Intuitively, it would make sense to have that data dir be adjusted by this variable as well. That way, both your build and data will be persisted when developing in containers with different volume mount locations.