### PR TITLE
App: Apply seccomp exceptions in `volume_rendering_xr`

### DIFF
--- a/applications/volume_rendering_xr/Dockerfile
+++ b/applications/volume_rendering_xr/Dockerfile
@@ -95,6 +95,15 @@ ENV PATH="${PATH}:${VULKAN_SDK}/bin"
 ENV CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:${VULKAN_SDK}"
 
 ############################################################
+# Windrunner configuration
+# 
+# Add known IGX dGPU syscall requirements to the Windrunner
+# seccomp whitelist
+############################################################
+COPY /applications/volume_rendering_xr/thirdparty/magicleap/seccomp_whitelist.cfg \
+     /usr/share/windrunner/seccomp_whitelist.cfg
+
+############################################################
 # Environment variables
 ############################################################
 # Magic Leap Windrunner environment variables

--- a/applications/volume_rendering_xr/thirdparty/magicleap/seccomp_whitelist.cfg
+++ b/applications/volume_rendering_xr/thirdparty/magicleap/seccomp_whitelist.cfg
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Syscalls to allow in the Windrunner OpenXR backend, appended to the
+# built-in backend whitelist.
+
+tgkill
+renameat
+pselect6
+
+# You can add more seccomp violation exceptions here. Please note that you
+# are responsible for reviewing any violations that you add to this list.
+# Visit https://chromium.googlesource.com/chromiumos/docs/+/master/constants/syscalls.md#arm64-64_bit
+# to translate seccomp IDs to syscall names based on your host platform.


### PR DESCRIPTION
Manually adds syscalls to the whitelist used by the Magic Leap Windrunner backend to address issues seen on IGX dGPU.

Resolves https://github.com/nvidia-holoscan/holohub/issues/377. Tested with ML2 headset with the app container launched as the root user (`--as_root`) as specified as the workaround for the separate issue https://github.com/nvidia-holoscan/holohub/issues/378.