### PR TITLE
explicitly cast cudaError_t to int when logging it

### DIFF
--- a/operators/orsi/orsi_format_converter/format_converter.cpp
+++ b/operators/orsi/orsi_format_converter/format_converter.cpp
@@ -48,7 +48,7 @@
                          __LINE__,                                                              \
                          __FILE__,                                                              \
                          cudaGetErrorString(_holoscan_cuda_err),                                \
-                         _holoscan_cuda_err);                                                   \
+                         static_cast<int>(_holoscan_cuda_err));                                 \
     }                                                                                           \
     _holoscan_cuda_err;                                                                         \
   })

--- a/operators/orsi/orsi_segmentation_preprocessor/segmentation_preprocessor.cpp
+++ b/operators/orsi/orsi_segmentation_preprocessor/segmentation_preprocessor.cpp
@@ -46,7 +46,7 @@
                     __LINE__,                                                              \
                     __FILE__,                                                              \
                     cudaGetErrorString(_holoscan_cuda_err),                                \
-                    _holoscan_cuda_err);                                                   \
+                    static_cast<int>(_holoscan_cuda_err));                                 \
     }                                                                                      \
     _holoscan_cuda_err;                                                                    \
   })

--- a/operators/orsi/orsi_visualizer/lib/vis_orsi.cpp
+++ b/operators/orsi/orsi_visualizer/lib/vis_orsi.cpp
@@ -38,7 +38,7 @@
                          __LINE__,                                                              \
                          __FILE__,                                                              \
                          cudaGetErrorString(_holoscan_cuda_err),                                \
-                         _holoscan_cuda_err);                                                   \
+                         static_cast<int>(_holoscan_cuda_err));                                 \
     }                                                                                           \
     _holoscan_cuda_err;                                                                         \
   })

--- a/operators/qt_video/opengl_renderer.cpp
+++ b/operators/qt_video/opengl_renderer.cpp
@@ -31,7 +31,7 @@
                          __LINE__,                                                            \
                          __FILE__,                                                            \
                          cudaGetErrorString(_holoscan_cuda_err),                              \
-                         _holoscan_cuda_err);                                                 \
+                         static_cast<int>(_holoscan_cuda_err));                               \
     }                                                                                         \
     _holoscan_cuda_err;                                                                       \
   })

--- a/operators/qt_video/qt_video_op.cpp
+++ b/operators/qt_video/qt_video_op.cpp
@@ -31,7 +31,7 @@
                          __LINE__,                                                            \
                          __FILE__,                                                            \
                          cudaGetErrorString(_holoscan_cuda_err),                              \
-                         _holoscan_cuda_err);                                                 \
+                         static_cast<int>(_holoscan_cuda_err));                               \
     }                                                                                         \
     _holoscan_cuda_err;                                                                       \
   })

--- a/operators/velodyne_lidar/cpp/velodyne_convert_xyz.cu
+++ b/operators/velodyne_lidar/cpp/velodyne_convert_xyz.cu
@@ -39,7 +39,7 @@ __constant__ double d_vlp16_cos_pitch[data_collection::sensors::kVLP16LineCount]
                          __LINE__,                                                      \
                          __FILE__,                                                      \
                          cudaGetErrorString(cuda_status),                               \
-                         cuda_status);                                                  \
+                         static_cast<int>(cuda_status));                                \
       throw std::runtime_error("Unable to copy device to host");                        \
     }                                                                                   \
   }

--- a/operators/velodyne_lidar/cpp/velodyne_lidar.cpp
+++ b/operators/velodyne_lidar/cpp/velodyne_lidar.cpp
@@ -33,7 +33,7 @@
                          __LINE__,                                                      \
                          __FILE__,                                                      \
                          cudaGetErrorString(cuda_status),                               \
-                         cuda_status);                                                  \
+                         static_cast<int>(cuda_status));                                \
       throw std::runtime_error("Unable to copy device to host");                        \
     }                                                                                   \
   }


### PR DESCRIPTION
This MR just updates several copies of CUDA macros used in various operators so they will work with newer versions of the {fmt} library.

This was found to be necessary to use fmt v10.1.1 (Holoscan will likely bump to this version in the v2.6 release).