### PR TITLE
Endoscopy Tool Tracking using VTK for HSDK 2.1

### DIFF
--- a/applications/endoscopy_tool_tracking/README.md
+++ b/applications/endoscopy_tool_tracking/README.md
@@ -50,38 +50,18 @@ and visualization. The tool tracking application uses VTK to render the tool
 tracking results on top of the endoscopy video frames.
 
 
-### How to build the tool tracking application with VTK
+### How to build and run the Endoscopy Tool Tracking application with VTK
 
-Build the HoloHub container as described at the root [README.md](../../README.md)
+The following command builds and runs the Endoscopy Tool Tracking application with VTK:
 
-You need to create a docker image which includes VTK with the provided
-`vtk.Dockerfile` in the `operator/vtk_renderer` subdirectory:
-
-```bash
-docker build -t vtk:latest -f vtk.Dockerfile .
 ```
-Set vtk as the visualizer by:
+# change the configuration to use VTK (vtk_renderer) as the default renderer
+sed -i -e 's#^visualizer:.*#visualizer: "vtk"#' applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
 
-* Using a vtk_renderer instead of holoviz
-    ```bash
-    sed -i -e 's#^visualizer:.*#visualizer: "vtk"#' applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
-    applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking --data <data_dir>/endoscopy
-    ```
-Then, you can build the tool tracking application with the provided
-`Dockerfile`:
-
-```bash
-./dev_container launch --img vtk:latest
+# build and launch the application
+./dev_container build_and_run endoscopy_tool_tracking --build_with vtk_renderer --docker_file operators/vtk_renderer/vtk.Dockerfile
 ```
 
-Inside the container you can build the application with:
-
-```bash
-./run build endoscopy_tool_tracking --with vtk_renderer
-```
-
-Now you can run the tool tracking application with:
-
-```bash
-./run launch endoscopy_tool_tracking cpp
-```
+Arguments:
+- `--build_with` : instructs the script to build the application with the `vtk_renderer` operator
+- `--docker_file`: instructs the script to use the `operators/vtk_renderer/vtk.Dockerfile` that includes VTK libraries

--- a/applications/endoscopy_tool_tracking/cpp/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required(VERSION 3.20)
 project(endoscopy_tool_tracking CXX)
 
