### PR TITLE
Infra: Add `benchmarks` folder support in `run` commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,9 @@ set(CMAKE_INSTALL_RPATH "\$ORIGIN/../lib:/opt/nvidia/holoscan/lib/")
 # Build the applications
 add_subdirectory(applications)
 
+# Build the benchmarks
+add_subdirectory(benchmarks)
+
 # Build the operators
 add_subdirectory(operators)
 

--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -55,8 +55,6 @@ add_holohub_application(high_speed_endoscopy DEPENDS
 
 add_holohub_application(hyperspectral_segmentation)
 
-add_holohub_application(model_benchmarking)
-
 add_holohub_application(multiai_endoscopy)
 
 add_holohub_application(multiai_ultrasound DEPENDS

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_holohub_application(model_benchmarking)

--- a/run
+++ b/run
@@ -127,10 +127,17 @@ get_app_source_root_dir() {
     app_rel_path=${sub_app_path#"${SCRIPT_DIR}/applications/"}
     if [[ -n "$app_rel_path" ]]; then
       holohub_app_source="${SCRIPT_DIR}/applications/${app_rel_path}"
-    else
-      echo "Could not find subproject ${appname}"
-      exit 1
     fi
+  fi
+
+  # Check if the application is in the benchmarks folder
+  if [ ! -d "$holohub_app_source" ] && [ -d "${SCRIPT_DIR}/benchmarks/${appname}" ]; then
+    holohub_app_source="${SCRIPT_DIR}/benchmarks/${appname}"
+  fi
+
+  if [ ! -d "$holohub_app_source" ]; then
+    echo "Could not find project ${appname}"
+    exit 1
   fi
 
   echo -n "${holohub_app_source}"
@@ -793,7 +800,8 @@ launch() {
    json=$(${HOLOHUB_PY_EXE} -c 'import json,sys
 f=open("'${metadata_file}'")
 obj=json.load(f)
-for k, v in obj["application"]["run"].items():
+project_type = "benchmark" if "benchmark" in obj.keys() else "application"
+for k, v in obj[project_type]["run"].items():
   print(str(k)+"=\""+str(v)+"\"")
 ')
 
@@ -864,8 +872,9 @@ list() {
   echo "***** HoloHub applications ******"
 
   apps=$(find ${SCRIPT_DIR}/applications -name 'metadata.json' | sort -d)
+  apps+=$(find ${SCRIPT_DIR}/benchmarks -name 'metadata.json' | sort -d)
   for d in ${apps}; do
-    local appname=$(dirname $d | grep -Po '^'${SCRIPT_DIR}/applications/'\K[^ ]*')
+    local appname=$(dirname $d | grep -Po '^'${SCRIPT_DIR}'/(applications|benchmarks)/\K[^ ]*')
 
     local language="${appname##*/}"
     if [[ ${language} != "cpp" ]] && [[ ${language} != "python" ]]; then


### PR DESCRIPTION
Adds infrastructure support to list, build, and run projects in the `benchmarks` folder with the `run` script.

f458d3bedbd598eba06887049421453a54501458 created the "benchmarks" folder and project schema to highlight HoloHub performance-focused tools and projects. However, the "run" script at that time was hardcoded to search for projects only in the "applications" folder.

This change fixes the `model_benchmarking` application in particular to run according to existing README instructions.