### PR TITLE
Infra: Bump base containers for Holoscan SDK v2.4.0

### DIFF
--- a/dev_container
+++ b/dev_container
@@ -465,11 +465,11 @@ get_host_gpu() {
 }
 
 get_default_base_img() {
-    echo -n "nvcr.io/nvidia/clara-holoscan/holoscan:v2.3.0-"$(get_host_gpu)
+    echo -n "nvcr.io/nvidia/clara-holoscan/holoscan:v2.4.0-"$(get_host_gpu)
 }
 
 get_default_img() {
-    echo -n "holohub:ngc-v2.3.0-"$(get_host_gpu)
+    echo -n "holohub:ngc-v2.4.0-"$(get_host_gpu)
 }
 
 # This function returns the compute capacity of the system's GPU (8.6, 8.9, etc.)

--- a/tutorials/debugging/holoscan_container_vscode/.devcontainer/devcontainer.json
+++ b/tutorials/debugging/holoscan_container_vscode/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
-            "HOLOSCAN_SDK_IMAGE": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.3.0-dgpu",
+            "HOLOSCAN_SDK_IMAGE": "nvcr.io/nvidia/clara-holoscan/holoscan:v2.4.0-dgpu",
             "WORKSPACE_DIR": "${containerWorkspaceFolder}",
             "USERNAME": "holoscan",
             "USER_UID": 1000,


### PR DESCRIPTION
Bump for latest release:
https://github.com/nvidia-holoscan/holoscan-sdk/releases/tag/v2.4.0