-find_package(holoscan 0.5 REQUIRED CONFIG
+find_package(holoscan 2.1 REQUIRED CONFIG
              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
 add_executable(endoscopy_tool_tracking

--- a/applications/endoscopy_tool_tracking/cpp/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required(VERSION 3.20)
 project(endoscopy_tool_tracking CXX)
 
-find_package(holoscan 2.1 REQUIRED CONFIG
+find_package(holoscan 1.0 REQUIRED CONFIG
              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
 add_executable(endoscopy_tool_tracking

--- a/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
+++ b/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
@@ -15,11 +15,6 @@
 # limitations under the License.
 ---
 extensions:
-  - libgxf_std.so
-  - libgxf_cuda.so
-  - libgxf_multimedia.so
-  - libgxf_serialization.so
-  - libgxf_stream_playback.so
   - gxf_extensions/lstm_tensor_rt_inference/libgxf_lstm_tensor_rt_inference.so
 # Uncomment the following extension when using deltacast as a source
 #  - gxf_extensions/deltacast_videomaster/libgxf_videomaster.so

--- a/applications/endoscopy_tool_tracking/cpp/metadata.json
+++ b/applications/endoscopy_tool_tracking/cpp/metadata.json
@@ -10,12 +10,13 @@
 		"language": "C++",
 		"version": "1.0",
 		"changelog": {
-			"1.0": "Initial Release"
+			"1.0": "Initial Release",
+			"2.0": "Update to support Holoscan SDK 2.1.0"
 		},
 		"holoscan_sdk": {
-			"minimum_required_version": "0.5.0",
+			"minimum_required_version": "2.1.0",
 			"tested_versions": [
-				"0.5.0"
+				"2.1.0"
 			]
 		},
 		"platforms": ["amd64", "arm64"],

--- a/applications/endoscopy_tool_tracking/cpp/metadata.json
+++ b/applications/endoscopy_tool_tracking/cpp/metadata.json
@@ -14,9 +14,12 @@
 			"2.0": "Update to support Holoscan SDK 2.1.0"
 		},
 		"holoscan_sdk": {
-			"minimum_required_version": "2.1.0",
+			"minimum_required_version": "1.0.3",
 			"tested_versions": [
-				"2.1.0"
+				"1.0.3",
+				"2.0.0",
+				"2.1.0",
+				"2.2.0"
 			]
 		},
 		"platforms": ["amd64", "arm64"],

--- a/applications/endoscopy_tool_tracking/python/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/python/CMakeLists.txt
@@ -16,7 +16,7 @@
 # Add testing
 if(BUILD_TESTING)
   # To get the environment path
-  find_package(holoscan 0.5 REQUIRED CONFIG PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+  find_package(holoscan 1.0 REQUIRED CONFIG PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
   set(RECORDING_DIR ${CMAKE_CURRENT_BINARY_DIR}/recording_output)
   set(SOURCE_VIDEO_BASENAME python_endoscopy_tool_tracking_output)

--- a/applications/endoscopy_tool_tracking/python/metadata.json
+++ b/applications/endoscopy_tool_tracking/python/metadata.json
@@ -13,9 +13,12 @@
 			"1.0": "Initial Release"
 		},
 		"holoscan_sdk": {
-			"minimum_required_version": "0.5.0",
+			"minimum_required_version": "1.0.3",
 			"tested_versions": [
-				"0.5.0"
+				"1.0.3",
+				"2.0.0",
+				"2.1.0",
+				"2.2.0"
 			]
 		},
 		"platforms": [

--- a/dev_container
+++ b/dev_container
@@ -736,6 +736,8 @@ build_and_run_desc() { c_echo 'Build and run a requested application in a Docker
         --language : Specify the app language implementation to run.
                      Some applications provide both `cpp` and `python` implementations.
         --no_build : Launch the app without attempting to build it first
+        --build_args : Build the app with additional args
+        --build_with : List of optional operators that should be built separated by semicolons (;)
         --run_args : Run the app with additional args
         --verbose : Print extra output to console
         --dryrun : View build and run commands without doing anything
@@ -750,6 +752,8 @@ build_and_run() {
     local build_app=1
     local image_name=""
     local docker_file=""
+    local extra_build_args=""
+    local extra_build_with=""
     local extra_run_args=""
 
     # Parse CLI arguments next
@@ -788,6 +792,26 @@ build_and_run() {
             --no_build)
                 build_app=0
                 shift
+                ;;
+            --build_with)
+                if [[ -n "$2" ]]; then
+                    extra_build_with="--with '$2'"
+                    shift 2
+                else
+                    echo "Error: --build_with requires a value"
+                    build_and_run_desc
+                    exit 1
+                fi
+                ;;
+            --build_args)
+                if [[ -n "$2" ]]; then
+                    extra_build_args="--configure-args '$2'"
+                    shift 2
+                else
+                    echo "Error: --build_args requires a value"
+                    build_and_run_desc
+                    exit 1
+                fi
                 ;;
             --run_args)
                 if [[ -n "$2" ]]; then
@@ -851,7 +875,7 @@ build_and_run() {
 
     run_command ${SCRIPT_DIR}/dev_container build $container_build_args
     if [[ $build_app == 1 ]]; then
-        run_command ${SCRIPT_DIR}/dev_container launch $container_launch_args -- -c "./run build $app_name"
+        run_command ${SCRIPT_DIR}/dev_container launch $container_launch_args -- -c "./run build $app_name $extra_build_with $extra_build_args"
     fi
     run_command ${SCRIPT_DIR}/dev_container launch $container_launch_args -- -c "./run launch $app_name $app_language $extra_run_args"
 }

--- a/dev_container
+++ b/dev_container
@@ -736,7 +736,7 @@ build_and_run_desc() { c_echo 'Build and run a requested application in a Docker
         --language : Specify the app language implementation to run.
                      Some applications provide both `cpp` and `python` implementations.
         --no_build : Launch the app without attempting to build it first
-        --build_args : Build the app with additional args
+        --build_args : Build the app with additional CMake configuration arguments
         --build_with : List of optional operators that should be built separated by semicolons (;)
         --run_args : Run the app with additional args
         --verbose : Print extra output to console

--- a/operators/tool_tracking_postprocessor/tool_tracking_postprocessor.cpp
+++ b/operators/tool_tracking_postprocessor/tool_tracking_postprocessor.cpp
@@ -72,7 +72,7 @@ void ToolTrackingPostprocessorOp::setup(OperatorSpec& spec) {
   // Because coords is on host and mask is on device, emit them on separate ports for
   // compatibility with use of this operator in distributed applications.
   auto& out_coords = spec.output<gxf::Entity>("out_coords");
-  auto& out_mask = spec.output<gxf::Entity>("out_mask");
+  auto& out_mask = spec.output<gxf::Entity>("out_mask").condition(ConditionType::kNone);
 
   spec.param(in_, "in", "Input", "Input port.", &in_tensor);
   spec.param(

--- a/operators/version_helper_macros.hpp
+++ b/operators/version_helper_macros.hpp
@@ -1,3 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #ifndef VERSION_HELPER_MACROS_HPP
 #define VERSION_HELPER_MACROS_HPP
 

--- a/operators/version_helper_macros.hpp
+++ b/operators/version_helper_macros.hpp
@@ -1,0 +1,13 @@
+#ifndef VERSION_HELPER_MACROS_HPP
+#define VERSION_HELPER_MACROS_HPP
+
+// If GXF has gxf/std/dlpack_utils.hpp it has DLPack support
+#if __has_include("gxf/std/dlpack_utils.hpp")
+  #define GXF_HAS_DLPACK_SUPPORT 1
+  #include "gxf/std/tensor.hpp"
+#else
+  #define GXF_HAS_DLPACK_SUPPORT 0
+  #include "holoscan/core/gxf/gxf_tensor.hpp"
+#endif
+
+#endif /* VERSION_HELPER_MACROS_HPP */

--- a/operators/vtk_renderer/vtk.Dockerfile
+++ b/operators/vtk_renderer/vtk.Dockerfile
@@ -15,10 +15,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v2.1.0-dgpu
+ARG BASE_IMAGE=
 FROM ${BASE_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive
+
+# --------------------------------------------------------------------------
+#
+# Holohub run setup 
+#
+
+RUN mkdir -p /tmp/scripts
+COPY run /tmp/scripts/
+RUN mkdir -p /tmp/scripts/utilities
+COPY utilities/holohub_autocomplete /tmp/scripts/utilities/
+RUN chmod +x /tmp/scripts/run
+RUN /tmp/scripts/run setup
+
+# Enable autocomplete
+RUN echo ". /etc/bash_completion.d/holohub_autocomplete" >> /etc/bash.bashrc
+
 
 # Install dependencies
 RUN apt update && \

--- a/operators/vtk_renderer/vtk.Dockerfile
+++ b/operators/vtk_renderer/vtk.Dockerfile
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_IMAGE=holohub:ngc-v1.0.3-dgpu
+ARG BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v2.1.0-dgpu
 FROM ${BASE_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/operators/vtk_renderer/vtk_renderer.cpp
+++ b/operators/vtk_renderer/vtk_renderer.cpp
@@ -160,7 +160,7 @@ void VtkRendererOp::compute(InputContext& op_input, OutputContext&, ExecutionCon
   auto videostream = op_input.receive<gxf::Entity>("videostream").value();
   const auto videostream_tensor = videostream.get<Tensor>("");
   if (videostream_tensor) {
-    holoscan::gxf::GXFTensor in_tensor_gxf{videostream_tensor->dl_ctx()};
+    nvidia::gxf::Tensor in_tensor_gxf{videostream_tensor->dl_ctx()};
     auto& shape = in_tensor_gxf.shape();
     const int y = shape.dimension(0);
     const int x = shape.dimension(1);

--- a/operators/vtk_renderer/vtk_renderer.cpp
+++ b/operators/vtk_renderer/vtk_renderer.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "vtk_renderer.hpp"
+#include "../version_helper_macros.hpp"
 
 #include "holoscan/core/execution_context.hpp"
 #include "holoscan/core/gxf/entity.hpp"
@@ -160,7 +161,11 @@ void VtkRendererOp::compute(InputContext& op_input, OutputContext&, ExecutionCon
   auto videostream = op_input.receive<gxf::Entity>("videostream").value();
   const auto videostream_tensor = videostream.get<Tensor>("");
   if (videostream_tensor) {
+  #if GXF_HAS_DLPACK_SUPPORT
     nvidia::gxf::Tensor in_tensor_gxf{videostream_tensor->dl_ctx()};
+  #else
+    holoscan::gxf::GXFTensor in_tensor_gxf{videostream_tensor->dl_ctx()};
+  #endif
     auto& shape = in_tensor_gxf.shape();
     const int y = shape.dimension(0);
     const int x = shape.dimension(1);


### PR DESCRIPTION
This PR updates the Endoscopy Tool Tracking app to support HSDK 2.1 and updates the build and run instructions when using the application with the VTK renderer.

Additional changes:
- update Tool Tracking PostProcessor's out_mask optional
- update dev_container script with new `--build_with` and `--build_args` args to support building with additional operators and arguments, respectively.

Fixes gh-416