### PR TITLE
Fix Distributed Endoscopy Tool Tracking Test Failures

### DIFF
--- a/applications/endoscopy_tool_tracking_distributed/Dockerfile
+++ b/applications/endoscopy_tool_tracking_distributed/Dockerfile
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1
+
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+############################################################
+# Base image
+############################################################
+
+ARG BASE_IMAGE
+ARG GPU_TYPE
+
+FROM ${BASE_IMAGE} AS base
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Holohub Environment Variables
+ENV HOLOSCAN_INPUT_PATH=/workspace/holohub/data/endoscopy
+
+# --------------------------------------------------------------------------
+#
+# Holohub run setup
+#
+
+RUN mkdir -p /tmp/scripts
+COPY run /tmp/scripts/
+RUN mkdir -p /tmp/scripts/utilities
+COPY utilities/holohub_autocomplete /tmp/scripts/utilities/
+RUN chmod +x /tmp/scripts/run
+RUN /tmp/scripts/run setup
+
+# Enable autocomplete
+RUN echo ". /etc/bash_completion.d/holohub_autocomplete" >> /etc/bash.bashrc
+
+# - This variable is consumed by all dependencies below as an environment variable (CMake 3.22+)
+# - We use ARG to only set it at docker build time, so it does not affect cmake builds
+#   performed at docker run time in case users want to use a different BUILD_TYPE
+ARG CMAKE_BUILD_TYPE=Release
+
+
+# For benchmarking
+RUN apt update \
+    && apt install --no-install-recommends -y \
+    libcairo2-dev \
+    libgirepository1.0-dev \
+    gobject-introspection \
+    libgtk-3-dev \
+    libcanberra-gtk-module \
+    graphviz
+RUN if ! grep -q "VERSION_ID=\"22.04\"" /etc/os-release; then \
+        pip install setuptools; \
+    fi
+COPY benchmarks/holoscan_flow_benchmarking/requirements.txt /tmp/benchmarking_requirements.txt
+RUN pip install -r /tmp/benchmarking_requirements.txt

