### PR TITLE
Infra: Bump default base container to Holoscan SDK v2.2.0

### DIFF
--- a/dev_container
+++ b/dev_container
@@ -268,11 +268,11 @@ get_host_gpu() {
 
 
 get_default_base_img() {
-    echo -n "nvcr.io/nvidia/clara-holoscan/holoscan:v2.1.0-"$(get_host_gpu)
+    echo -n "nvcr.io/nvidia/clara-holoscan/holoscan:v2.2.0-"$(get_host_gpu)
 }
 
 get_default_img() {
-    echo -n "holohub:ngc-v2.1.0-"$(get_host_gpu)
+    echo -n "holohub:ngc-v2.2.0-"$(get_host_gpu)
 }
 
 # This function returns the compute capacity of the system's GPU (8.6, 8.9, etc.)


### PR DESCRIPTION
Follows the release of Holoscan SDK v2.2.0

https://github.com/nvidia-holoscan/holoscan-sdk/releases/tag/v2.2.0