### PR TITLE
Doc: Adopt RAPIDS code of conduct

### DIFF
--- a/CODE_OF_CONDUCT
+++ b/CODE_OF_CONDUCT
@@ -1,0 +1,4 @@
+We observe the [RAPIDS Contributor Covenant Code of Conduct](https://docs.rapids.ai/resources/conduct/)
+to foster a positive Holoscan community.
+
+Please report any instances of conduct violations to holoscan-conduct@nvidia.com.


### PR DESCRIPTION
Adopt the RAPIDS community code of conduct to set expectations for Holoscan and HoloHub engagement.