### PR TITLE
App Install - Prevent null variables during a clean build

### DIFF
--- a/applications/endoscopy_tool_tracking/cpp/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/cpp/CMakeLists.txt
@@ -155,7 +155,7 @@ endif()
 # Install application and dependencies into the install/ directory for packaging
 install(
   TARGETS endoscopy_tool_tracking
-  DESTINATION "${CMAKE_SOURCE_DIR}/install/endoscopy_tool_tracking_cpp"
+  DESTINATION endoscopy_tool_tracking_cpp
   COMPONENT "holohub-apps"
 )
 
@@ -170,14 +170,14 @@ install(
 )
 
 install(
-  DIRECTORY ${gxf_lstm_tensor_rt_inference_BINARY_DIR}/
+  DIRECTORY ${CMAKE_BINARY_DIR}/gxf_extensions/lstm_tensor_rt_inference/
   DESTINATION endoscopy_tool_tracking_cpp
   FILES_MATCHING PATTERN "*.so"
   PATTERN "CMakeFiles" EXCLUDE)
 
 install(
   FILES
-  ${lstm_tensor_rt_inference_BINARY_DIR}/liblstm_tensor_rt_inference.so
-  ${tool_tracking_postprocessor_BINARY_DIR}/libtool_tracking_postprocessor.so
+  ${CMAKE_BINARY_DIR}/operators/lstm_tensor_rt_inference/liblstm_tensor_rt_inference.so
+  ${CMAKE_BINARY_DIR}/operators/tool_tracking_postprocessor/libtool_tracking_postprocessor.so
   DESTINATION endoscopy_tool_tracking_cpp
   COMPONENT "holohub-apps")

--- a/applications/endoscopy_tool_tracking/python/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/python/CMakeLists.txt
@@ -67,7 +67,7 @@ endif()
 # Install application and dependencies into the install/ directory for packaging
 install(
   FILES endoscopy_tool_tracking.py
-  DESTINATION "endoscopy_tool_tracking_python"
+  DESTINATION endoscopy_tool_tracking_python
   COMPONENT "holohub-apps"
 )
 
@@ -82,7 +82,7 @@ install(
 )
 
 install(
-  DIRECTORY ${gxf_lstm_tensor_rt_inference_BINARY_DIR}/
+  DIRECTORY ${CMAKE_BINARY_DIR}/gxf_extensions/lstm_tensor_rt_inference/
   DESTINATION endoscopy_tool_tracking_python
   FILES_MATCHING PATTERN "*.so"
   PATTERN "CMakeFiles" EXCLUDE
@@ -90,12 +90,12 @@ install(
 
 install(
   FILES
-    ${lstm_tensor_rt_inference_BINARY_DIR}/liblstm_tensor_rt_inference.so
-    ${tool_tracking_postprocessor_BINARY_DIR}/libtool_tracking_postprocessor.so
-  DESTINATION "endoscopy_tool_tracking_python"
+    ${CMAKE_BINARY_DIR}/operators/lstm_tensor_rt_inference/liblstm_tensor_rt_inference.so
+    ${CMAKE_BINARY_DIR}/operators/tool_tracking_postprocessor/libtool_tracking_postprocessor.so
+  DESTINATION endoscopy_tool_tracking_python
   COMPONENT "holohub-apps"
 )
 
 install(
-  DIRECTORY ${Holohub-internal_BINARY_DIR}/python/lib/holohub
+  DIRECTORY ${CMAKE_BINARY_DIR}/python/lib/holohub
   DESTINATION endoscopy_tool_tracking_python)

--- a/applications/object_detection_torch/CMakeLists.txt
+++ b/applications/object_detection_torch/CMakeLists.txt
@@ -122,13 +122,13 @@ endif()
 # Install application and dependencies into the install/ directory for packaging
 install(
   TARGETS object_detection_torch
-  DESTINATION "${CMAKE_SOURCE_DIR}/install/object_detection_torch"
+  DESTINATION object_detection_torch
   COMPONENT "holohub-apps"
 )
 
 install(
   FILES
     "${object_detection_torch_BINARY_DIR}/object_detection_torch.yaml"
-  DESTINATION "${CMAKE_SOURCE_DIR}/install/object_detection_torch"
+  DESTINATION object_detection_torch
   COMPONENT "holohub-apps"
 )


### PR DESCRIPTION
In a clean build, some variables may not be available during the cmake `install` stage. 

The fix is to use `CMAKE_BINARY_DIR` + relative path to the dependencies.