### PR TITLE
cast enums to int for fmt v10 compatibility

### DIFF
--- a/applications/multiai_endoscopy/cpp/post-proc-cpu/multi_ai.cpp
+++ b/applications/multiai_endoscopy/cpp/post-proc-cpu/multi_ai.cpp
@@ -81,8 +81,9 @@ void print_tensor(const std::shared_ptr<holoscan::Tensor>& tensor,
   auto ndim = tensor->ndim();
   auto itemsize = tensor->itemsize();
 
-  HOLOSCAN_LOG_INFO(
-      "device.device_type={}, device.device_id={}", device.device_type, device.device_id);
+  HOLOSCAN_LOG_INFO("device.device_type={}, device.device_id={}",
+                    static_cast<int>(device.device_type),
+                    device.device_id);
   HOLOSCAN_LOG_INFO(
       "dtype.code={}, dtype.bits={}, dtype.lanes={}", dtype.code, dtype.bits, dtype.lanes);
   for (int i = 0; i < shape.size(); ++i) { HOLOSCAN_LOG_INFO("shape[{}]={}", i, shape[i]); }

--- a/applications/multiai_endoscopy/cpp/post-proc-cpu/multi_ai.cpp
+++ b/applications/multiai_endoscopy/cpp/post-proc-cpu/multi_ai.cpp
@@ -42,7 +42,7 @@
                          __LINE__,                                                      \
                          __FILE__,                                                      \
                          cudaGetErrorString(cuda_status),                               \
-                         cuda_status);                                                  \
+                         static_cast<int>(cuda_status));                                \
       throw std::runtime_error("Unable to copy device to host");                        \
     }                                                                                   \
   }

--- a/applications/multiai_endoscopy/cpp/post-proc-matx-cpu/multi_ai.cpp
+++ b/applications/multiai_endoscopy/cpp/post-proc-matx-cpu/multi_ai.cpp
@@ -36,7 +36,7 @@
                          __LINE__,                                                      \
                          __FILE__,                                                      \
                          cudaGetErrorString(cuda_status),                               \
-                         cuda_status);                                                  \
+                         static_cast<int>(cuda_status));                                \
       throw std::runtime_error("Unable to copy device to host");                        \
     }                                                                                   \
   }

--- a/applications/multiai_endoscopy/cpp/post-proc-matx-cpu/multi_ai.cpp
+++ b/applications/multiai_endoscopy/cpp/post-proc-matx-cpu/multi_ai.cpp
@@ -53,8 +53,9 @@ void print_tensor(const std::shared_ptr<holoscan::Tensor>& tensor, size_t n_prin
   auto ndim = tensor->ndim();
   auto itemsize = tensor->itemsize();
 
-  HOLOSCAN_LOG_INFO(
-      "device.device_type={}, device.device_id={}", device.device_type, device.device_id);
+  HOLOSCAN_LOG_INFO("device.device_type={}, device.device_id={}",
+                    static_cast<int>(device.device_type),
+                    device.device_id);
   HOLOSCAN_LOG_INFO(
       "dtype.code={}, dtype.bits={}, dtype.lanes={}", dtype.code, dtype.bits, dtype.lanes);
   for (int i = 0; i < shape.size(); ++i) { HOLOSCAN_LOG_INFO("shape[{}]={}", i, shape[i]); }

--- a/applications/multiai_endoscopy/cpp/post-proc-matx-gpu/multi_ai.cu
+++ b/applications/multiai_endoscopy/cpp/post-proc-matx-gpu/multi_ai.cu
@@ -37,7 +37,7 @@
                          __LINE__,                                                      \
                          __FILE__,                                                      \
                          cudaGetErrorString(cuda_status),                               \
-                         cuda_status);                                                  \
+                         static_cast<int>(cuda_status));                                \
       throw std::runtime_error("Unable to copy device to host");                        \
     }                                                                                   \
   }

