### PR TITLE
Cast output in `XrFrameOp` for `fmt` updates

### DIFF
--- a/operators/XrFrameOp/xr_session.cpp
+++ b/operators/XrFrameOp/xr_session.cpp
@@ -260,7 +260,7 @@ XrSession::PollResult XrSession::poll_events() {
         break;
       case XR_TYPE_EVENT_DATA_REFERENCE_SPACE_CHANGE_PENDING:
       default: {
-        HOLOSCAN_LOG_DEBUG("Ignoring event type %d", event->type);
+        HOLOSCAN_LOG_DEBUG("Ignoring event type %d", static_cast<int>(event->type));
         break;
       }
     }


### PR DESCRIPTION
v2.6.0 will update the underlying `fmt` library from major version 8 to 10, with minor API breakage.

Addresses reported build failure on x86: 4909073