### PR TITLE
Infra: Add `update_readme.sh` utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 )
 [![Pages](https://img.shields.io/github/actions/workflow/status/nvidia-holoscan/holohub/generate_pages.yml?branch=main&label=Pages)](https://nvidia-holoscan.github.io/holohub/)
 
-[![Applications](https://img.shields.io/badge/Applications-64-59A700)](https://github.com/nvidia-holoscan/holohub/tree/main/applications)
+[![Applications](https://img.shields.io/badge/Applications-65-59A700)](https://github.com/nvidia-holoscan/holohub/tree/main/applications)
 [![Operators](https://img.shields.io/badge/Operators-45-59A700)](https://github.com/nvidia-holoscan/holohub/tree/main/operators)
 [![Tutorials](https://img.shields.io/badge/Tutorials-7-59A700)](https://github.com/nvidia-holoscan/holohub/tree/main/tutorials)
 

--- a/utilities/update_readme.sh
+++ b/utilities/update_readme.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+
+# Simple utility script to update GitHub badges in the HoloHub README.md file.
+# Usage:
+#
+# ```bash
+# ./utilities/update_readme.sh
+# git add README.md && git commit -s -m "Update HoloHub Project Statistics"
+# ```
+
+python ./utilities/gather_metadata.py --output aggregate_metadata.json
+app_count=$(cat aggregate_metadata.json | grep "\"source_folder\": \"applications\"" | wc -l)
+sed -i -E "s/Applications-([0-9]+)/Applications-$app_count/" README.md
+ops_count=$(cat aggregate_metadata.json | grep "\"source_folder\": \"operators\"" | wc -l)
+sed -i -E "s/Operators-([0-9]+)/Operators-$ops_count/" README.md
+tutorial_count=$(cat aggregate_metadata.json | grep "\"source_folder\": \"tutorials\"" | wc -l)
+sed -i -E "s/Tutorials-([0-9]+)/Tutorials-$tutorial_count/" README.md


### PR DESCRIPTION
Changes:
1. Add `update_readme.sh` utility as a convenient workaround for updating GitHub badges in the HoloHub README file while permissions issues are pending (see 9b50520b5b99df51f39b19cc0bd6eb8006c4c0bd)
2. Run the script and commit changes for up-to-date GitHub badges