### PR TITLE
Dev: Update `.gitignore` to ignore local dev directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,14 @@ aggregate_metadata.json
 .venv/
 ngc-cli/
 .bash_history
+.python_history
 .wget-hsts
+
 .cache/
 .cupy/
+.cmake/
+.docker/
+.config/
+.local/
+tmp/
+


### PR DESCRIPTION
Adds several development directories to `.gitignore`, including
- `tmp`, for local development
- several package cache directories populating by the `Windrunner` executable when building or running XR examples