### PR TITLE
Enable packaging of the applications using Holoscan CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 build-*/
+install/
 data/
 ci/
 CTestConfig.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/deps)
 include(HoloHubConfigHelpers)
 
 # Set install directory
-set(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/install")
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set_property(CACHE CMAKE_INSTALL_PREFIX PROPERTY VALUE "${CMAKE_SOURCE_DIR}/install")
+endif()
 
 # Enable Testing
 include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/deps)
 # To configure which apps/operators to build
 include(HoloHubConfigHelpers)
 
+# Set install directory
+set(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/install")
+
 # Enable Testing
 include(CTest)
 

--- a/applications/endoscopy_tool_tracking/README.md
+++ b/applications/endoscopy_tool_tracking/README.md
@@ -109,3 +109,7 @@ There are a two launch profiles configured for this application:
 
 1. **(debugpy) endoscopy_tool_tracking/python**: This launch profile enables debugging of Python code.
 2. **(pythoncpp) endoscopy_tool_tracking/python**: This launch profile enables debugging of Python and C++ code.
+
+## Containerize the application
+
+To containerize the application, first build the application, run the `package-app.sh` script in the [cpp](./cpp/package-app.sh) or the [python](./python/package-app.sh) directory and then follow the generated output to package and run the application.

--- a/applications/endoscopy_tool_tracking/README.md
+++ b/applications/endoscopy_tool_tracking/README.md
@@ -112,4 +112,6 @@ There are a two launch profiles configured for this application:
 
 ## Containerize the application
 
-To containerize the application, first build the application, run the `package-app.sh` script in the [cpp](./cpp/package-app.sh) or the [python](./python/package-app.sh) directory and then follow the generated output to package and run the application.
+To containerize the application using [Holoscan CLI](https://docs.nvidia.com/holoscan/sdk-user-guide/cli/cli.html), first build the application, run the `package-app.sh` script in the [cpp](./cpp/package-app.sh) or the [python](./python/package-app.sh) directory and then follow the generated output to package and run the application.
+
+Refer to the [Packaging Holoscan Applications](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_packager.html) section of the [Holoscan User Guide](https://docs.nvidia.com/holoscan/sdk-user-guide/) to learn more about installing the Holoscan CLI or packaging your application using Holoscan CLI.

--- a/applications/endoscopy_tool_tracking/cpp/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/cpp/CMakeLists.txt
@@ -159,20 +159,25 @@ install(
   COMPONENT "holohub-apps"
 )
 
-file(READ "${endoscopy_tool_tracking_BINARY_DIR}/endoscopy_tool_tracking.yaml" APP_YAML_FILE)
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/endoscopy_tool_tracking.yaml" APP_YAML_FILE)
 string(REPLACE "gxf_extensions/lstm_tensor_rt_inference/" "" APP_YAML_FILE "${APP_YAML_FILE}")
-file(WRITE "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_cpp/endoscopy_tool_tracking.yaml" "${APP_YAML_FILE}")
+file(WRITE "${CMAKE_BINARY_DIR}/packaging/cpp/endoscopy_tool_tracking.yaml" "${APP_YAML_FILE}")
+
+install(
+  FILES ${CMAKE_BINARY_DIR}/packaging/cpp/endoscopy_tool_tracking.yaml
+  DESTINATION endoscopy_tool_tracking_cpp
+  COMPONENT "holohub-apps"
+)
 
 install(
   DIRECTORY ${gxf_lstm_tensor_rt_inference_BINARY_DIR}/
-  DESTINATION "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_cpp"
+  DESTINATION endoscopy_tool_tracking_cpp
   FILES_MATCHING PATTERN "*.so"
   PATTERN "CMakeFiles" EXCLUDE)
 
 install(
   FILES
-    ${lstm_tensor_rt_inference_BINARY_DIR}/liblstm_tensor_rt_inference.so
-    ${tool_tracking_postprocessor_BINARY_DIR}/libtool_tracking_postprocessor.so
-  DESTINATION "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_cpp"
-  COMPONENT "holohub-apps"
-)
+  ${lstm_tensor_rt_inference_BINARY_DIR}/liblstm_tensor_rt_inference.so
+  ${tool_tracking_postprocessor_BINARY_DIR}/libtool_tracking_postprocessor.so
+  DESTINATION endoscopy_tool_tracking_cpp
+  COMPONENT "holohub-apps")

--- a/applications/endoscopy_tool_tracking/cpp/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/cpp/CMakeLists.txt
@@ -151,3 +151,28 @@ if(FLOW_BENCHMARKING)
   # Set test timeout to 25 minutes
   set_tests_properties(endoscopy_tool_tracking_cpp_benchmark_test PROPERTIES TIMEOUT 1500)
 endif()
+
+# Install application and dependencies into the install/ directory for packaging
+install(
+  TARGETS endoscopy_tool_tracking
+  DESTINATION "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_cpp"
+  COMPONENT "holohub-apps"
+)
+
+file(READ "${endoscopy_tool_tracking_BINARY_DIR}/endoscopy_tool_tracking.yaml" APP_YAML_FILE)
+string(REPLACE "gxf_extensions/lstm_tensor_rt_inference/" "" APP_YAML_FILE "${APP_YAML_FILE}")
+file(WRITE "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_cpp/endoscopy_tool_tracking.yaml" "${APP_YAML_FILE}")
+
+install(
+  DIRECTORY ${gxf_lstm_tensor_rt_inference_BINARY_DIR}/
+  DESTINATION "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_cpp"
+  FILES_MATCHING PATTERN "*.so"
+  PATTERN "CMakeFiles" EXCLUDE)
+
+install(
+  FILES
+    ${lstm_tensor_rt_inference_BINARY_DIR}/liblstm_tensor_rt_inference.so
+    ${tool_tracking_postprocessor_BINARY_DIR}/libtool_tracking_postprocessor.so
+  DESTINATION "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_cpp"
+  COMPONENT "holohub-apps"
+)

--- a/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
+++ b/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+# Required fields for packaging the application
+# See https://docs.nvidia.com/holoscan/sdk-user-guide/cli/run_config.html#
 application:
   title: Holohub - Endoscopy Tool Tracking
   version: 1.0

--- a/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
+++ b/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
@@ -14,6 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+application:
+  title: Holohub - Endoscopy Tool Tracking
+  version: 1.0
+  inputFormats: []
+  outputFormats: ["screen"]
+
+resources:
+  cpu: 2
+  gpu: 1
+  memory: 1Gi
+  gpuMemory: 1Gi
+
 extensions:
   - gxf_extensions/lstm_tensor_rt_inference/libgxf_lstm_tensor_rt_inference.so
 # Uncomment the following extension when using deltacast as a source

--- a/applications/endoscopy_tool_tracking/cpp/package-app.sh
+++ b/applications/endoscopy_tool_tracking/cpp/package-app.sh
@@ -16,50 +16,15 @@
 set -e
 
 GIT_ROOT=$(readlink -f ./$(git rev-parse --show-cdup))
+APP_PATH="$GIT_ROOT/install/endoscopy_tool_tracking_cpp"
 
-# Utilities
+. $GIT_ROOT/utilities/bash_utils.sh
 
-YELLOW="\e[1;33m"
-RED="\e[1;31m"
-NOCOLOR="\e[0m"
-
-print_error() {
-    echo -e "${RED}ERROR${NOCOLOR}:" $*
-}
-
-get_host_gpu() {
-    if ! command -v nvidia-smi >/dev/null; then
-        print_error Y "Could not find any GPU drivers on host. Defaulting build to target dGPU/CPU stack."
-        echo -n "dgpu"
-    elif nvidia-smi  2>/dev/null | grep nvgpu -q; then
-        echo -n "igpu"
-    else
-        echo -n "dgpu"
-    fi
-}
-
-get_host_arch() {
-    echo -n "$(uname -m)"
-}
-
-if [ ! -d $GIT_ROOT/build/endoscopy_tool_tracking ]; then
+if [ ! -d $APP_PATH ]; then
     print_error "Please build the Endoscopy Tool Tracking application first with the following command:"
     print_error "./dev_container build_and_run endoscopy_tool_tracking"
     exit -1
 fi
-
-APP_PATH="$GIT_ROOT/endoscopy_tool_tracking_cpp"
-echo Creating application directory $APP_PATH...
-mkdir -p $APP_PATH
-echo Copying application files to $APP_PATH...
-cp -f $GIT_ROOT/build/endoscopy_tool_tracking/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking $APP_PATH
-cp -f $GIT_ROOT/build/endoscopy_tool_tracking/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml $APP_PATH
-cp -f $GIT_ROOT/build/endoscopy_tool_tracking/gxf_extensions/lstm_tensor_rt_inference/*.so $APP_PATH
-cp -f $GIT_ROOT/build/endoscopy_tool_tracking/operators/lstm_tensor_rt_inference/liblstm_tensor_rt_inference.so $APP_PATH
-cp -f $GIT_ROOT/build/endoscopy_tool_tracking/operators/tool_tracking_postprocessor/libtool_tracking_postprocessor.so $APP_PATH
-
-echo Updating application configuration...
-sed -e s!gxf_extensions/lstm_tensor_rt_inference/!!g -i $APP_PATH/endoscopy_tool_tracking.yaml
 
 PLATFORM=x64-workstation
 GPU=$(get_host_gpu)

--- a/applications/endoscopy_tool_tracking/cpp/package-app.sh
+++ b/applications/endoscopy_tool_tracking/cpp/package-app.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GIT_ROOT=$(readlink -f ./$(git rev-parse --show-cdup))
+
+# Utilities
+
+YELLOW="\e[1;33m"
+RED="\e[1;31m"
+NOCOLOR="\e[0m"
+
+print_error() {
+    echo -e "${RED}ERROR${NOCOLOR}:" $*
+}
+
+if [ ! -d $GIT_ROOT/build/endoscopy_tool_tracking ]; then
+    print_error "Please build the Endoscopy Tool Tracking application first with the following command:"
+    print_error "./dev_container build_and_run endoscopy_tool_tracking"
+    exit -1
+fi
+
+APP_PATH="$GIT_ROOT/endoscopy_tool_tracking_cpp"
+echo Creating application directory $APP_PATH...
+mkdir -p $APP_PATH
+echo Copying application files to $APP_PATH...
+cp -f $GIT_ROOT/build/endoscopy_tool_tracking/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking $APP_PATH
+cp -f $GIT_ROOT/build/endoscopy_tool_tracking/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml $APP_PATH
+cp -f $GIT_ROOT/build/endoscopy_tool_tracking/gxf_extensions/lstm_tensor_rt_inference/*.so $APP_PATH
+cp -f $GIT_ROOT/build/endoscopy_tool_tracking/operators/lstm_tensor_rt_inference/liblstm_tensor_rt_inference.so $APP_PATH
+cp -f $GIT_ROOT/build/endoscopy_tool_tracking/operators/tool_tracking_postprocessor/libtool_tracking_postprocessor.so $APP_PATH
+
+echo Updating application configuration...
+sed -e s!gxf_extensions/lstm_tensor_rt_inference/!!g -i $APP_PATH/endoscopy_tool_tracking.yaml
+
+
+echo -e "done\n"
+echo -e Use the following commands to package and run the Endoscopy Tool Tracking application:\n
+echo -e "Package the application:\n"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform x64-workstation -t holohub-endoscopy-tool-tracking-cpp $APP_PATH/endoscopy_tool_tracking --include onnx holoviz${NOCOLOR}"
+echo -e "Run the application:\n"
+echo -e "${YELLOW}holoscan run -r \$(docker images | grep "holohub-endoscopy-tool-tracking-cpp" | awk '{print \$1\":\"\$2}') -i $GIT_ROOT/data/endoscopy${NOCOLOR}"

--- a/applications/endoscopy_tool_tracking/cpp/package-app.sh
+++ b/applications/endoscopy_tool_tracking/cpp/package-app.sh
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -e
 
 GIT_ROOT=$(readlink -f ./$(git rev-parse --show-cdup))
 
@@ -24,6 +25,21 @@ NOCOLOR="\e[0m"
 
 print_error() {
     echo -e "${RED}ERROR${NOCOLOR}:" $*
+}
+
+get_host_gpu() {
+    if ! command -v nvidia-smi >/dev/null; then
+        print_error Y "Could not find any GPU drivers on host. Defaulting build to target dGPU/CPU stack."
+        echo -n "dgpu"
+    elif nvidia-smi  2>/dev/null | grep nvgpu -q; then
+        echo -n "igpu"
+    else
+        echo -n "dgpu"
+    fi
+}
+
+get_host_arch() {
+    echo -n "$(uname -m)"
 }
 
 if [ ! -d $GIT_ROOT/build/endoscopy_tool_tracking ]; then
@@ -45,10 +61,17 @@ cp -f $GIT_ROOT/build/endoscopy_tool_tracking/operators/tool_tracking_postproces
 echo Updating application configuration...
 sed -e s!gxf_extensions/lstm_tensor_rt_inference/!!g -i $APP_PATH/endoscopy_tool_tracking.yaml
 
+PLATFORM=x64-workstation
+GPU=$(get_host_gpu)
+if [ $(get_host_arch) == "aarch64" ]; then
+    PLATFORM=igx-orin-devkit
+fi
 
 echo -e "done\n"
-echo -e Use the following commands to package and run the Endoscopy Tool Tracking application:\n
-echo -e "Package the application:\n"
-echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform x64-workstation -t holohub-endoscopy-tool-tracking-cpp $APP_PATH/endoscopy_tool_tracking --include onnx holoviz${NOCOLOR}"
-echo -e "Run the application:\n"
+echo -e Use the following commands to package and run the Endoscopy Tool Tracking application:
+echo -e "Package the application:"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform [igx-orin-devkit | jetson-agx-orin-devkit | sbsa, x64-workstation] --platform-config [igpu | dgpu] -t holohub-endoscopy-tool-tracking-cpp $APP_PATH/endoscopy_tool_tracking --include onnx holoviz${NOCOLOR}"
+echo -e "\nFor example:"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform ${PLATFORM} --platform-config ${GPU} -t holohub-endoscopy-tool-tracking-cpp $APP_PATH/endoscopy_tool_tracking --include onnx holoviz${NOCOLOR}"
+echo -e "\nRun the application:"
 echo -e "${YELLOW}holoscan run -r \$(docker images | grep "holohub-endoscopy-tool-tracking-cpp" | awk '{print \$1\":\"\$2}') -i $GIT_ROOT/data/endoscopy${NOCOLOR}"

--- a/applications/endoscopy_tool_tracking/cpp/package-app.sh
+++ b/applications/endoscopy_tool_tracking/cpp/package-app.sh
@@ -33,10 +33,11 @@ if [ $(get_host_arch) == "aarch64" ]; then
 fi
 
 echo -e "done\n"
-echo -e Use the following commands to package and run the Endoscopy Tool Tracking application:
+echo -e Install Holoscan CLI and then use the following commands to package and run the Endoscopy Tool Tracking application:
 echo -e "Package the application:"
 echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform [igx-orin-devkit | jetson-agx-orin-devkit | sbsa, x64-workstation] --platform-config [igpu | dgpu] -t holohub-endoscopy-tool-tracking-cpp $APP_PATH/endoscopy_tool_tracking --include onnx holoviz${NOCOLOR}"
 echo -e "\nFor example:"
 echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform ${PLATFORM} --platform-config ${GPU} -t holohub-endoscopy-tool-tracking-cpp $APP_PATH/endoscopy_tool_tracking --include onnx holoviz${NOCOLOR}"
 echo -e "\nRun the application:"
 echo -e "${YELLOW}holoscan run -r \$(docker images | grep "holohub-endoscopy-tool-tracking-cpp" | awk '{print \$1\":\"\$2}') -i $GIT_ROOT/data/endoscopy${NOCOLOR}"
+echo -e "\n\nRefer to Packaging Holoscan Applications (https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_packager.html) in the User Guide for more information."

--- a/applications/endoscopy_tool_tracking/python/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/python/CMakeLists.txt
@@ -63,3 +63,32 @@ if(BUILD_TESTING)
   )
 
 endif()
+
+# Install application and dependencies into the install/ directory for packaging
+install(
+  FILES ${CMAKE_CURRENT_SOURCE_DIR}/endoscopy_tool_tracking.py
+  DESTINATION "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_python"
+  COMPONENT "holohub-apps"
+)
+
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/endoscopy_tool_tracking.yaml" APP_YAML_FILE)
+string(REPLACE "gxf_extensions/lstm_tensor_rt_inference/" "" APP_YAML_FILE "${APP_YAML_FILE}")
+file(WRITE "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_python/endoscopy_tool_tracking.yaml" "${APP_YAML_FILE}")
+
+install(
+  DIRECTORY ${gxf_lstm_tensor_rt_inference_BINARY_DIR}/
+  DESTINATION "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_python"
+  FILES_MATCHING PATTERN "*.so"
+  PATTERN "CMakeFiles" EXCLUDE)
+
+install(
+  FILES
+    ${lstm_tensor_rt_inference_BINARY_DIR}/liblstm_tensor_rt_inference.so
+    ${tool_tracking_postprocessor_BINARY_DIR}/libtool_tracking_postprocessor.so
+  DESTINATION "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_python"
+  COMPONENT "holohub-apps"
+)
+
+install(
+  DIRECTORY ${Holohub-internal_BINARY_DIR}/python/lib/holohub
+  DESTINATION "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_python")

--- a/applications/endoscopy_tool_tracking/python/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/python/CMakeLists.txt
@@ -66,29 +66,36 @@ endif()
 
 # Install application and dependencies into the install/ directory for packaging
 install(
-  FILES ${CMAKE_CURRENT_SOURCE_DIR}/endoscopy_tool_tracking.py
-  DESTINATION "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_python"
+  FILES endoscopy_tool_tracking.py
+  DESTINATION "endoscopy_tool_tracking_python"
   COMPONENT "holohub-apps"
 )
 
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/endoscopy_tool_tracking.yaml" APP_YAML_FILE)
 string(REPLACE "gxf_extensions/lstm_tensor_rt_inference/" "" APP_YAML_FILE "${APP_YAML_FILE}")
-file(WRITE "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_python/endoscopy_tool_tracking.yaml" "${APP_YAML_FILE}")
+file(WRITE "${CMAKE_BINARY_DIR}/packaging/python/endoscopy_tool_tracking.yaml" "${APP_YAML_FILE}")
+
+install(
+  FILES ${CMAKE_BINARY_DIR}/packaging/python/endoscopy_tool_tracking.yaml
+  DESTINATION endoscopy_tool_tracking_python
+  COMPONENT "holohub-apps"
+)
 
 install(
   DIRECTORY ${gxf_lstm_tensor_rt_inference_BINARY_DIR}/
-  DESTINATION "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_python"
+  DESTINATION endoscopy_tool_tracking_python
   FILES_MATCHING PATTERN "*.so"
-  PATTERN "CMakeFiles" EXCLUDE)
+  PATTERN "CMakeFiles" EXCLUDE
+)
 
 install(
   FILES
     ${lstm_tensor_rt_inference_BINARY_DIR}/liblstm_tensor_rt_inference.so
     ${tool_tracking_postprocessor_BINARY_DIR}/libtool_tracking_postprocessor.so
-  DESTINATION "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_python"
+  DESTINATION "endoscopy_tool_tracking_python"
   COMPONENT "holohub-apps"
 )
 
 install(
   DIRECTORY ${Holohub-internal_BINARY_DIR}/python/lib/holohub
-  DESTINATION "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_python")
+  DESTINATION endoscopy_tool_tracking_python)

--- a/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py
+++ b/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py
@@ -303,7 +303,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-d",
         "--data",
-        default="none",
+        default=os.environ.get("HOLOSCAN_INPUT_PATH", None),
         help=("Set the data path"),
     )
     args = parser.parse_args()

--- a/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.yaml
+++ b/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.yaml
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+# Required fields for packaging the application
+# See https://docs.nvidia.com/holoscan/sdk-user-guide/cli/run_config.html#
 application:
   title: Holohub - Endoscopy Tool Tracking
   version: 1.0

--- a/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.yaml
+++ b/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.yaml
@@ -14,6 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+application:
+  title: Holohub - Endoscopy Tool Tracking
+  version: 1.0
+  inputFormats: []
+  outputFormats: ["screen"]
+
+resources:
+  cpu: 2
+  gpu: 1
+  memory: 1Gi
+  gpuMemory: 1Gi
+
 extensions:
 - gxf_extensions/lstm_tensor_rt_inference/libgxf_lstm_tensor_rt_inference.so
 - gxf_extensions/yuan_qcap/libgxf_qcap_source.so

--- a/applications/endoscopy_tool_tracking/python/package-app.sh
+++ b/applications/endoscopy_tool_tracking/python/package-app.sh
@@ -33,10 +33,11 @@ if [ $(get_host_arch) == "aarch64" ]; then
 fi
 
 echo -e "done\n"
-echo -e Use the following commands to package and run the Endoscopy Tool Tracking application:
+echo -e Install Holoscan CLI and then use the following commands to package and run the Endoscopy Tool Tracking application:
 echo -e "Package the application:"
 echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform [igx-orin-devkit | jetson-agx-orin-devkit | sbsa, x64-workstation] --platform-config [igpu | dgpu] -t holohub-endoscopy-tool-tracking-python $APP_PATH/endoscopy_tool_tracking.py --include onnx holoviz${NOCOLOR}"
 echo -e "\nFor example:"
 echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform ${PLATFORM} --platform-config ${GPU} -t holohub-endoscopy-tool-tracking-python $APP_PATH/endoscopy_tool_tracking.py --include onnx holoviz${NOCOLOR}"
 echo -e "\nRun the application:"
 echo -e "${YELLOW}holoscan run -r \$(docker images | grep "holohub-endoscopy-tool-tracking-python" | awk '{print \$1\":\"\$2}') -i $GIT_ROOT/data/endoscopy${NOCOLOR}"
+echo -e "\n\nRefer to Packaging Holoscan Applications (https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_packager.html) in the User Guide for more information."

--- a/applications/endoscopy_tool_tracking/python/package-app.sh
+++ b/applications/endoscopy_tool_tracking/python/package-app.sh
@@ -16,50 +16,15 @@
 set -e
 
 GIT_ROOT=$(readlink -f ./$(git rev-parse --show-cdup))
+APP_PATH="$GIT_ROOT/install/endoscopy_tool_tracking_python"
 
-# Utilities
+. $GIT_ROOT/utilities/bash_utils.sh
 
-YELLOW="\e[1;33m"
-RED="\e[1;31m"
-NOCOLOR="\e[0m"
-
-print_error() {
-    echo -e "${RED}ERROR${NOCOLOR}:" $*
-}
-
-get_host_gpu() {
-    if ! command -v nvidia-smi >/dev/null; then
-        print_error Y "Could not find any GPU drivers on host. Defaulting build to target dGPU/CPU stack."
-        echo -n "dgpu"
-    elif nvidia-smi  2>/dev/null | grep nvgpu -q; then
-        echo -n "igpu"
-    else
-        echo -n "dgpu"
-    fi
-}
-
-get_host_arch() {
-    echo -n "$(uname -m)"
-}
-
-if [ ! -d $GIT_ROOT/build/endoscopy_tool_tracking ]; then
+if [ ! -d $APP_PATH ]; then
     print_error "Please build the Endoscopy Tool Tracking application first with the following command:"
     print_error "./dev_container build_and_run endoscopy_tool_tracking"
     exit -1
 fi
-
-APP_PATH="$GIT_ROOT/endoscopy_tool_tracking_python"
-echo Creating application directory $APP_PATH...
-mkdir -p $APP_PATH
-echo Copying application files to $APP_PATH...
-cp -f $GIT_ROOT/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py $APP_PATH
-cp -f $GIT_ROOT/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.yaml $APP_PATH
-cp -f $GIT_ROOT/build/endoscopy_tool_tracking/gxf_extensions/lstm_tensor_rt_inference/*.so $APP_PATH
-cp -f $GIT_ROOT/build/endoscopy_tool_tracking/operators/lstm_tensor_rt_inference/liblstm_tensor_rt_inference.so $APP_PATH
-cp -f $GIT_ROOT/build/endoscopy_tool_tracking/operators/tool_tracking_postprocessor/libtool_tracking_postprocessor.so $APP_PATH
-cp -rf $GIT_ROOT/build/endoscopy_tool_tracking/python/lib/holohub $APP_PATH
-echo Updating application configuration...
-sed -e s!gxf_extensions/lstm_tensor_rt_inference/!!g -i $APP_PATH/endoscopy_tool_tracking.yaml
 
 PLATFORM=x64-workstation
 GPU=$(get_host_gpu)

--- a/applications/endoscopy_tool_tracking/python/package-app.sh
+++ b/applications/endoscopy_tool_tracking/python/package-app.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GIT_ROOT=$(readlink -f ./$(git rev-parse --show-cdup))
+
+# Utilities
+
+YELLOW="\e[1;33m"
+RED="\e[1;31m"
+NOCOLOR="\e[0m"
+
+print_error() {
+    echo -e "${RED}ERROR${NOCOLOR}:" $*
+}
+
+if [ ! -d $GIT_ROOT/build/endoscopy_tool_tracking ]; then
+    print_error "Please build the Endoscopy Tool Tracking application first with the following command:"
+    print_error "./dev_container build_and_run endoscopy_tool_tracking"
+    exit -1
+fi
+
+APP_PATH="$GIT_ROOT/endoscopy_tool_tracking_python"
+echo Creating application directory $APP_PATH...
+mkdir -p $APP_PATH
+echo Copying application files to $APP_PATH...
+cp -f $GIT_ROOT/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py $APP_PATH
+cp -f $GIT_ROOT/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.yaml $APP_PATH
+cp -f $GIT_ROOT/build/endoscopy_tool_tracking/gxf_extensions/lstm_tensor_rt_inference/*.so $APP_PATH
+cp -f $GIT_ROOT/build/endoscopy_tool_tracking/operators/lstm_tensor_rt_inference/liblstm_tensor_rt_inference.so $APP_PATH
+cp -f $GIT_ROOT/build/endoscopy_tool_tracking/operators/tool_tracking_postprocessor/libtool_tracking_postprocessor.so $APP_PATH
+cp -rf $GIT_ROOT/build/endoscopy_tool_tracking/python/lib/holohub $APP_PATH
+echo Updating application configuration...
+sed -e s!gxf_extensions/lstm_tensor_rt_inference/!!g -i $APP_PATH/endoscopy_tool_tracking.yaml
+
+
+echo -e "done\n"
+echo -e Use the following commands to package and run the Endoscopy Tool Tracking application:\n
+echo -e "Package the application:\n"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform x64-workstation -t holohub-endoscopy-tool-tracking-python $APP_PATH/endoscopy_tool_tracking.py --include onnx holoviz${NOCOLOR}"
+echo -e "Run the application:\n"
+echo -e "${YELLOW}holoscan run -r \$(docker images | grep "holohub-endoscopy-tool-tracking-python" | awk '{print \$1\":\"\$2}') -i $GIT_ROOT/data/endoscopy${NOCOLOR}"

--- a/applications/object_detection_torch/CMakeLists.txt
+++ b/applications/object_detection_torch/CMakeLists.txt
@@ -118,3 +118,24 @@ if(BUILD_TESTING)
     PASS_REGULAR_EXPRESSION "Valid video output!"
   )
 endif()
+
+get_cmake_property(_variableNames VARIABLES)
+list (SORT _variableNames)
+foreach (_variableName ${_variableNames})
+    message(STATUS "${_variableName}=${${_variableName}}")
+endforeach()
+
+
+# Install application and dependencies into the install/ directory for packaging
+install(
+  TARGETS object_detection_torch
+  DESTINATION "${CMAKE_SOURCE_DIR}/install/object_detection_torch"
+  COMPONENT "holohub-apps"
+)
+
+install(
+  FILES
+    "${object_detection_torch_BINARY_DIR}/object_detection_torch.yaml"
+  DESTINATION "${CMAKE_SOURCE_DIR}/install/object_detection_torch"
+  COMPONENT "holohub-apps"
+)

--- a/applications/object_detection_torch/CMakeLists.txt
+++ b/applications/object_detection_torch/CMakeLists.txt
@@ -119,13 +119,6 @@ if(BUILD_TESTING)
   )
 endif()
 
-get_cmake_property(_variableNames VARIABLES)
-list (SORT _variableNames)
-foreach (_variableName ${_variableNames})
-    message(STATUS "${_variableName}=${${_variableName}}")
-endforeach()
-
-
 # Install application and dependencies into the install/ directory for packaging
 install(
   TARGETS object_detection_torch

--- a/applications/object_detection_torch/README.md
+++ b/applications/object_detection_torch/README.md
@@ -74,4 +74,6 @@ export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/hpcx/ompi/lib"
 
 ## Containerize the application
 
-To containerize the application, first build the application and then run the `package-app.sh` script and follow the generated output to package and run the application.
+To containerize the application using [Holoscan CLI](https://docs.nvidia.com/holoscan/sdk-user-guide/cli/cli.html), first build the application and then run the `package-app.sh` script and follow the generated output to package and run the application.
+
+Refer to the [Packaging Holoscan Applications](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_packager.html) section of the [Holoscan User Guide](https://docs.nvidia.com/holoscan/sdk-user-guide/) to learn more about installing the Holoscan CLI or packaging your application using Holoscan CLI.

--- a/applications/object_detection_torch/README.md
+++ b/applications/object_detection_torch/README.md
@@ -71,3 +71,7 @@ On aarch64, if application is executed from within the holoscan sdk container an
 ```bash
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/hpcx/ompi/lib"
 ```
+
+## Containerize the application
+
+To containerize the application, first build the application and then run the `package-app.sh` script and follow the generated output to package and run the application.

--- a/applications/object_detection_torch/main.cpp
+++ b/applications/object_detection_torch/main.cpp
@@ -264,6 +264,18 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  if (data_path.empty()) {
+    // Get the input data environment variable
+    auto input_path = std::getenv("HOLOSCAN_INPUT_PATH");
+    if (input_path == nullptr || input_path[0] == '\0') {
+      HOLOSCAN_LOG_ERROR(
+          "Input data not provided. Use --data or set HOLOSCAN_INPUT_PATH environment variable.");
+      exit(-1);
+    }
+    data_path = std::string(input_path);
+  }
+  HOLOSCAN_LOG_INFO("Using input data from {}", data_path);
+
   if (config_name != "") {
     app->config(config_name);
   } else {
@@ -277,8 +289,7 @@ int main(int argc, char **argv) {
 
   auto source = app->from_config("source").as<std::string>();
   app->set_source(source);
-  if (data_path != "")
-    app->set_datapath(data_path);
+  app->set_datapath(data_path);
   app->run();
 
   return 0;

--- a/applications/object_detection_torch/object_detection_torch.yaml
+++ b/applications/object_detection_torch/object_detection_torch.yaml
@@ -14,6 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+application:
+  title: Holohub - Object Detection Torch
+  version: 1.0
+  inputFormats: []
+  outputFormats: ["screen"]
+
+resources:
+  cpu: 2
+  gpu: 1
+  memory: 1Gi
+  gpuMemory: 2Gi
+
 extensions:
 
 source: "replayer" # or "aja"

--- a/applications/object_detection_torch/object_detection_torch.yaml
+++ b/applications/object_detection_torch/object_detection_torch.yaml
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+# Required fields for packaging the application
+# See https://docs.nvidia.com/holoscan/sdk-user-guide/cli/run_config.html#
 application:
   title: Holohub - Object Detection Torch
   version: 1.0

--- a/applications/object_detection_torch/package-app.sh
+++ b/applications/object_detection_torch/package-app.sh
@@ -33,10 +33,11 @@ if [ $(get_host_arch) == "aarch64" ]; then
 fi
 
 echo -e "done\n"
-echo -e Use the following commands to package and run the Object Detection Torch application:
+echo -e Install Holoscan CLI and then use the following commands to package and run the Object Detection Torch application:
 echo -e "Package the application:"
 echo -e "${YELLOW}holoscan package -c $APP_PATH/object_detection_torch.yaml --platform [igx-orin-devkit | jetson-agx-orin-devkit | sbsa, x64-workstation] --platform-config [igpu | dgpu] -t holohub-object-detection-torch $APP_PATH/object_detection_torch --include onnx holoviz torch${NOCOLOR}"
 echo -e "\nFor example:"
 echo -e "${YELLOW}holoscan package -c $APP_PATH/object_detection_torch.yaml --platform ${PLATFORM} --platform-config ${GPU} -t holohub-object-detection-torch $APP_PATH/object_detection_torch --include onnx holoviz torch${NOCOLOR}"
 echo -e "\nRun the application:"
 echo -e "${YELLOW}holoscan run -r \$(docker images | grep "holohub-object-detection-torch" | awk '{print \$1\":\"\$2}') -i $GIT_ROOT/data/object_detection_torch${NOCOLOR}"
+echo -e "\n\nRefer to Packaging Holoscan Applications (https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_packager.html) in the User Guide for more information."

--- a/applications/object_detection_torch/package-app.sh
+++ b/applications/object_detection_torch/package-app.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+GIT_ROOT=$(readlink -f ./$(git rev-parse --show-cdup))
+
+# Utilities
+
+YELLOW="\e[1;33m"
+RED="\e[1;31m"
+NOCOLOR="\e[0m"
+
+print_error() {
+    echo -e "${RED}ERROR${NOCOLOR}:" $*
+}
+
+if [ ! -d $GIT_ROOT/build/object_detection_torch ]; then
+    print_error "Please build the Object Detection Torch application first with the following command:"
+    print_error "./dev_container build_and_run object_detection_torch"
+    exit -1
+fi
+
+APP_PATH="$GIT_ROOT/object_detection_torch"
+echo Creating application directory $APP_PATH...
+mkdir -p $APP_PATH
+echo Copying application files to $APP_PATH...
+cp -f $GIT_ROOT/build/object_detection_torch/applications/object_detection_torch/object_detection_torch $APP_PATH
+cp -f $GIT_ROOT/build/object_detection_torch/applications/object_detection_torch/object_detection_torch.yaml $APP_PATH
+
+echo -e "done\n"
+echo -e Use the following commands to package and run the Object Detection Torch application:\n
+echo -e "Package the application:\n"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/object_detection_torch.yaml --platform x64-workstation -t holohub-object-detection-torch $APP_PATH/object_detection_torch --include onnx holoviz torch${NOCOLOR}"
+echo -e "Run the application:\n"
+echo -e "${YELLOW}holoscan run -r \$(docker images | grep "holohub-object-detection-torch" | awk '{print \$1\":\"\$2}') -i $GIT_ROOT/data/object_detection_torch${NOCOLOR}"

--- a/applications/object_detection_torch/package-app.sh
+++ b/applications/object_detection_torch/package-app.sh
@@ -53,6 +53,7 @@ echo Creating application directory $APP_PATH...
 mkdir -p $APP_PATH
 echo Copying application files to $APP_PATH...
 cp -f $GIT_ROOT/build/object_detection_torch/applications/object_detection_torch/object_detection_torch $APP_PATH
+cp -f $GIT_ROOT/build/object_detection_torch/applications/object_detection_torch/object_detection_torch.yaml $APP_PATH
 
 PLATFORM=x64-workstation
 GPU=$(get_host_gpu)

--- a/applications/object_detection_torch/package-app.sh
+++ b/applications/object_detection_torch/package-app.sh
@@ -16,44 +16,15 @@
 set -e
 
 GIT_ROOT=$(readlink -f ./$(git rev-parse --show-cdup))
+APP_PATH="$GIT_ROOT/install/object_detection_torch"
 
-# Utilities
+. $GIT_ROOT/utilities/bash_utils.sh
 
-YELLOW="\e[1;33m"
-RED="\e[1;31m"
-NOCOLOR="\e[0m"
-
-print_error() {
-    echo -e "${RED}ERROR${NOCOLOR}:" $*
-}
-
-get_host_gpu() {
-    if ! command -v nvidia-smi >/dev/null; then
-        print_error Y "Could not find any GPU drivers on host. Defaulting build to target dGPU/CPU stack."
-        echo -n "dgpu"
-    elif nvidia-smi  2>/dev/null | grep nvgpu -q; then
-        echo -n "igpu"
-    else
-        echo -n "dgpu"
-    fi
-}
-
-get_host_arch() {
-    echo -n "$(uname -m)"
-}
-
-if [ ! -d $GIT_ROOT/build/object_detection_torch ]; then
+if [ ! -d $APP_PATH ]; then
     print_error "Please build the Object Detection Torch application first with the following command:"
     print_error "./dev_container build_and_run object_detection_torch"
     exit -1
 fi
-
-APP_PATH="$GIT_ROOT/object_detection_torch"
-echo Creating application directory $APP_PATH...
-mkdir -p $APP_PATH
-echo Copying application files to $APP_PATH...
-cp -f $GIT_ROOT/build/object_detection_torch/applications/object_detection_torch/object_detection_torch $APP_PATH
-cp -f $GIT_ROOT/build/object_detection_torch/applications/object_detection_torch/object_detection_torch.yaml $APP_PATH
 
 PLATFORM=x64-workstation
 GPU=$(get_host_gpu)

--- a/run
+++ b/run
@@ -540,6 +540,8 @@ build_desc() {
   echo "                                          Default: build"
   echo "                                          Associated environment variable: CMAKE_BUILD_PATH"
   echo "   --benchmark                          : Build for Holoscan Flow Benchmarking."
+  echo "   --install                            : Install applications and its dependencies to"
+  echo "                                          install/<app> if supported."
   echo "   --configure-args <extra_args>        : Additional configuration arguments"
   echo "                                          multiple arguments can be passed between quotes"
   echo "                                          or using several --configure-args in the command line"
@@ -604,6 +606,7 @@ build() {
   local build_type="${CMAKE_BUILD_TYPE:-release}"
   local build_path="${CMAKE_BUILD_PATH}"
   local benchmark=false
+  local install=false
 
   for i in "${!ARGS[@]}"; do
       arg="${ARGS[i]}"
@@ -623,6 +626,8 @@ build() {
           benchmark=true
           configure_args="${configure_args} -DCMAKE_CXX_FLAGS=-I$PWD/benchmarks/holoscan_flow_benchmarking"
           echo "Building for Holoscan Flow Benchmarking"
+      elif [ "$arg" = "--install" ]; then
+          install=true
       elif [ "$arg" = "--configure-args" ]; then
          configure_args="${configure_args} ${ARGS[i+1]}"
          echo "Adding configuration arguments: ${ARGS[i+1]}"
@@ -678,9 +683,12 @@ build() {
   run_command cmake --build ${build_path} -j
   ret=$?
   check_exit_code $ret "Error building application."
-  run_command cmake --install ${build_path}
-  ret=$?
-  check_exit_code $ret "Error installing application."
+
+  if [ $install == true ]; then
+    run_command cmake --install ${build_path}
+    ret=$?
+    check_exit_code $ret "Error installing application."
+  fi
 
   if [ $benchmark == true ]; then
     app_source_root_path=$(get_app_source_root_dir $1)
@@ -903,6 +911,7 @@ clear_cache() {
   echo "Clearing cache..."
   run_command rm -rf ${SCRIPT_DIR}/build
   run_command rm -rf ${SCRIPT_DIR}/build-*
+  run_command rm -rf ${SCRIPT_DIR}/install
 }
 
 clear_cache_desc() {

--- a/run
+++ b/run
@@ -678,6 +678,9 @@ build() {
   run_command cmake --build ${build_path} -j
   ret=$?
   check_exit_code $ret "Error building application."
+  run_command cmake --install ${build_path}
+  ret=$?
+  check_exit_code $ret "Error installing application."
 
   if [ $benchmark == true ]; then
     app_source_root_path=$(get_app_source_root_dir $1)

--- a/run
+++ b/run
@@ -830,8 +830,8 @@ for k, v in obj[project_type]["run"].items():
       workdir="cd ${holohub_build_dir}"
    fi
 
-   local environment="export PYTHONPATH=\${PYTHONPATH}:${holoscan_sdk_install}/../../../python/lib:${holohub_build_dir}/python/lib:${SCRIPT_DIR} && export HOLOHUB_DATA_PATH=${holohub_data_dir}"
-   local reset_environment="export PYTHONPATH=${PYTHONPATH} && export HOLOHUB_DATA_PATH=\"${HOLOHUB_DATA_PATH}\""
+   local environment="export PYTHONPATH=\${PYTHONPATH}:${holoscan_sdk_install}/../../../python/lib:${holohub_build_dir}/python/lib:${SCRIPT_DIR} && export HOLOHUB_DATA_PATH=${holohub_data_dir} && export HOLOSCAN_INPUT_PATH=${holohub_data_dir}"
+   local reset_environment="export PYTHONPATH=${PYTHONPATH} && export HOLOHUB_DATA_PATH=\"${HOLOHUB_DATA_PATH}\" && export HOLOSCAN_INPUT_PATH=\"${HOLOSCAN_INPUT_PATH}\""
 
    if [ ${verbose} ]; then
     echo "Run environment: $environment"

--- a/utilities/bash_utils.sh
+++ b/utilities/bash_utils.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+
+# Utilities
+
+YELLOW="\e[1;33m"
+RED="\e[1;31m"
+NOCOLOR="\e[0m"
+
+print_error() {
+    echo -e "${RED}ERROR${NOCOLOR}:" $*
+}
+
+get_host_gpu() {
+    if ! command -v nvidia-smi >/dev/null; then
+        print_error Y "Could not find any GPU drivers on host. Defaulting build to target dGPU/CPU stack."
+        echo -n "dgpu"
+    elif nvidia-smi  2>/dev/null | grep nvgpu -q; then
+        echo -n "igpu"
+    else
+        echo -n "dgpu"
+    fi
+}
+
+get_host_arch() {
+    echo -n "$(uname -m)"
+}


### PR DESCRIPTION
Add scripts to package the Endoscopy Tool Tracking application and the Object Detection Torch application.

The script copies necessary files from the build output and generates commands to use with the Holoscan CLI.