### PR TITLE
Update RTI Connext version to 7.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,3 +69,9 @@ RUN if ! grep -q "VERSION_ID=\"22.04\"" /etc/os-release; then \
     fi
 COPY benchmarks/holoscan_flow_benchmarking/requirements.txt /tmp/benchmarking_requirements.txt
 RUN pip install -r /tmp/benchmarking_requirements.txt
+
+# For RTI Connext DDS
+RUN apt update \
+    && apt install --no-install-recommends -y \
+        openjdk-21-jre
+RUN echo 'export JREHOME=$(readlink /etc/alternatives/java | sed -e "s/\/bin\/java//")' >> /etc/bash.bashrc

--- a/applications/body_pose_estimation/README.md
+++ b/applications/body_pose_estimation/README.md
@@ -114,10 +114,10 @@ the output published by this application:
 Installing RTI Connext into the development container is not currently
 supported, so enabling DDS support with this application requires RTI Connext
 be installed onto the host and then mounted into the container at runtime.
-To mount RTI Connext into the container, ensure that the `NDDSHOME` environment
-variable is set to the path of the RTI Connext installation on the host and
-then use the following:
+To mount RTI Connext into the container, ensure that the `NDDSHOME` and
+`CONNEXTDDS_ARCH` environment variables are set (which can be done using the RTI
+`setenv` script) then use the following:
 
 ```sh
-./dev_container launch --img holohub:bpe --docker_opts "-v $NDDSHOME:/opt/dds -e NDDSHOME=/opt/dds"
+./dev_container launch --img holohub:bpe --docker_opts "-v $NDDSHOME:/opt/dds -e NDDSHOME=/opt/dds -e CONNEXTDDS_ARCH=$CONNEXTDDS_ARCH"
 ```

--- a/applications/dds_video/README.md
+++ b/applications/dds_video/README.md
@@ -35,7 +35,7 @@ the `NDDSHOME` environment variable to the RTI Connext installation directory
 (such as when using the RTI `setenv` scripts), or manually at build time, e.g.:
 
 ```sh
-$ ./run build dds_video --configure-args -DRTI_CONNEXT_DDS_DIR=~/rti/rti_connext_dds-6.1.2
+$ ./run build dds_video --configure-args -DRTI_CONNEXT_DDS_DIR=~/rti/rti_connext_dds-7.3.0
 ```
 
 ### Building with a Container
@@ -44,10 +44,11 @@ Due to the license requirements of RTI Connext it is not currently supported to
 install RTI Connext into a development container. Instead, Connext should be
 installed onto the host as above and then the development container can be
 launched with the RTI Connext folder mounted at runtime. To do so, ensure that
-the `NDDSHOME` environment variable is set and use the following:
+the `NDDSHOME` and `CONNEXTDDS_ARCH` environment variables are set (which can be
+done using the RTI `setenv` script) and use the following:
 
 ```sh
-./dev_container launch --docker_opts "-v $NDDSHOME:/opt/dds -e NDDSHOME=/opt/dds"
+./dev_container launch --docker_opts "-v $NDDSHOME:/opt/dds -e NDDSHOME=/opt/dds -e CONNEXTDDS_ARCH=$CONNEXTDDS_ARCH"
 ```
 
 ## Running the Application
