### PR TITLE
Bump the HoloHub landing page to v2.2.0

### DIFF
--- a/src/Hero.jsx
+++ b/src/Hero.jsx
@@ -6,10 +6,10 @@ const Hero = () => {
     <div className="hidden sm:mb-8 sm:flex sm:justify-center">
       <div className="relative rounded-full px-3 py-1  mt-2 text-sm leading-6 text-gray-600 ring-1 ring-gray-900/10 hover:ring-gray-900/20">
         What's New? &nbsp;
-        <a href="https://github.com/nvidia-holoscan/holoscan-sdk/releases/tag/v2.1.0" className="font-semibold text-lime-500"
+        <a href="https://github.com/nvidia-holoscan/holoscan-sdk/releases/tag/v2.2.0" className="font-semibold text-lime-500"
         target="_blank">
           <span className="absolute inset-0" aria-hidden="true" />
-          Just shipped NVIDIA Holoscan SDK v2.1.0 <span aria-hidden="true">&rarr;</span>
+          Just shipped NVIDIA Holoscan SDK v2.2.0 <span aria-hidden="true">&rarr;</span>
         </a>
       </div>
     </div>


### PR DESCRIPTION
Bumps landing page card to reference the latest Holoscan SDK release (v2.2.0)