### PR TITLE
Ignore HOME files in Git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ aggregate_metadata.json
 # Dev
 .venv/
 ngc-cli/
+.bash_history
+.wget-hsts
+


### PR DESCRIPTION
e5f4d97d updated the `dev_container launch` command to set the `HOME` environment variable to the default HoloHub container workspace. As a result, temporary files such as `.bash_history` that are written to the container `HOME` path may now persist in the HoloHub source directory after the container stops.

It is not immediately obvious whether the referenced files should be removed or allowed to persist. It can be useful to refer back to commands from the previous container session. For now we may simply prevent `.bash_history` from being committed to Git history as this is a per-user file.

Follows previous unintentional commit at https://github.com/nvidia-holoscan/holohub/pull/406.