### PR TITLE
multiai_ultrasound: Fix allocation error when using AJA source

### DIFF
--- a/applications/multiai_ultrasound/python/multiai_ultrasound.py
+++ b/applications/multiai_ultrasound/python/multiai_ultrasound.py
@@ -73,6 +73,8 @@ class MultiAIICardio(Application):
 
         in_dtype = "rgba8888" if is_aja else "rgb888"
         in_components = 4 if is_aja else 3
+        # FormatConverterOp needs an temporary buffer if converting from RGBA
+        format_convert_pool_blocks = 4 if in_components == 4 else 3
         bytes_per_float32 = 4
         plax_cham_pre = FormatConverterOp(
             self,
@@ -83,7 +85,7 @@ class MultiAIICardio(Application):
                 name="plax_cham_pre_pool",
                 storage_type=MemoryStorageType.DEVICE,
                 block_size=320 * 320 * bytes_per_float32 * in_components,
-                num_blocks=3,
+                num_blocks=format_convert_pool_blocks,
             ),
             cuda_stream_pool=cuda_stream_pool,
             **self.kwargs("plax_cham_pre"),
@@ -97,7 +99,7 @@ class MultiAIICardio(Application):
                 name="aortic_ste_pre_pool",
                 storage_type=MemoryStorageType.DEVICE,
                 block_size=300 * 300 * bytes_per_float32 * in_components,
-                num_blocks=3,
+                num_blocks=format_convert_pool_blocks,
             ),
             cuda_stream_pool=cuda_stream_pool,
             **self.kwargs("aortic_ste_pre"),
@@ -111,7 +113,7 @@ class MultiAIICardio(Application):
                 name="b_mode_pers_pre_pool",
                 storage_type=MemoryStorageType.DEVICE,
                 block_size=320 * 240 * bytes_per_float32 * in_components,
-                num_blocks=3,
+                num_blocks=format_convert_pool_blocks,
             ),
             cuda_stream_pool=cuda_stream_pool,
             **self.kwargs("b_mode_pers_pre"),


### PR DESCRIPTION
Use increased block size for FormatConverterOP when input is RGBA instead of RGB because the converter needs to add an additional temporary buffer in that case.