### PR TITLE
Infra: Update host GPU detection logic

### DIFF
--- a/dev_container
+++ b/dev_container
@@ -454,13 +454,14 @@ check_nvidia_ctk() {
 #===============================================================================
 
 get_host_gpu() {
-    if lsmod | grep -q nvidia_drm && command -v nvidia-smi >/dev/null; then
-        echo -n "dgpu"
-    elif lsmod | grep -q nvgpu; then
-        echo -n "igpu"
+    if ! command -v nvidia-smi >/dev/null; then
+        echo "Could not find any GPU drivers on host. Defaulting build to target dGPU/CPU stack."
+        echo -n "dgpu";
+    elif [[ ! $(nvidia-smi --query-gpu=name --format=csv,noheader) ]] || \
+         [[ $(nvidia-smi --query-gpu=name --format=csv,noheader -i 0) =~ "Orin (nvgpu)" ]]; then
+        echo -n "igpu";
     else
-        c_echo_err Y "Could not find any GPU drivers on host. Defaulting build to target dGPU/CPU stack."
-        echo -n "dgpu"
+        echo -n "dgpu";
     fi
 }
 


### PR DESCRIPTION
Updates `dev_container get_host_gpu` to drop reliance on `lsmod` in favor of `nvidia-smi` parsing for dGPU/iGPU detection.

Fixes observed behavior on Jetpack 6.1 (Jetson AGX) and IGX Orin equivalent where `dgpu` was erroneously detected and the wrong base container pulled.

Steps to reproduce:
```
./dev_container get_host_gpu
```
or
```
./dev_container build --verbose
```

Intended to address containerized runtime failures on iGPU system:
```
[checkMacros.cpp::catchCudaError::212] Error Code 1: Cuda Runtime (no kernel image is available for execution on the device)
```

## Testing

Verified with `./dev_container get_host_gpu` on:
- Jetson AGX (Jetpack 6.1)
- IGX Orin iGPU (IGX OS 1.1)
- IGX Orin dGPU (IGX OS 1.0)
- IGX Orin dGPU (IGX OS 1.1)
- x86_64 dGPU

Currently rebuilding on iGPU system to verify fix for Cuda Runtime error noted above.