### PR TITLE
Ext: Link `nvinfer_plugin` directly in `lstm_tensor_rt_inference`

### DIFF
--- a/gxf_extensions/lstm_tensor_rt_inference/CMakeLists.txt
+++ b/gxf_extensions/lstm_tensor_rt_inference/CMakeLists.txt
@@ -31,6 +31,8 @@ target_link_libraries(gxf_lstm_tensor_rt_inference_lib
     CUDA::cudart
     GXF::cuda
     GXF::std
+    nvinfer
+    nvinfer_plugin
     nvonnxparser
     yaml-cpp
     holoscan::core  # included only as a way to find dlpack/dlpack.h for GXF::std


### PR DESCRIPTION
Explicitly adds TensorRT libraries to link with
`gxf_lstm_tensor_rt_inference` library in order to resolve the observed 2.6 build error in early testing:
```
libgxf_lstm_tensor_rt_inference_lib.so: undefined symbol: initLibNvInferPlugins
```

The LSTM TensorRT Inference GXF extension relies on the TensorRT `nvinfer` library in its public interface and privately on the TensorRT `nvinfer_plugin` library. On inspection we see that the `initLibNvInferPlugins` symbol is undefined in the `libgxf_lstm_tensor_rt_inference_lib.so` library in builds based on 2.6, 2.5, and earlier:
```
$ run build endoscopy_tool_tracking
$ objdump -x path/to/libgxf_lstm_tensor_rt_inference_lib.so | grep
initLibNvInferPlugins
00000000000000      F *UND* 000000000000000    initLibNvInferPlugins
```

Inspecting TensorRT 8.6, we see that `libnvonnxparser.so` depends directly on `libnvinfer_plugin.so` in 8.6, so that the missing `initLibNvInferPlugins` symbol in the GXF extension is resolved transitively on load. By contrast, in TensorRT 10.3 `libnvonnxparser.so` does not depend on `libnvinfer_plugin.so`, resulting in the original error observed above.

Fix verified in x86 HoloHub container based on TensorRT 10.3.