### PR TITLE
Update `__init__.py` template to support Python operators emitting and receiving custom C++ types 

### DIFF
--- a/cmake/pybind11/__init__.py
+++ b/cmake/pybind11/__init__.py
@@ -13,7 +13,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
+
 import holoscan.core
 import holoscan.gxf
 
 from ._@MODULE_NAME@ import @MODULE_CLASS_NAME@
+
+try:
+    # If a register_types function exists, register the types with the SDK
+    from ._@MODULE_NAME@ import register_types as _register_types
+
+    try:
+        from holoscan.core import io_type_registry
+    except ImportError as e:
+        warnings.warn(
+            "`holoscan.core.io_type_registry` is unavailable in Holoscan SDK < 2.1.0. "
+            "To use a user-defined `register_types` function, you must upgrade Holoscan SDK."
+        )
+        raise e
+
+    # register any custom emitter/receiver types with the SDK's registry
+    _register_types(io_type_registry)
+except ImportError as e:
+    # Most extensions will not provide a user-defined `register_types` function, so don't warn or
+    # raise an error in that case.
+    pass


### PR DESCRIPTION
## Background
Holoscan 2.1 has a new feature to allow registering type handling code for Python operators to send or receive new user-defined C++ types ([see docs here](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_create_operator_python_bindings.html#customizing-the-c-types-a-python-operator-can-emit-or-receive))

Using this requires the user to define a `register_types` function in their module's pybind11 bindings. The `__init__.py` for the module then needs to pass `holoscan.core.io_typ_registry` to that `register_types` function so that the user's types will be registered with the SDK.

For Holohub, since the user does not write the `__init__.py` file, we should automate this process by updating the `__init__.py` template used. That is done here via  a try/except clause that will register the types whenever a `register_types` function is defined in the module.

## Additional Details

Using the `register_types` feature requires Holoscan SDK 2.1, but the template change here is backwards compatible with older releases due to the try/except around the imports.