### PR TITLE
Increase BlockMemoryPool block count for Colonoscopy and Ultrasound segmentation app

### DIFF
--- a/applications/colonoscopy_segmentation/colonoscopy_segmentation.py
+++ b/applications/colonoscopy_segmentation/colonoscopy_segmentation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -99,7 +99,7 @@ class ColonoscopyApp(Application):
         width_preprocessor = 1350
         height_preprocessor = 1072
         preprocessor_block_size = width_preprocessor * height_preprocessor * n_channels * bpp
-        preprocessor_num_blocks = 2
+        preprocessor_num_blocks = 3
         segmentation_preprocessor = FormatConverterOp(
             self,
             name="segmentation_preprocessor",

--- a/applications/ultrasound_segmentation/cpp/main.cpp
+++ b/applications/ultrasound_segmentation/cpp/main.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,7 +69,7 @@ class App : public holoscan::Application {
     int width_preprocessor = 1264;
     int height_preprocessor = 1080;
     uint64_t preprocessor_block_size = width_preprocessor * height_preprocessor * n_channels * bpp;
-    uint64_t preprocessor_num_blocks = 2;
+    uint64_t preprocessor_num_blocks = 3;
     auto segmentation_preprocessor = make_operator<ops::FormatConverterOp>(
         "segmentation_preprocessor",
         from_config("segmentation_preprocessor"),

--- a/applications/ultrasound_segmentation/python/ultrasound_segmentation.py
+++ b/applications/ultrasound_segmentation/python/ultrasound_segmentation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -99,7 +99,7 @@ class UltrasoundApp(Application):
         width_preprocessor = 1264
         height_preprocessor = 1080
         preprocessor_block_size = width_preprocessor * height_preprocessor * n_channels * bpp
-        preprocessor_num_blocks = 2
+        preprocessor_num_blocks = 3
         segmentation_preprocessor = FormatConverterOp(
             self,
             name="segmentation_preprocessor",


### PR DESCRIPTION
To avoid error message when InferenceOp is holding references to input tensor.