### PR TITLE
Remove arguments and use env var for data input

### DIFF
--- a/applications/endoscopy_tool_tracking_distributed/cpp/README.md
+++ b/applications/endoscopy_tool_tracking_distributed/cpp/README.md
@@ -24,5 +24,14 @@ If you want to manually convert the video data, please refer to the instructions
 Run the following command to start the application.  This will run the app with a pre-recorded video as input:
 
 ```sh
+# Start the application with all three fragments
 ./dev_container build_and_run endoscopy_tool_tracking_distributed --language cpp
+
+# Use the following commands to run the same application three processes:
+# Start the application with the video_in fragment
+./dev_container build_and_run endoscopy_tool_tracking_distributed --language cpp --run_args "--driver --worker --fragments video_in --address :10000"
+# Start the application with the inference fragment
+./dev_container build_and_run endoscopy_tool_tracking_distributed --language cpp --run_args "--worker --fragments inference --address :10000"
+# Start the application with the visualization fragment
+./dev_container build_and_run endoscopy_tool_tracking_distributed --language cpp --run_args "--worker --fragments viz --address :10000"
 ```

--- a/applications/endoscopy_tool_tracking_distributed/cpp/main.cpp
+++ b/applications/endoscopy_tool_tracking_distributed/cpp/main.cpp
@@ -151,27 +151,6 @@ class App : public holoscan::Application {
   std::string datapath_ = "data/endoscopy";
 };
 
-/** Helper function to parse the command line arguments */
-bool parse_arguments(int argc, char** argv, std::string& config_name, std::string& data_path) {
-  static struct option long_options[] = {{"data", required_argument, 0, 'd'}, {0, 0, 0, 0}};
-
-  while (int c = getopt_long(argc, argv, "d", long_options, NULL)) {
-    if (c == -1 || c == '?') break;
-
-    switch (c) {
-      case 'd':
-        data_path = optarg;
-        break;
-      default:
-        std::cout << "Unknown arguments returned: " << c << std::endl;
-        return false;
-    }
-  }
-
-  if (optind < argc) { config_name = argv[optind++]; }
-  return true;
-}
-
 /** Main function */
 int main(int argc, char** argv) {
   // Get the yaml configuration file

--- a/applications/endoscopy_tool_tracking_distributed/cpp/metadata.json
+++ b/applications/endoscopy_tool_tracking_distributed/cpp/metadata.json
@@ -32,7 +32,7 @@
 			]
 		},
 		"run": {
-			"command": "<holohub_app_bin>/endoscopy_tool_tracking_distributed --data <holohub_data_dir>/endoscopy",
+			"command": "HOLOSCAN_INPUT_PATH=<holohub_data_dir>/endoscopy <holohub_app_bin>/endoscopy_tool_tracking_distributed",
 			"workdir": "holohub_bin"
 		}
 	}

--- a/applications/endoscopy_tool_tracking_distributed/python/README.md
+++ b/applications/endoscopy_tool_tracking_distributed/python/README.md
@@ -22,10 +22,15 @@ If you want to manually convert the video data, please refer to the instructions
 
 ### Run Instructions
 
-### Run Instructions
-
-Run the following command to start the application.  This will run the app with a pre-recorded video as input:
-
 ```sh
+# Start the application with all three fragments
 ./dev_container build_and_run endoscopy_tool_tracking_distributed --language python
+
+# Use the following commands to run the same application three processes:
+# Start the application with the video_in fragment
+./dev_container build_and_run endoscopy_tool_tracking_distributed --language python --run_args "--driver --worker --fragments video_in --address :10000"
+# Start the application with the inference fragment
+./dev_container build_and_run endoscopy_tool_tracking_distributed --language python --run_args "--worker --fragments inference --address :10000"
+# Start the application with the visualization fragment
+./dev_container build_and_run endoscopy_tool_tracking_distributed --language python --run_args "--worker --fragments viz --address :10000"
 ```

--- a/applications/endoscopy_tool_tracking_distributed/python/endoscopy_tool_tracking.py
+++ b/applications/endoscopy_tool_tracking_distributed/python/endoscopy_tool_tracking.py
@@ -13,13 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
-from argparse import ArgumentParser
+import sys
 
 from cloud_inference_fragment import CloudInferenceFragment
 from holoscan.core import Application
 from video_input_fragment import VideoInputFragment
 from viz_fragment import VizFragment
+
+logger = logging.getLogger("endoscopy_tool_tracking_distributed")
 
 
 class EndoscopyApp(Application):
@@ -76,31 +79,13 @@ class EndoscopyApp(Application):
 
 
 if __name__ == "__main__":
-    # get the Application's arguments
-    app_argv = Application().argv
+    config_file = os.path.join(os.path.dirname(__file__), "endoscopy_tool_tracking.yaml")
+    data_path = os.environ.get("HOLOSCAN_INPUT_PATH", None)
 
