### PR TITLE
Fix cropping issue

### DIFF
--- a/applications/body_pose_estimation/body_pose_estimation.py
+++ b/applications/body_pose_estimation/body_pose_estimation.py
@@ -351,6 +351,9 @@ class BodyPoseEstimationApp(Application):
     def compose(self):
         pool = UnboundedAllocator(self, name="pool")
 
+        # Input data type of preprocessor
+        in_dtype = "rgb888"
+
         # Determine if the DDS Publisher is enabled.
         dds_common_args = self.kwargs("dds_common")
         dds_publisher_args = dds_common_args | self.kwargs("dds_publisher")
@@ -368,6 +371,8 @@ class BodyPoseEstimationApp(Application):
                 **v4l2_args,
             )
             source_output = "signal"
+            # v4l2 operator outputs RGBA8888
+            in_dtype = "rgba8888"
         elif self.source == "replayer":
             source = VideoStreamReplayerOp(
                 self,
@@ -405,6 +410,7 @@ class BodyPoseEstimationApp(Application):
             self,
             name="preprocessor",
             pool=pool,
+            in_dtype=in_dtype,
             **preprocessor_args,
         )
 

--- a/applications/tao_peoplenet/tao_peoplenet.py
+++ b/applications/tao_peoplenet/tao_peoplenet.py
@@ -246,6 +246,9 @@ class FaceDetectApp(Application):
     def compose(self):
         pool = UnboundedAllocator(self, name="pool")
 
+        # Input data type of preprocessor
+        in_dtype = "rgb888"
+
         if self.source == "v4l2":
             v4l2_args = self.kwargs("v4l2_source")
             if self.video_device != "none":
@@ -257,6 +260,8 @@ class FaceDetectApp(Application):
                 **v4l2_args,
             )
             source_output = "signal"
+            # v4l2 operator outputs RGBA8888
+            in_dtype = "rgba8888"
         elif self.source == "replayer":
             source = VideoStreamReplayerOp(
                 self,
@@ -277,6 +282,7 @@ class FaceDetectApp(Application):
             self,
             name="preprocessor",
             pool=pool,
+            in_dtype=in_dtype,
             **preprocessor_args,
         )
 


### PR DESCRIPTION
Found a cropping issue during hackathon that affects tao_peoplenet and body_pose_estimation apps.  
Jonathan found the fix by specifying `in_dtype` for the preprocessor.

The image that was going into Inference Op was missing 25% of the right side of the picture, so the body and face detection is not working properly.  With this fix, the bounding boxes for the person on the right is working as expected.


**Before**
![before](https://github.com/nvidia-holoscan/holohub/assets/60016436/8b21edd1-6fea-4415-bfc4-4bcf69debcba)

**After**
![after](https://github.com/nvidia-holoscan/holohub/assets/60016436/581a8764-3867-4ebe-ad90-e18438f7521f)
