### PR TITLE
basic_network Python app - handle unavailable parameter values in HSDK 2.1

### DIFF
--- a/applications/basic_networking_ping/README.md
+++ b/applications/basic_networking_ping/README.md
@@ -20,6 +20,18 @@ Please refer to the basic network operator documentation for more configuration 
 This application requires:
 1. Linux
 
+### Quick Start
+
+Use the following to build and run the application:
+
+```bash
+# Start the receiver
+./dev_container build_and_run basic_networking_ping --base_img holoscan-dev-container:main --language <cpp|python> --run_args basic_networking_ping_rx.yaml
+# Start the transmitter
+./dev_container build_and_run basic_networking_ping --base_img holoscan-dev-container:main --language <cpp|python> --run_args basic_networking_ping_tx.yaml
+```
+
+
 ### Build Instructions
 
 Please refer to the top level Holohub README.md file for information on how to build this application.
@@ -30,7 +42,10 @@ Running the sample uses the standard HoloHub `run` script:
 
 
 ```bash
-./run launch basic_networking_ping <language> --configure-args config_file.yaml
+# Start the receiver
+./run launch basic_networking_ping <language> --extra_args basic_networking_ping_rx.yaml
+# Start the transmitter
+./run launch basic_networking_ping <language> --extra_args basic_networking_ping_tx.yaml
 ```
 
-Language can be either C++ or Python.
+Note: `language`  can be either C++ or Python.

--- a/applications/basic_networking_ping/cpp/CMakeLists.txt
+++ b/applications/basic_networking_ping/cpp/CMakeLists.txt
@@ -31,11 +31,11 @@ target_link_libraries(basic_networking_ping
 
 # Copy config file
 add_custom_target(basic_networking_ping_rx_yaml
-  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/../basic_networking_ping_rx.yaml" ${CMAKE_BINARY_DIR}
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/../basic_networking_ping_rx.yaml" ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../basic_networking_ping_rx.yaml"
 )
 add_custom_target(basic_networking_ping_tx_yaml
-  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/../basic_networking_ping_tx.yaml" ${CMAKE_BINARY_DIR}
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/../basic_networking_ping_tx.yaml" ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../basic_networking_ping_tx.yaml"
 )
 

--- a/applications/basic_networking_ping/cpp/CMakeLists.txt
+++ b/applications/basic_networking_ping/cpp/CMakeLists.txt
@@ -31,11 +31,11 @@ target_link_libraries(basic_networking_ping
 
 # Copy config file
 add_custom_target(basic_networking_ping_rx_yaml
-  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/../basic_networking_ping_rx.yaml" ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/../basic_networking_ping_rx.yaml" ${CMAKE_BINARY_DIR}
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../basic_networking_ping_rx.yaml"
 )
 add_custom_target(basic_networking_ping_tx_yaml
-  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/../basic_networking_ping_tx.yaml" ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/../basic_networking_ping_tx.yaml" ${CMAKE_BINARY_DIR}
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../basic_networking_ping_tx.yaml"
 )
 

--- a/applications/basic_networking_ping/cpp/metadata.json
+++ b/applications/basic_networking_ping/cpp/metadata.json
@@ -39,7 +39,7 @@
 		},
 		"run": {
 			"command": "<holohub_app_bin>/basic_networking_ping",
-			"workdir": "holohub_bin"
+			"workdir": "holohub_app_bin"
 		}
 	}
 }

--- a/applications/basic_networking_ping/python/CMakeLists.txt
+++ b/applications/basic_networking_ping/python/CMakeLists.txt
@@ -18,3 +18,17 @@
 add_custom_target(basic_networking_ping_python ALL
   DEPENDS basic_network_python
 )
+
+# Copy config file
+message(STATUS "Copying configuration files to ${CMAKE_CURRENT_BINARY_DIR}")
+add_custom_target(basic_networking_ping_rx_yaml_python
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/../basic_networking_ping_rx.yaml" ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../basic_networking_ping_rx.yaml"
+)
+add_custom_target(basic_networking_ping_tx_yaml_python
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/../basic_networking_ping_tx.yaml" ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../basic_networking_ping_tx.yaml"
+)
+
+add_dependencies(basic_networking_ping_python basic_networking_ping_rx_yaml_python)
+add_dependencies(basic_networking_ping_python basic_networking_ping_tx_yaml_python)

--- a/applications/basic_networking_ping/python/basic_networking_ping.py
+++ b/applications/basic_networking_ping/python/basic_networking_ping.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
 
 import logging
 import sys
+from pathlib import Path
 
 from holoscan.conditions import CountCondition
 from holoscan.core import Application, Operator, OperatorSpec
@@ -65,8 +66,8 @@ class App(Application):
     def compose(self):
         # Define the tx and rx operators, allowing the tx operator to execute 10 times
         if len(self.kwargs("network_tx")) > 0:
-            tx = BasicNetworkPingTxOp(self, CountCondition(self, NUM_MSGS), name="tx")
             basic_net_tx = BasicNetworkOpTx(self, name="basic_net_tx", **self.kwargs("network_tx"))
+            tx = BasicNetworkPingTxOp(self, CountCondition(self, NUM_MSGS), name="tx")
             self.add_flow(tx, basic_net_tx, {("msg_out", "burst_in")})
         else:
             logger.info("No TX config found")
@@ -88,6 +89,10 @@ if __name__ == "__main__":
         sys.exit(-1)
 
     config_path = sys.argv[1]
+    if not Path(config_path).is_file():
+        logger.error(f"Configuration file {config_path} not found")
+        sys.exit(-2)
+
     app = App()
     app.config(config_path)
     app.run()

--- a/applications/basic_networking_ping/python/metadata.json
+++ b/applications/basic_networking_ping/python/metadata.json
@@ -17,7 +17,9 @@
 		"holoscan_sdk": {
 			"minimum_required_version": "0.6.0",
 			"tested_versions": [
-				"0.6.0"
+				"0.6.0",
+				"2.1.0",
+				"2.2.0"
 			]
 		},
 		"ranking": 1,


### PR DESCRIPTION
Variables defined by `spec.param` are not ready in `initialize()` due to a change in HSDK 2.1.

This fix calls the original initialize logic when in `compute()` once if the connection is yet to be initialized.

Updates the README with instructions to run the receiver and the transmitter along with CMAKE to copy config files to the correct locations.