### PR TITLE
Re-enable default holohub data path for Endoscopy Tool Tracking

### DIFF
--- a/applications/endoscopy_tool_tracking/cpp/main.cpp
+++ b/applications/endoscopy_tool_tracking/cpp/main.cpp
@@ -273,7 +273,7 @@ class App : public holoscan::Application {
   std::string source_ = "replayer";
   std::string visualizer_name = "holoviz";
   Record record_type_ = Record::NONE;
-  std::string datapath = "data/endoscopy";
+  std::string datapath = "";
 };
 
 /** Helper function to parse the command line arguments */
@@ -309,12 +309,15 @@ int main(int argc, char** argv) {
   if (data_directory.empty()) {
     // Get the input data environment variable
     auto input_path = std::getenv("HOLOSCAN_INPUT_PATH");
-    if (input_path == nullptr || input_path[0] == '\0') {
+    if (input_path != nullptr && input_path[0] != '\0') {
+      data_directory = std::string(input_path);
+    } else if (std::filesystem::is_directory(std::filesystem::current_path() / "data/endoscopy")) {
+      data_directory = std::string((std::filesystem::current_path() / "data/endoscopy").c_str());
+    } else {
       HOLOSCAN_LOG_ERROR(
           "Input data not provided. Use --data or set HOLOSCAN_INPUT_PATH environment variable.");
       exit(-1);
     }
-    data_directory = std::string(input_path);
   }
 
   if (config_path.empty()) {

--- a/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py
+++ b/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py
@@ -275,6 +275,7 @@ class EndoscopyApp(Application):
 
 
 if __name__ == "__main__":
+    default_data_path = f"{os.getcwd()}/data/endoscopy"
     # Parse args
     parser = ArgumentParser(description="Endoscopy tool tracking demo application.")
     parser.add_argument(
@@ -303,8 +304,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "-d",
         "--data",
-        default=os.environ.get("HOLOSCAN_INPUT_PATH", None),
-        help=("Set the data path"),
+        default=os.environ.get("HOLOSCAN_INPUT_PATH", default_data_path),
+        help=("Set the data path (default: %(default)s)."),
     )
     args = parser.parse_args()
     record_type = args.record_type
@@ -315,6 +316,13 @@ if __name__ == "__main__":
         config_file = os.path.join(os.path.dirname(__file__), "endoscopy_tool_tracking.yaml")
     else:
         config_file = args.config
+
+    # handle case where HOLOSCAN_INPUT_PATH is set with no value
+    if len(args.data) == 0:
+        args.data = default_data_path
+
+    if not os.path.isdir(args.data):
+        raise ValueError(f"Data path '{args.data}' does not exist. Use --data or set HOLOSCAN_INPUT_PATH environment variable.")
 
     app = EndoscopyApp(record_type=record_type, source=args.source, data=args.data)
     app.config(config_file)

--- a/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py
+++ b/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py
@@ -322,7 +322,9 @@ if __name__ == "__main__":
         args.data = default_data_path
 
     if not os.path.isdir(args.data):
-        raise ValueError(f"Data path '{args.data}' does not exist. Use --data or set HOLOSCAN_INPUT_PATH environment variable.")
+        raise ValueError(
+            f"Data path '{args.data}' does not exist. Use --data or set HOLOSCAN_INPUT_PATH environment variable."
+        )
 
     app = EndoscopyApp(record_type=record_type, source=args.source, data=args.data)
     app.config(config_file)

--- a/run
+++ b/run
@@ -841,7 +841,7 @@ for k, v in obj[project_type]["run"].items():
       workdir="cd ${holohub_build_dir}"
    fi
 
-   local environment="export PYTHONPATH=\${PYTHONPATH}:${holoscan_sdk_install}/../../../python/lib:${holohub_build_dir}/python/lib:${SCRIPT_DIR} && export HOLOHUB_DATA_PATH=${holohub_data_dir} && export HOLOSCAN_INPUT_PATH=${holohub_data_dir}"
+   local environment="export PYTHONPATH=\${PYTHONPATH}:${holoscan_sdk_install}/../../../python/lib:${holohub_build_dir}/python/lib:${SCRIPT_DIR} && export HOLOHUB_DATA_PATH=${holohub_data_dir} && export HOLOSCAN_INPUT_PATH=${HOLOSCAN_INPUT_PATH:=$holohub_data_dir}"
    local reset_environment="export PYTHONPATH=${PYTHONPATH} && export HOLOHUB_DATA_PATH=\"${HOLOHUB_DATA_PATH}\" && export HOLOSCAN_INPUT_PATH=\"${HOLOSCAN_INPUT_PATH}\""
 
    if [ ${verbose} ]; then


### PR DESCRIPTION
Fix an issue introduced in #466 to use the Holohub data path (`data/endoscopy`) if exists.