### PR TITLE
Bump base container for Holoscan SDK v2.3.0

### DIFF
--- a/dev_container
+++ b/dev_container
@@ -465,11 +465,11 @@ get_host_gpu() {
 }
 
 get_default_base_img() {
-    echo -n "nvcr.io/nvidia/clara-holoscan/holoscan:v2.2.0-"$(get_host_gpu)
+    echo -n "nvcr.io/nvidia/clara-holoscan/holoscan:v2.3.0-"$(get_host_gpu)
 }
 
 get_default_img() {
-    echo -n "holohub:ngc-v2.2.0-"$(get_host_gpu)
+    echo -n "holohub:ngc-v2.3.0-"$(get_host_gpu)
 }
 
 # This function returns the compute capacity of the system's GPU (8.6, 8.9, etc.)


### PR DESCRIPTION
Bumps the HoloHub container to build on the Holoscan SDK v2.3.0 public NGC development container following v2.3.0 availability.