### PR TITLE
Fix setup script for runtime container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,11 @@ RUN apt update \
     gobject-introspection \
     libgtk-3-dev \
     libcanberra-gtk-module \
-    graphviz
+    graphviz\
+    ninja-build
+
+RUN pip3 install meson
+
 RUN if ! grep -q "VERSION_ID=\"22.04\"" /etc/os-release; then \
         pip install setuptools; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN apt update \
     graphviz\
     ninja-build
 
-RUN pip3 install meson
+RUN pip install meson
 
 RUN if ! grep -q "VERSION_ID=\"22.04\"" /etc/os-release; then \
         pip install setuptools; \

--- a/run
+++ b/run
@@ -379,10 +379,13 @@ setup() {
      install_cuda_dependencies_package libcudnn8-dev cuda$short_cuda_version
   fi
 
-  # Make sure we do not install any cuda12 packages
-  install_cuda_dependencies_package libnvinfer-dev cuda$short_cuda_version
-  install_cuda_dependencies_package libnvinfer-plugin-dev cuda$short_cuda_version
-  install_cuda_dependencies_package libnvonnxparsers-dev cuda$short_cuda_version
+  # Check the current version of libnvinfer-bin
+  installed_libnvinferbin=$(dpkg --status libnvinfer-bin 2>/dev/null | grep -Po '^Version: \K[^-]*')
+  installed_libnvinferbin_version=${installed_libnvinferbin%.*}
+  install_cuda_dependencies_package libnvinfer-headers-dev $installed_libnvinferbin_version
+  install_cuda_dependencies_package libnvinfer-dev $installed_libnvinferbin_version
+  install_cuda_dependencies_package libnvinfer-plugin-dev $installed_libnvinferbin_version
+  install_cuda_dependencies_package libnvonnxparsers-dev $installed_libnvinferbin_version
 
   # Install the autocomplete
   echo "Installing autocomplete"

--- a/run
+++ b/run
@@ -334,8 +334,8 @@ setup() {
   fi
 
   # git
-  git_version=$(dpkg --status git | grep -Po '^Version: \K[^-]*')
-  if [[ $git_version == "" ]]; then
+  git_path=$(which git)
+  if [[ $git_path == "" ]]; then
     echo "Installing git"
     apt-get install --no-install-recommends -y git
   fi

--- a/run
+++ b/run
@@ -333,6 +333,12 @@ setup() {
     apt-get install --no-install-recommends -y libv4l-dev
   fi
 
+  # git
+  git_version=$(dpkg --status git | grep -Po '^Version: \K[^-]*')
+  if [[ $git_version == "" ]]; then
+    echo "Installing git"
+    apt-get install --no-install-recommends -y git
+  fi
 
   # Install ngc-cli
   ngc_version=$(ngc --version 2>/dev/null | grep -Po '^NGC CLI \K[^-]*')


### PR DESCRIPTION
When using a base image based on Ubuntu 22.04 and installation of Holoscan SDK, some dependencies are missing.