### PR TITLE
VSCode - Compound Task for DETT - Set address and worker-address with port

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -437,11 +437,15 @@
                 "--fragments",
                 "video_in",
                 "--address",
-                "127.0.0.1:10000",
-                "--nic",
-                "lo",
+                ":10000",
+                "--worker-address",
+                ":10001",
             ],
             "environment": [
+                {
+                    "name": "HOLOSCAN_LOG_LEVEL",
+                    "value": "DEBUG"
+                },
                 {
                     "name": "HOLOSCAN_INPUT_PATH",
                     "value": "${env:HOLOHUB_DATA_DIR}/endoscopy"
@@ -475,11 +479,15 @@
                 "--fragments",
                 "inference",
                 "--address",
-                "127.0.0.1:10000",
-                "--nic",
-                "lo",
+                ":10000",
+                "--worker-address",
+                ":10002",
             ],
             "environment": [
+                {
+                    "name": "HOLOSCAN_LOG_LEVEL",
+                    "value": "DEBUG"
+                },
                 {
                     "name": "HOLOSCAN_INPUT_PATH",
                     "value": "${env:HOLOHUB_DATA_DIR}/endoscopy"
@@ -513,11 +521,15 @@
                 "--fragments",
                 "viz",
                 "--address",
-                "127.0.0.1:10000",
-                "--nic",
-                "lo",
+                ":10000",
+                "--worker-address",
+                ":10003",
             ],
             "environment": [
+                {
+                    "name": "HOLOSCAN_LOG_LEVEL",
+                    "value": "DEBUG"
+                },
                 {
                     "name": "HOLOSCAN_INPUT_PATH",
                     "value": "${env:HOLOHUB_DATA_DIR}/endoscopy"
@@ -590,9 +602,9 @@
                 "--fragments",
                 "video_in",
                 "--address",
-                "127.0.0.1:10000",
-                "--nic",
-                "lo",
+                ":10000",
+                "--worker-address",
+                ":10001",
             ],
             "presentation": {
                 "hidden": true,
@@ -626,9 +638,9 @@
                 "--fragments",
                 "inference",
                 "--address",
-                "127.0.0.1:10000",
-                "--nic",
-                "lo",
+                ":10000",
+                "--worker-address",
+                ":10002",
             ],
             "presentation": {
                 "hidden": true,
@@ -662,9 +674,9 @@
                 "--fragments",
                 "viz",
                 "--address",
-                "127.0.0.1:10000",
-                "--nic",
-                "lo",
+                ":10000",
+                "--worker-address",
+                ":10003",
             ],
             "presentation": {
                 "hidden": true,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -66,17 +66,11 @@
         {
             "type": "shell",
             "label": "Build basic_networking_ping (delay 3s)",
-            "command": "./run",
-            "args": [
-                "build",
-                "basic_networking_ping",
-                "--type",
-                "debug"
-            ],
+            "command": "sleep 3",
             "options": {
                 "cwd": "${env:WORKSPACE_DIR}"
             },
-            "dependsOn": "Delay Task (3s)",
+            "dependsOn": "Build basic_networking_ping",
             "group": "build",
             "problemMatcher": [],
             "detail": "CMake template build task",
@@ -255,17 +249,11 @@
         {
             "type": "shell",
             "label": "Build endoscopy_tool_tracking_distributed (delay 3s)",
-            "command": "./run",
-            "args": [
-                "build",
-                "endoscopy_tool_tracking_distributed",
-                "--type",
-                "debug"
-            ],
+            "command": "sleep 3",
             "options": {
                 "cwd": "${env:WORKSPACE_DIR}"
             },
-            "dependsOn": "Delay Task (3s)",
+            "dependsOn": "Build endoscopy_tool_tracking_distributed",
             "group": "build",
             "problemMatcher": [],
             "detail": "CMake template build task",
@@ -282,17 +270,11 @@
         {
             "type": "shell",
             "label": "Build endoscopy_tool_tracking_distributed (delay 5s)",
-            "command": "./run",
-            "args": [
-                "build",
-                "endoscopy_tool_tracking_distributed",
-                "--type",
-                "debug"
-            ],
+            "command": "sleep 5",
             "options": {
                 "cwd": "${env:WORKSPACE_DIR}"
             },
-            "dependsOn": "Delay Task (5s)",
+            "dependsOn": "Build endoscopy_tool_tracking_distributed",
             "group": "build",
             "problemMatcher": [],
             "detail": "CMake template build task",

--- a/applications/endoscopy_tool_tracking_distributed/python/endoscopy_tool_tracking.py
+++ b/applications/endoscopy_tool_tracking_distributed/python/endoscopy_tool_tracking.py
@@ -113,7 +113,6 @@ def parse_args() -> argparse.Namespace:
 if __name__ == "__main__":
     args = parse_args()
 
-    print(f"==========================> data={args.data}")
     if args.data is None:
         logger.error(
             "Input data not provided. Use --data or set HOLOSCAN_INPUT_PATH environment variable."


### PR DESCRIPTION
When launching the Distributed Endoscopy Tool Tracking compound task on IGX, worker fragments, including the worker thread launched along with the driver, may not always be able to connect to the driver. 

This fix explicitly configures the worker address ports and reconfigures build tasks to build first and then delay start.