### PR TITLE
Fix huggingface-cli install

### DIFF
--- a/applications/vila_live/requirements.txt
+++ b/applications/vila_live/requirements.txt
@@ -4,6 +4,6 @@ asyncio==3.4.3
 pillow==10.3.0
 torchvision==0.16
 ninja
-huggingface-cli
+huggingface-hub[cli]
 s2wrapper@git+https://github.com/bfshi/scaling_on_scales
 


### PR DESCRIPTION
`huggingface-cli` is now installed through `huggingface-hub`
This will fix this error for the vila_live application:
```
ERROR: Could not find a version that satisfies the requirement huggingface-cli (from versions: none)
```