-    # Parse args
-    parser = ArgumentParser(description="Endoscopy tool tracking demo application.")
+    if data_path is None:
+        logger.error("HOLOSCAN_INPUT_PATH is not set. Please set it to the path of the video data.")
+        sys.exit(-1)
 
-    parser.add_argument(
-        "-c",
-        "--config",
-        default="none",
-        help=("Set config path to override the default config file location"),
-    )
-    parser.add_argument(
-        "-d",
-        "--data",
-        default="none",
-        help=("Set the data path"),
-    )
-    args = parser.parse_args(app_argv[1:])
-
-    if args.config == "none":
-        config_file = os.path.join(os.path.dirname(__file__), "endoscopy_tool_tracking.yaml")
-    else:
-        config_file = args.config
-
-    app = EndoscopyApp(data=args.data)
+    app = EndoscopyApp(data_path)
     app.config(config_file)
     app.run()

--- a/applications/endoscopy_tool_tracking_distributed/python/endoscopy_tool_tracking.py
+++ b/applications/endoscopy_tool_tracking_distributed/python/endoscopy_tool_tracking.py
@@ -41,21 +41,27 @@ class EndoscopyApp(Application):
         self.input_path = data
 
     def compose(self):
+        width = 854
+        height = 480
+        # 4 bytes/channel, 3 channels
+        source_block_size = width * height * 3 * 4
+        source_num_blocks = 2
+        
         video_in_fragment = VideoInputFragment(self, "video_in", self.input_path)
         inference_fragment = CloudInferenceFragment(
             self,
             "inference",
             self.input_path,
-            video_in_fragment.width,
-            video_in_fragment.height,
-            video_in_fragment.source_block_size,
-            video_in_fragment.source_num_blocks,
+            width,
+            height,
+            source_block_size,
+            source_num_blocks,
         )
         viz_fragment = VizFragment(
             self,
             "viz",
-            video_in_fragment.width,
-            video_in_fragment.height,
+            width,
+            height,
         )
 
         # Flow definition

--- a/applications/endoscopy_tool_tracking_distributed/python/endoscopy_tool_tracking.py
+++ b/applications/endoscopy_tool_tracking_distributed/python/endoscopy_tool_tracking.py
@@ -46,7 +46,7 @@ class EndoscopyApp(Application):
         # 4 bytes/channel, 3 channels
         source_block_size = width * height * 3 * 4
         source_num_blocks = 2
-        
+
         video_in_fragment = VideoInputFragment(self, "video_in", self.input_path)
         inference_fragment = CloudInferenceFragment(
             self,

--- a/applications/endoscopy_tool_tracking_distributed/python/metadata.json
+++ b/applications/endoscopy_tool_tracking_distributed/python/metadata.json
@@ -38,7 +38,7 @@
 			]
 		},
 		"run": {
-			"command": "python3 <holohub_app_source>/endoscopy_tool_tracking.py --data <holohub_data_dir>/endoscopy",
+			"command": "HOLOSCAN_INPUT_PATH=<holohub_data_dir>/endoscopy python3 <holohub_app_source>/endoscopy_tool_tracking.py",
 			"workdir": "holohub_bin"
 		}
 	}

--- a/applications/endoscopy_tool_tracking_distributed/python/video_input_fragment.py
+++ b/applications/endoscopy_tool_tracking_distributed/python/video_input_fragment.py
@@ -20,41 +20,18 @@ from holoscan.operators import VideoStreamReplayerOp
 
 
 class VideoInputFragment(Fragment):
-    @property
-    def source_block_size(self):
-        print("Getting value")
-        return self._source_block_size
-
-    @property
-    def source_num_blocks(self):
-        return self._source_num_blocks
-
-    @property
-    def width(self):
-        return self._width
-
-    @property
-    def height(self):
-        return self._height
-
     def __init__(self, app, name, video_dir):
         super().__init__(app, name)
         self.video_dir = video_dir
 
-        self._width = 854
-        self._height = 480
-        video_dir = self.video_dir
-        if not os.path.exists(video_dir):
+        if not os.path.exists(self.video_dir):
             raise ValueError(f"Could not find video data: {video_dir=}")
-        self.input_op = VideoStreamReplayerOp(
-            self,
-            name="replayer",
-            directory=video_dir,
-            **self.kwargs("replayer"),
-        )
-        # 4 bytes/channel, 3 channels
-        self._source_block_size = self._width * self._height * 3 * 4
-        self._source_num_blocks = 2
 
     def compose(self):
-        self.add_operator(self.input_op)
+        input_op = VideoStreamReplayerOp(
+            self,
+            name="replayer",
+            directory=self.video_dir,
+            **self.kwargs("replayer"),
+        )
+        self.add_operator(input_op)


### PR DESCRIPTION
This PR fixes an issue where in distributed mode, passing arguments such as `--worker` will be taken by the argument handler.

- Remove handling of arguments and use `HOLOSCAN_INPUT_PATH` as data input
- Add instructions to run the application in distributed mode