### PR TITLE
Benchmark: Fix masked `-h` argument in flow tracking graph tool

### DIFF
--- a/benchmarks/holoscan_flow_benchmarking/app_perf_graph.py
+++ b/benchmarks/holoscan_flow_benchmarking/app_perf_graph.py
@@ -191,7 +191,6 @@ def parse_arguments():
         "filenames", nargs="+", help="The files to plot. In live mode, provide a folder."
     )
     parser.add_argument(
-        "-h",
         "--highlight",
         action="store_true",
         help="highlight nodes in the graph whose average latency is higher than the average of all the operators",


### PR DESCRIPTION
Fixes a small issue in `app_perf_graph.py` where the `-h` short option referred to either `--highlight` or the built-in `--help`, which prevented the tool from launching.

`app_perf_graph.py` is part of the `holoscan_flow_tracking` benchmarking tools/tutorial and is used for translating flow tracking log output into operator flow graphviz visualizations. The `-h` option is removed, but the `--highlight` long flag can still be used to launch the tool with highlighting.

Under previous behavior launching the script would return an error:
```
$ python3 app_perf_graph.py
...
argparse.ArgumentError: argument -h/--highlight: conflicting option string: -h
```