@@ -89,8 +90,8 @@ For more details, see the [RTI Connext Guide to Improve DDS Network Performance 
 
 The QoS profiles used by the application can also be modified by editing the
 `qos_profiles.xml` file in the application directory. For more information about modifying
-the QoS profiles, see the [RTI Connext Basic QoS](https://community.rti.com/static/documentation/connext-dds/6.1.2/doc/manuals/connext_dds_professional/getting_started_guide/cpp11/intro_qos.html)
-tutorial or the [RTI Connext QoS Reference Guide](https://community.rti.com/static/documentation/connext-dds/6.1.2/doc/manuals/connext_dds_professional/qos_reference/index.htm).
+the QoS profiles, see the [RTI Connext Basic QoS](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/getting_started_guide/cpp11/intro_qos.html)
+tutorial or the [RTI Connext QoS Reference Guide](https://community.rti.com/static/documentation/connext-dds/7.3.0/doc/manuals/connext_dds_professional/qos_reference/index.htm).
 
 ### Publishing Shapes from the RTI Shapes Demo
 

--- a/applications/dds_video/metadata.json
+++ b/applications/dds_video/metadata.json
@@ -27,7 +27,7 @@
 					"name": "RTI Connext",
 					"author": "Real-Time Innovations",
 					"license": "Closed",
-					"version": "6.1.2",
+					"version": "7.3.0",
 					"url": "https://www.rti.com/products"
 				}
 			]

--- a/operators/dds/README.md
+++ b/operators/dds/README.md
@@ -22,7 +22,7 @@ the `NDDSHOME` environment variable to the RTI Connext installation directory
 (such as when using the RTI `setenv` scripts), or manually at build time, e.g.:
 
 ```sh
-$ ./run build dds_video --configure-args -DRTI_CONNEXT_DDS_DIR=~/rti/rti_connext_dds-6.1.2
+$ ./run build dds_video --configure-args -DRTI_CONNEXT_DDS_DIR=~/rti/rti_connext_dds-7.3.0
 ```
 
 ##### Using a Development Container
@@ -31,9 +31,10 @@ Due to the license requirements of RTI Connext it is not currently supported to
 install RTI Connext into a development container. Instead, if a development
 container is to be used, Connext should be installed onto the host as above and
 then the container can be launched with the RTI Connext folder mounted at
-runtime. To do so, ensure that the `NDDSHOME` environment variable is set and
-use the following:
+runtime. To do so, ensure that the `NDDSHOME` and `CONNEXTDDS_ARCH` environment
+variables are set (which can be done using the RTI `setenv` script) and use the
+following:
 
 ```sh
-./dev_container launch --docker_opts "-v $NDDSHOME:/opt/dds -e NDDSHOME=/opt/dds"
+./dev_container launch --docker_opts "-v $NDDSHOME:/opt/dds -e NDDSHOME=/opt/dds -e CONNEXTDDS_ARCH=$CONNEXTDDS_ARCH"
 ```

--- a/operators/dds/base/metadata.json
+++ b/operators/dds/base/metadata.json
@@ -27,7 +27,7 @@
 					"name": "RTI Connext",
 					"author": "Real-Time Innovations",
 					"license": "Closed",
-					"version": "6.1.2",
+					"version": "7.3.0",
 					"url": "https://www.rti.com/products"
 				}
 			]

--- a/operators/dds/dds_shapes_subscriber/metadata.json
+++ b/operators/dds/dds_shapes_subscriber/metadata.json
@@ -27,7 +27,7 @@
 					"name": "RTI Connext",
 					"author": "Real-Time Innovations",
 					"license": "Closed",
-					"version": "6.1.2",
+					"version": "7.3.0",
 					"url": "https://www.rti.com/products"
 				}
 			]

--- a/operators/dds/video/dds_video_publisher/metadata.json
+++ b/operators/dds/video/dds_video_publisher/metadata.json
@@ -27,7 +27,7 @@
 					"name": "RTI Connext",
 					"author": "Real-Time Innovations",
 					"license": "Closed",
-					"version": "6.1.2",
+					"version": "7.3.0",
 					"url": "https://www.rti.com/products"
 				}
 			]

--- a/operators/dds/video/dds_video_subscriber/metadata.json
+++ b/operators/dds/video/dds_video_subscriber/metadata.json
@@ -27,7 +27,7 @@
 					"name": "RTI Connext",
 					"author": "Real-Time Innovations",
 					"license": "Closed",
-					"version": "6.1.2",
+					"version": "7.3.0",
 					"url": "https://www.rti.com/products"
 				}
 			]


### PR DESCRIPTION
 - Updates documentation and metadata to point to the latest RTI Connext 7.3.0 LTS release.
 - Adds CONNEXTDDS_ARCH environment variable to build container launch command.
 - Installs Java (and sets JREHOME environment variable) in the dev container, which is required by the RTI build time code generation tools.