### PR TITLE
Infra: Bug fix for default `CMAKE_INSTALL_PREFIX`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ include(HoloHubConfigHelpers)
 
 # Set install directory
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set_property(CACHE CMAKE_INSTALL_PREFIX PROPERTY VALUE "${CMAKE_SOURCE_DIR}/install")
+  set(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/install" CACHE PATH "Installation directory" FORCE)
 endif()
 
 # Enable Testing


### PR DESCRIPTION
Fixes issue where `CMAKE_INSTALL_PREFIX` cache variable was not properly initialized to the HoloHub default installation directory on a clean build.

The previous default `CMAKE_INSTALL_PREFIX` initialization relied on latest CMake guidance (3.30), whereas HoloHub requires compatibility with CMake>=3.20.

Under fixed behavior `./run build endoscopy_tool_tracking --install` properly installs to the HoloHub `install` subfolder.

Latest docs: https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT.html
3.20: https://cmake.org/cmake/help/v3.20/variable/CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT.html