--- a/applications/endoscopy_tool_tracking_distributed/cpp/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking_distributed/cpp/CMakeLists.txt
@@ -58,43 +58,29 @@ add_dependencies(endoscopy_tool_tracking_distributed endoscopy_tool_tracking_dis
 # Add testing
 if(BUILD_TESTING)
 
-  set(RECORDING_DIR ${CMAKE_CURRENT_BINARY_DIR}/recording_output)
-  set(SOURCE_VIDEO_BASENAME cpp_endoscopy_tool_tracking_output)
-  set(VALIDATION_FRAMES_DIR ${CMAKE_SOURCE_DIR}/applications/endoscopy_tool_tracking_distributed/testing/)
-
-  file(MAKE_DIRECTORY ${RECORDING_DIR})
-
   # Configure the yaml file for testing
   file(READ "${CMAKE_CURRENT_SOURCE_DIR}/endoscopy_tool_tracking.yaml" CONFIG_FILE)
   string(REPLACE "count: 0" "count: 10" CONFIG_FILE ${CONFIG_FILE})
-  string(REPLACE "record_type: \"none\"" "record_type: \"visualizer\"" CONFIG_FILE ${CONFIG_FILE})
-  string(REPLACE "directory: \"/tmp\"" "directory: \"${RECORDING_DIR}\"" CONFIG_FILE ${CONFIG_FILE})
-  string(REPLACE "basename: \"tensor\"" "basename: \"${SOURCE_VIDEO_BASENAME}\"" CONFIG_FILE ${CONFIG_FILE})
 
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/endoscopy_tool_tracking_testing.yaml" ${CONFIG_FILE})
 
   # Add test
-  add_test(NAME endoscopy_tool_tracking_distributed_cpp_test
-           COMMAND endoscopy_tool_tracking_distributed ${CMAKE_CURRENT_BINARY_DIR}/endoscopy_tool_tracking_testing.yaml
-                   --data "${HOLOHUB_DATA_DIR}/endoscopy"
+  add_test(NAME endoscopy_tool_tracking_distributed_cpp_test_args
+           COMMAND endoscopy_tool_tracking_distributed --data "${HOLOHUB_DATA_DIR}/endoscopy" --config "${CMAKE_CURRENT_BINARY_DIR}/endoscopy_tool_tracking_testing.yaml"
            WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-  set_tests_properties(endoscopy_tool_tracking_distributed_cpp_test PROPERTIES
+
+  set_tests_properties(endoscopy_tool_tracking_distributed_cpp_test_args PROPERTIES
                        PASS_REGULAR_EXPRESSION "Reach end of file or playback count reaches to the limit. Stop ticking."
                        FAIL_REGULAR_EXPRESSION "[^a-z]Error;ERROR;Failed")
 
-  # Add a test to check the validity of the frames
-  add_test(NAME endoscopy_tool_tracking_distributed_cpp_render_test
-      COMMAND python3 ${CMAKE_SOURCE_DIR}/utilities/video_validation.py
-      --source_video_dir ${RECORDING_DIR}
-      --source_video_basename ${SOURCE_VIDEO_BASENAME}
-      --output_dir ${RECORDING_DIR}
-      --validation_frames_dir ${VALIDATION_FRAMES_DIR}
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  )
+  add_test(NAME endoscopy_tool_tracking_distributed_cpp_test_env_var
+            COMMAND endoscopy_tool_tracking_distributed
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
-  set_tests_properties(endoscopy_tool_tracking_distributed_cpp_render_test PROPERTIES
-  DEPENDS endoscopy_tool_tracking_distributed_cpp_test
-  PASS_REGULAR_EXPRESSION "Valid video output!"
-  )
+  set_tests_properties(endoscopy_tool_tracking_distributed_cpp_test_env_var PROPERTIES
+    ENVIRONMENT "HOLOSCAN_INPUT_PATH=${HOLOHUB_DATA_DIR}/endoscopy;HOLOSCAN_CONFIG_PATH=${CMAKE_CURRENT_BINARY_DIR}/endoscopy_tool_tracking_testing.yaml")
 
+  set_tests_properties(endoscopy_tool_tracking_distributed_cpp_test_env_var PROPERTIES
+                        PASS_REGULAR_EXPRESSION "Reach end of file or playback count reaches to the limit. Stop ticking."
+                        FAIL_REGULAR_EXPRESSION "[^a-z]Error;ERROR;Failed")
 endif()

--- a/applications/endoscopy_tool_tracking_distributed/cpp/metadata.json
+++ b/applications/endoscopy_tool_tracking_distributed/cpp/metadata.json
@@ -32,7 +32,7 @@
 			]
 		},
 		"run": {
-			"command": "HOLOSCAN_INPUT_PATH=<holohub_data_dir>/endoscopy <holohub_app_bin>/endoscopy_tool_tracking_distributed",
+			"command": "<holohub_app_bin>/endoscopy_tool_tracking_distributed",
 			"workdir": "holohub_bin"
 		}
 	}

--- a/applications/endoscopy_tool_tracking_distributed/python/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking_distributed/python/CMakeLists.txt
@@ -41,7 +41,7 @@ if(BUILD_TESTING)
           WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
   set_tests_properties(endoscopy_tool_tracking_distributed_python_test_env_vars PROPERTIES
-                       ENVIRONMENT "HOLOSCAN_CONFIG_PATH=${CMAKE_CURRENT_BINARY_DIR}/endoscopy_tool_tracking_testing.yaml;PYTHONPATH=${GXF_LIB_DIR}/../python/lib:${CMAKE_BINARY_DIR}/python/lib")
+                       ENVIRONMENT "HOLOSCAN_INPUT_PATH=${HOLOHUB_DATA_DIR}/endoscopy;HOLOSCAN_CONFIG_PATH=${CMAKE_CURRENT_BINARY_DIR}/endoscopy_tool_tracking_testing.yaml;PYTHONPATH=${GXF_LIB_DIR}/../python/lib:${CMAKE_BINARY_DIR}/python/lib")
 
   set_tests_properties(endoscopy_tool_tracking_distributed_python_test_env_vars PROPERTIES
                        PASS_REGULAR_EXPRESSION "Reach end of file or playback count reaches to the limit. Stop ticking.;"

--- a/applications/endoscopy_tool_tracking_distributed/python/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking_distributed/python/CMakeLists.txt
@@ -18,48 +18,33 @@ if(BUILD_TESTING)
   # To get the environment path
   find_package(holoscan 2.1 REQUIRED CONFIG PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
-  set(RECORDING_DIR ${CMAKE_CURRENT_BINARY_DIR}/recording_output)
-  set(SOURCE_VIDEO_BASENAME python_endoscopy_tool_tracking_output)
-  set(VALIDATION_FRAMES_DIR ${CMAKE_SOURCE_DIR}/applications/endoscopy_tool_tracking/testing/)
-
-  file(MAKE_DIRECTORY ${RECORDING_DIR})
-
   # Configure the yaml file for testing
   file(READ "${CMAKE_CURRENT_SOURCE_DIR}/endoscopy_tool_tracking.yaml" CONFIG_FILE)
   string(REPLACE "count: 0" "count: 10" CONFIG_FILE ${CONFIG_FILE})
-  string(REPLACE "directory: \"/tmp\"" "directory: \"${RECORDING_DIR}\"" CONFIG_FILE ${CONFIG_FILE})
-  string(REPLACE "basename: \"tensor\"" "basename: \"${SOURCE_VIDEO_BASENAME}\"" CONFIG_FILE ${CONFIG_FILE})
 
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/endoscopy_tool_tracking_testing.yaml" ${CONFIG_FILE})
 
   # Add test
-  add_test(NAME endoscopy_tool_tracking_distributed_python_test
-           COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/endoscopy_tool_tracking.py
-                   --config ${CMAKE_CURRENT_BINARY_DIR}/endoscopy_tool_tracking_testing.yaml
-                   --data ${HOLOHUB_DATA_DIR}/endoscopy
-                   --record_type visualizer
+  add_test(NAME endoscopy_tool_tracking_distributed_python_test_args
+           COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/endoscopy_tool_tracking.py --data "${HOLOHUB_DATA_DIR}/endoscopy" --config "${CMAKE_CURRENT_BINARY_DIR}/endoscopy_tool_tracking_testing.yaml"
            WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
-  set_property(TEST endoscopy_tool_tracking_distributed_python_test PROPERTY ENVIRONMENT
-               "PYTHONPATH=${GXF_LIB_DIR}/../python/lib:${CMAKE_BINARY_DIR}/python/lib")
+  set_tests_properties(endoscopy_tool_tracking_distributed_python_test_args PROPERTIES
+                       ENVIRONMENT "PYTHONPATH=${GXF_LIB_DIR}/../python/lib:${CMAKE_BINARY_DIR}/python/lib")
 
-  set_tests_properties(endoscopy_tool_tracking_distributed_python_test PROPERTIES
-                PASS_REGULAR_EXPRESSION "Reach end of file or playback count reaches to the limit. Stop ticking.;"
-                FAIL_REGULAR_EXPRESSION "[^a-z]Error;ERROR;Failed")
+  set_tests_properties(endoscopy_tool_tracking_distributed_python_test_args PROPERTIES
+                       PASS_REGULAR_EXPRESSION "Reach end of file or playback count reaches to the limit. Stop ticking.;"
+                       FAIL_REGULAR_EXPRESSION "[^a-z]Error;ERROR;Failed")
 
-  # Add a test to check the validity of the frames
-  add_test(NAME endoscopy_tool_tracking_distributed_python_render_test
-    COMMAND python3 ${CMAKE_SOURCE_DIR}/utilities/video_validation.py
-    --source_video_dir ${RECORDING_DIR}
-    --source_video_basename ${SOURCE_VIDEO_BASENAME}
-    --output_dir ${RECORDING_DIR}
-    --validation_frames_dir ${VALIDATION_FRAMES_DIR}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  )
+  add_test(NAME endoscopy_tool_tracking_distributed_python_test_env_vars
+          COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/endoscopy_tool_tracking.py --data "${HOLOHUB_DATA_DIR}/endoscopy" --config "${CMAKE_CURRENT_BINARY_DIR}/endoscopy_tool_tracking_testing.yaml"
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
-  set_tests_properties(endoscopy_tool_tracking_distributed_python_render_test PROPERTIES
-    DEPENDS endoscopy_tool_tracking_distributed_python_test
-    PASS_REGULAR_EXPRESSION "Valid video output!"
-  )
+  set_tests_properties(endoscopy_tool_tracking_distributed_python_test_env_vars PROPERTIES
+                       ENVIRONMENT "HOLOSCAN_CONFIG_PATH=${CMAKE_CURRENT_BINARY_DIR}/endoscopy_tool_tracking_testing.yaml;PYTHONPATH=${GXF_LIB_DIR}/../python/lib:${CMAKE_BINARY_DIR}/python/lib")
+
+  set_tests_properties(endoscopy_tool_tracking_distributed_python_test_env_vars PROPERTIES
+                       PASS_REGULAR_EXPRESSION "Reach end of file or playback count reaches to the limit. Stop ticking.;"
+                       FAIL_REGULAR_EXPRESSION "[^a-z]Error;ERROR;Failed")
 
 endif()

--- a/applications/endoscopy_tool_tracking_distributed/python/endoscopy_tool_tracking.py
+++ b/applications/endoscopy_tool_tracking_distributed/python/endoscopy_tool_tracking.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import logging
 import os
 import sys
@@ -84,14 +85,41 @@ class EndoscopyApp(Application):
         )
 
 
-if __name__ == "__main__":
-    config_file = os.path.join(os.path.dirname(__file__), "endoscopy_tool_tracking.yaml")
-    data_path = os.environ.get("HOLOSCAN_INPUT_PATH", None)
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Distributed Endoscopy Tool Tracking Application")
+    parser.add_argument(
+        "--data",
+        type=str,
+        required=False,
+        default=os.environ.get("HOLOSCAN_INPUT_PATH", None),
+        help="Input dataset.",
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        required=False,
+        default=os.environ.get(
+            "HOLOSCAN_CONFIG_PATH",
+            os.path.join(os.path.dirname(__file__), "endoscopy_tool_tracking.yaml"),
+        ),
+        help="Input dataset.",
+    )
 
-    if data_path is None:
-        logger.error("HOLOSCAN_INPUT_PATH is not set. Please set it to the path of the video data.")
+    args, _ = parser.parse_known_args()
+
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    print(f"==========================> data={args.data}")
+    if args.data is None:
+        logger.error(
+            "Input data not provided. Use --data or set HOLOSCAN_INPUT_PATH environment variable."
+        )
         sys.exit(-1)
 
-    app = EndoscopyApp(data_path)
-    app.config(config_file)
+    app = EndoscopyApp(args.data)
+    app.config(args.config)
     app.run()

--- a/applications/endoscopy_tool_tracking_distributed/python/metadata.json
+++ b/applications/endoscopy_tool_tracking_distributed/python/metadata.json
@@ -38,7 +38,7 @@
 			]
 		},
 		"run": {
-			"command": "HOLOSCAN_INPUT_PATH=<holohub_data_dir>/endoscopy python3 <holohub_app_source>/endoscopy_tool_tracking.py",
+			"command": "python3 <holohub_app_source>/endoscopy_tool_tracking.py --data <holohub_data_dir>/endoscopy",
 			"workdir": "holohub_bin"
 		}
 	}


### PR DESCRIPTION
This PR implements two options to provide input data and config file and fixes the test failures:

- Allows users to provide input data and config file via 
  - arguments: `--data` and `--config`, or
  - environment variables: `HOLOSCAN_INPUT_PATH` and `HOLOSCAN_CONFIG_PATH` (as prescribed by [HAP specifications](https://docs.nvidia.com/holoscan/sdk-user-guide/cli/hap.html))
  - fix test cases and add additional ones to cover both use cases
  - remove existing frame validation coverage since this app does not support recording