--- a/applications/multiai_endoscopy/cpp/post-proc-matx-gpu/multi_ai.cu
+++ b/applications/multiai_endoscopy/cpp/post-proc-matx-gpu/multi_ai.cu
@@ -54,8 +54,9 @@ void print_tensor(const std::shared_ptr<holoscan::Tensor>& tensor, size_t n_prin
   auto ndim = tensor->ndim();
   auto itemsize = tensor->itemsize();
 
-  HOLOSCAN_LOG_INFO(
-      "device.device_type={}, device.device_id={}", device.device_type, device.device_id);
+  HOLOSCAN_LOG_INFO("device.device_type={}, device.device_id={}",
+                    static_cast<int>(device.device_type),
+                    device.device_id);
   HOLOSCAN_LOG_INFO(
       "dtype.code={}, dtype.bits={}, dtype.lanes={}", dtype.code, dtype.bits, dtype.lanes);
   for (int i = 0; i < shape.size(); ++i) { HOLOSCAN_LOG_INFO("shape[{}]={}", i, shape[i]); }

--- a/operators/npp_filter/npp_filter.cpp
+++ b/operators/npp_filter/npp_filter.cpp
@@ -282,7 +282,8 @@ void NppFilterOp::compute(InputContext& op_input, OutputContext& op_output,
     throw std::runtime_error(fmt::format("Unknown filter {}.", filter_.get()));
   }
   if (status != NPP_SUCCESS) {
-    throw std::runtime_error(fmt::format("Filter {} failed with error {}", filter_.get(), status));
+    throw std::runtime_error(
+        fmt::format("Filter {} failed with error {}", filter_.get(), static_cast<int>(status)));
   }
 
   // pass the CUDA stream to the output message

--- a/operators/orsi/orsi_format_converter/format_converter.cpp
+++ b/operators/orsi/orsi_format_converter/format_converter.cpp
@@ -713,8 +713,8 @@ void FormatConverterOp::convertTensorFormat(const void* in_tensor_data, void* ou
                                          scale_max_,
                                          npp_stream_ctx_);
       } else {
-        throw std::runtime_error(
-            fmt::format("Failed to convert channel order (NPP error code: {})", status));
+        throw std::runtime_error(fmt::format("Failed to convert channel order (NPP error code: {})",
+                                             static_cast<int>(status)));
       }
       break;
     }
@@ -737,7 +737,8 @@ void FormatConverterOp::convertTensorFormat(const void* in_tensor_data, void* ou
       status = nppiRGBToYUV420_8u_C3P3R(in_tensor_ptr, src_step, out_yuv_ptrs, out_yuv_steps, roi);
       if (status != NPP_SUCCESS) {
         throw std::runtime_error(
-            fmt::format("rgb888 to yuv420 conversion failed (NPP error code: {})", status));
+            fmt::format("rgb888 to yuv420 conversion failed (NPP error code: {})",
+              static_cast<int>(status)));
       }
       break;
     }
@@ -759,7 +760,8 @@ void FormatConverterOp::convertTensorFormat(const void* in_tensor_data, void* ou
       status = nppiYUV420ToRGB_8u_P3AC4R(in_yuv_ptrs, in_yuv_steps, out_tensor_ptr, dst_step, roi);
       if (status != NPP_SUCCESS) {
         throw std::runtime_error(
-            fmt::format("yuv420 to rgba8888 conversion failed (NPP error code: {})", status));
+            fmt::format("yuv420 to rgba8888 conversion failed (NPP error code: {})",
+                        static_cast<int>(status)));
       }
       break;
     }
@@ -781,7 +783,8 @@ void FormatConverterOp::convertTensorFormat(const void* in_tensor_data, void* ou
       status = nppiYUV420ToRGB_8u_P3C3R(in_yuv_ptrs, in_yuv_steps, out_tensor_ptr, dst_step, roi);
       if (status != NPP_SUCCESS) {
         throw std::runtime_error(
-            fmt::format("yuv420 to rgb888 conversion failed (NPP error code: {})", status));
+            fmt::format("yuv420 to rgb888 conversion failed (NPP error code: {})",
+                        static_cast<int>(status)));
       }
       break;
     }
@@ -800,7 +803,8 @@ void FormatConverterOp::convertTensorFormat(const void* in_tensor_data, void* ou
           nppiNV12ToRGB_709HDTV_8u_P2C3R(in_y_uv_ptrs, in_y_uv_step, out_tensor_ptr, dst_step, roi);
       if (status != NPP_SUCCESS) {
         throw std::runtime_error(
-            fmt::format("NV12 to rgb888 conversion failed (NPP error code: {})", status));
+            fmt::format("NV12 to rgb888 conversion failed (NPP error code: {})",
+                        static_cast<int>(status)));
       }
       break;
     }


### PR DESCRIPTION
This follow up to #514 fixes a few more CUDA_TRY macros that were missed there along with also casting `DLDeviceType` and `NppStatus` enums when logging them.