### PR TITLE
Add .viminfo and .lesshst to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ ngc-cli/
 .bash_history
 .python_history
 .wget-hsts
+.viminfo
+.lesshst
 
 .cache/
 .cupy/


### PR DESCRIPTION
These files are created during many developer flows and, with the dev container mounting this Git repo as the home directory, they pollute the Git working tree.