### PR TITLE
App: Revert `volume_rendering` Holoscan SDK minimum to v1.0

### DIFF
--- a/applications/volume_rendering/cpp/CMakeLists.txt
+++ b/applications/volume_rendering/cpp/CMakeLists.txt
@@ -15,7 +15,7 @@
 cmake_minimum_required(VERSION 3.20)
 project(volume_rendering)
 
-find_package(holoscan 2.1 REQUIRED CONFIG
+find_package(holoscan 1.0 REQUIRED CONFIG
              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
 add_executable(volume_rendering

--- a/applications/volume_rendering/cpp/metadata.json
+++ b/applications/volume_rendering/cpp/metadata.json
@@ -14,8 +14,10 @@
 			"2.0": "Update to Holoscan SDK 2.1"
 		},
 		"holoscan_sdk": {
-			"minimum_required_version": "2.1.0",
+			"minimum_required_version": "1.0.3",
 			"tested_versions": [
+				"1.0.3",
+				"2.0.0",
 				"2.1.0"
 			]
 		},

--- a/applications/volume_rendering/python/CMakeLists.txt
+++ b/applications/volume_rendering/python/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required(VERSION 3.20)
 project(volume_rendering_python LANGUAGES NONE)
 
-find_package(holoscan 2.1 REQUIRED CONFIG
+find_package(holoscan 2.0 REQUIRED CONFIG
              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
 # Enable the operators

--- a/applications/volume_rendering/python/metadata.json
+++ b/applications/volume_rendering/python/metadata.json
@@ -13,8 +13,9 @@
 			"1.0": "Initial Release"
 		},
 		"holoscan_sdk": {
-			"minimum_required_version": "2.0.0",
+			"minimum_required_version": "1.0.3",
 			"tested_versions": [
+				"1.0.3",
 				"2.0.0",
 				"2.1.0"
 			]

--- a/applications/volume_rendering/python/metadata.json
+++ b/applications/volume_rendering/python/metadata.json
@@ -13,8 +13,9 @@
 			"1.0": "Initial Release"
 		},
 		"holoscan_sdk": {
-			"minimum_required_version": "2.1.0",
+			"minimum_required_version": "2.0.0",
 			"tested_versions": [
+				"2.0.0",
 				"2.1.0"
 			]
 		},

--- a/doc/release.md
+++ b/doc/release.md
@@ -32,7 +32,7 @@ NVIDIA maintains a curated subset of first-party applications in HoloHub that re
 - [`body_pose_estimation`](/applications/body_pose_estimation/README.md)
 - [`endoscopy_tool_tracking`](/applications/endoscopy_tool_tracking/README.md)
 - [`multiai_ultrasound`](/applications/multiai_ultrasound/README.md)
-- [`volume_rendering`](/applications/volume_rendering/README.md)
+- [`volume_rendering` (C++)](/applications/volume_rendering/README.md)
 
 ### Short Term Support
 

--- a/operators/volume_loader/CMakeLists.txt
+++ b/operators/volume_loader/CMakeLists.txt
@@ -15,7 +15,7 @@
 cmake_minimum_required(VERSION 3.20)
 project(volume_loader)
 
-find_package(holoscan 2.1 REQUIRED CONFIG
+find_package(holoscan 0.6 REQUIRED CONFIG
              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
 # Set CMP0135 policy to NEW to use time of extraction for files extracted by

--- a/operators/volume_loader/metadata.json
+++ b/operators/volume_loader/metadata.json
@@ -15,7 +15,10 @@
         "holoscan_sdk": {
             "minimum_required_version": "0.6.0",
             "tested_versions": [
-                "0.6.0"
+                "0.6.0",
+                "1.0.3",
+                "2.0.0",
+                "2.1.0"
             ]
         },
         "platforms": [

--- a/operators/volume_renderer/CMakeLists.txt
+++ b/operators/volume_renderer/CMakeLists.txt
@@ -84,6 +84,7 @@ target_link_libraries(volume_renderer
     clara::viz::renderer
     clara::viz::core
     clara::viz::core::hw
+    GXF::multimedia
 )
 
 target_include_directories(volume_renderer INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/operators/volume_renderer/metadata.json
+++ b/operators/volume_renderer/metadata.json
@@ -14,9 +14,11 @@
             "2.0": "Updates for compatibility with XR operators"
         },
         "holoscan_sdk": {
-            "minimum_required_version": "2.0.0",
+            "minimum_required_version": "1.0.3",
             "tested_versions": [
-                "2.0.0"
+                "1.0.3",
+                "2.0.0",
+                "2.1.0"
             ]
         },
         "platforms": [


### PR DESCRIPTION
Reverts `volume_rendering` C++/Python application and `volume_loader` operator to require a minimum of Holoscan SDK v1.0, rather than v2.1.

As part of Volume Rendering Python updates
663542b67da39a32a2ee0d37d9b91aefb0e787e7 increased the minimum version of Holoscan SDK required for the apps and operator to v2.1. However, `volume_rendering` is required to be compatible with Holoscan SDK v1.0 and v2.0 as part of the Nvidia AI Enterprise program strategy documented at
https://github.com/nvidia-holoscan/holohub/blob/main/doc/release.md#holoscan-sdk-long-term-compatibility.

On review the C++ `volume_rendering` application still builds and runs with Holoscan SDK v1.0 and v2.0 NVAIE containers if the CMake minimum package requirement is reverted to v1.0. Proposing we revert that minimum requirement with no other feature changes.