### PR TITLE
App: Use Vulkan SDK packages in `volume_rendering_xr`

### DIFF
--- a/applications/volume_rendering_xr/Dockerfile
+++ b/applications/volume_rendering_xr/Dockerfile
@@ -28,36 +28,6 @@ COPY applications/volume_rendering_xr/thirdparty/magicleap/MagicLeapRemoteRender
 RUN /tmp/base-setup.sh
 
 ############################################################
-# Vulkan SDK
-#
-# Use the SDK because we need the newer Vulkan headers and the newer shader compiler than provided
-# by the Ubuntu deb packages. These are compile time dependencies, we still use the Vulkan loaded
-# and the Vulkan validation layer as runtime components provided by Ubuntu packages because that's
-# what the user will have on their installations.
-############################################################
-FROM base as vulkansdk-builder
-ARG VULKAN_SDK_VERSION
-
-WORKDIR /opt/vulkansdk
-ENV CMAKE_GENERATOR=Ninja
-
-# Note there is no aarch64 binary version to download, therefore for aarch64 we also download the x86_64 version which
-# includes the source. Then remove the binaries and build the aarch64 version from source.
-RUN wget -nv --show-progress --progress=bar:force:noscroll \
-    https://sdk.lunarg.com/sdk/download/${VULKAN_SDK_VERSION}/linux/vulkansdk-linux-x86_64-${VULKAN_SDK_VERSION}.tar.gz
-RUN tar -xzf vulkansdk-linux-x86_64-${VULKAN_SDK_VERSION}.tar.gz
-RUN if [ $(uname -m) = "aarch64" ]; then \
-    apt update \
-    && apt install --no-install-recommends -y python-is-python3 python3-distutils \
-    && rm -rf /var/lib/apt/lists/* \
-    && cd ${VULKAN_SDK_VERSION} \
-    && rm -rf x86_64 \
-    && MAKEFLAGS="-j $(nproc)" \
-    && unset CMAKE_GENERATOR \
-    && ./vulkansdk shaderc glslang headers; \
-    fi
-
-############################################################
 # OpenXR dev dependencies
 ############################################################
 FROM base as dev
@@ -77,22 +47,9 @@ RUN apt update \
         libxrandr-dev \
         libxxf86vm-dev \
         mesa-common-dev \
+        libvulkan-dev="1.3.204.1-*" \
+        glslang-tools="11.8.0+1.3.204.0-*" \
     && rm -rf /var/lib/apt/lists/*
-
-# Copy vulkan sdk
-# NOTE: It's all in x86_64 even if that's not the target platform
-# (Vulkan SDK cmake scripting issue)
-ARG VULKAN_SDK_VERSION
-ENV VULKAN_SDK=/opt/vulkansdk/${VULKAN_SDK_VERSION}
-COPY --from=vulkansdk-builder ${VULKAN_SDK}/x86_64/ ${VULKAN_SDK}
-
-# We need to use the headers and shader compiler of the SDK but want to link against the
-# Vulkan loader provided by the Ubuntu package. Therefore create a link in the SDK directory
-# pointing to the system Vulkan loader library.
-RUN rm -f ${VULKAN_SDK}/lib/libvulkan.so* \
-    && ln -s /lib/$(uname -m)-linux-gnu/libvulkan.so.1 ${VULKAN_SDK}/lib/libvulkan.so
-ENV PATH="${PATH}:${VULKAN_SDK}/bin"
-ENV CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:${VULKAN_SDK}"
 
 ############################################################
 # Windrunner configuration

--- a/applications/volume_rendering_xr/Dockerfile
+++ b/applications/volume_rendering_xr/Dockerfile
@@ -16,7 +16,6 @@
 # limitations under the License.
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG VULKAN_SDK_VERSION=1.3.216.0
 
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as base
@@ -48,7 +47,6 @@ RUN apt update \
         libxxf86vm-dev \
         mesa-common-dev \
         libvulkan-dev="1.3.204.1-*" \
-        glslang-tools="11.8.0+1.3.204.0-*" \
     && rm -rf /var/lib/apt/lists/*
 
 ############################################################


### PR DESCRIPTION
Updates the `volume_rendering_xr` application Dockerfile to fetch Vulkan SDK libraries as Debian packages.

Addresses an issue where the Vulkan SDK installer v1.3.216.0 is no longer available for download as of 2024.07.23. Instead we use Debian packages for the closest version (1.3.204.1).

The container build previously fetched and built Vulkan SDK libraries from source on arm64. This was a reflection of previous availability where  Vulkan SDK arm64 Jammy Debian packages were previously not available from apt.

Resolves https://github.com/nvidia-holoscan/holohub/issues/440.

Tested on x86_64 with the Windrunner XR simulator, will validate on IGX as well before merge.