### PR TITLE
Fix warning because of "as" in smallcap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 ARG BASE_IMAGE
 ARG GPU_TYPE
 
-FROM ${BASE_IMAGE} as base
+FROM ${BASE_IMAGE} AS base
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Fix the following warning

Ref: https://docs.docker.com/reference/build-checks/from-as-casing/