### PR TITLE
Infra: Automate PR creation for README badge statistics updates

### DIFF
--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -27,10 +27,15 @@ jobs:
           sed -i -E "s/Operators-([0-9]+)/Operators-$ops_count/" README.md
           tutorial_count=$(cat aggregate_metadata.json | grep "\"source_folder\": \"tutorials\"" | wc -l)
           sed -i -E "s/Tutorials-([0-9]+)/Tutorials-$tutorial_count/" README.md
-      
-      - name: Auto-Commit README Changes
-        uses: EndBug/add-and-commit@v9
+          git diff HEAD -- README.md
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6.0.5
         with:
-          add: 'README.md'
-          commit: '--signoff'
-          message: Update README Project Statistics
+          add-paths: 'README.md'
+          commit-message: '[auto] Update README Project Statistics'
+          signoff: true
+          branch: readme-auto-update/patch
+          title: Update README Project Statistics
+          body: 'Automated update to reflect HoloHub project counts in the HoloHub README file.'
+          reviewers: tbirdso,jjomier


### PR DESCRIPTION
Update README statistics workflow to create a PR rather than attempting to merge project statistics updates directly into `main`.

Workaround for new branch protections in HoloHub preventing the previous workflow from auto-commiting statistics updates to `main`. Workflow will continue to trigger only on new pushes to `main`.

Example workflow: https://github.com/tbirdso/holohub/actions/runs/9555442193/job/26338686786

Example automatic PR: https://github.com/tbirdso/holohub/pull/3