### PR TITLE
App: Fix Endoscopy Tool Tracking C++ Test Config

### DIFF
--- a/applications/endoscopy_tool_tracking/cpp/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/cpp/CMakeLists.txt
@@ -73,7 +73,8 @@ if(BUILD_TESTING)
 
   # Add test
   add_test(NAME endoscopy_tool_tracking_cpp_test
-           COMMAND endoscopy_tool_tracking ${CMAKE_CURRENT_BINARY_DIR}/endoscopy_tool_tracking_testing.yaml
+           COMMAND endoscopy_tool_tracking
+                   --config ${CMAKE_CURRENT_BINARY_DIR}/endoscopy_tool_tracking_testing.yaml
                    --data "${HOLOHUB_DATA_DIR}/endoscopy"
            WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   set_tests_properties(endoscopy_tool_tracking_cpp_test PROPERTIES


### PR DESCRIPTION
Fixes issue where Endoscopy Tool Tracking C++ tests were relying on the default YAML configuration rather than the expected test configuration.

153bdfd updated the Endoscopy Tool Tracking C++ app CLI:
- Under previous behavior a configuration path could be passed as the 0th positional argument
- Under new behavior a configuration path may be passed as a keyword `--config` argument. This brings the C++ app CLI into closer alignment with the existing `--data` argument and with the Python app CLI.

Prior to this fix, C++ test failures were observed:
- The test config file was not properly passed to the app under the new CLI. Instead the default test config was used, which does not define a stop condition and led to test timeout.
- The C++ render test failed due to relying on frame output from the test above.

Reproduced previous test failures locally and verified tests pass with this fix applied.