### PR TITLE
Optimize endoscopy tool tracking app

### DIFF
--- a/applications/endoscopy_tool_tracking_distributed/cpp/main.cpp
+++ b/applications/endoscopy_tool_tracking_distributed/cpp/main.cpp
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights
- * reserved. SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,8 +92,7 @@ class CloudInferenceFragment : public holoscan::Fragment {
     // use UnboundedAllocator for now.
     auto tool_tracking_postprocessor = make_operator<ops::ToolTrackingPostprocessorOp>(
         "tool_tracking_postprocessor",
-        Arg("device_allocator") = make_resource<UnboundedAllocator>("device_allocator"),
-        Arg("host_allocator") = make_resource<UnboundedAllocator>("host_allocator"));
+        Arg("device_allocator") = make_resource<UnboundedAllocator>("device_allocator"));
 
     add_flow(format_converter, lstm_inferer);
     add_flow(lstm_inferer, tool_tracking_postprocessor, {{"tensor", "in"}});
@@ -139,10 +138,7 @@ class App : public holoscan::Application {
 
     // Flow definition
     add_flow(video_in, cloud_inference, {{"replayer", "format_converter"}});
-    add_flow(cloud_inference,
-             viz,
-             {{"tool_tracking_postprocessor.out_coords", "holoviz.receivers"},
-              {"tool_tracking_postprocessor.out_mask", "holoviz.receivers"}});
+    add_flow(cloud_inference, viz, {{"tool_tracking_postprocessor.out", "holoviz.receivers"}});
 
     add_flow(video_in, viz, {{"replayer.output", "holoviz.receivers"}});
   }

--- a/applications/endoscopy_tool_tracking_distributed/python/cloud_inference_fragment.py
+++ b/applications/endoscopy_tool_tracking_distributed/python/cloud_inference_fragment.py
@@ -98,7 +98,6 @@ class CloudInferenceFragment(Fragment):
                 self,
                 name="device_allocator",
             ),
-            host_allocator=UnboundedAllocator(self, name="host_allocator"),
         )
 
         self.add_flow(format_converter, lstm_inferer)

--- a/applications/endoscopy_tool_tracking_distributed/python/endoscopy_tool_tracking.py
+++ b/applications/endoscopy_tool_tracking_distributed/python/endoscopy_tool_tracking.py
@@ -72,10 +72,7 @@ class EndoscopyApp(Application):
         self.add_flow(
             inference_fragment,
             viz_fragment,
-            {
-                ("tool_tracking_postprocessor.out_coords", "holoviz.receivers"),
-                ("tool_tracking_postprocessor.out_mask", "holoviz.receivers"),
-            },
+            {("tool_tracking_postprocessor.out", "holoviz.receivers")},
         )
 
         self.add_flow(

--- a/applications/h264/h264_endoscopy_tool_tracking/cpp/main.cpp
+++ b/applications/h264/h264_endoscopy_tool_tracking/cpp/main.cpp
@@ -181,8 +181,7 @@ class App : public holoscan::Application {
     auto tool_tracking_postprocessor = make_operator<ops::ToolTrackingPostprocessorOp>(
         "tool_tracking_postprocessor",
         from_config("tool_tracking_postprocessor"),
-        Arg("device_allocator") = make_resource<UnboundedAllocator>("device_allocator"),
-        Arg("host_allocator") = make_resource<UnboundedAllocator>("host_allocator"));
+        Arg("device_allocator") = make_resource<UnboundedAllocator>("device_allocator"));
 
     const bool record_output = from_config("record_output").as<bool>();
 
@@ -206,9 +205,7 @@ class App : public holoscan::Application {
         decoder_output_format_converter, rgb_float_format_converter, {{"tensor", "source_video"}});
     add_flow(rgb_float_format_converter, lstm_inferer);
     add_flow(lstm_inferer, tool_tracking_postprocessor, {{"tensor", "in"}});
-    add_flow(tool_tracking_postprocessor,
-             visualizer,
-             {{"out_coords", "receivers"}, {"out_mask", "receivers"}});
+    add_flow(tool_tracking_postprocessor, visualizer, {{"out", "receivers"}});
 
     if (record_output) {
       auto encoder_async_condition =

--- a/applications/h264/h264_endoscopy_tool_tracking/python/h264_endoscopy_tool_tracking.py
+++ b/applications/h264/h264_endoscopy_tool_tracking/python/h264_endoscopy_tool_tracking.py
@@ -247,7 +247,6 @@ class EndoscopyApp(Application):
             self,
             name="tool_tracking_postprocessor",
             device_allocator=UnboundedAllocator(self, "device_allocator"),
-            host_allocator=UnboundedAllocator(self, "host_allocator"),
             **self.kwargs("tool_tracking_postprocessor"),
         )
 
@@ -287,11 +286,7 @@ class EndoscopyApp(Application):
         )
         self.add_flow(rgb_float_format_converter, lstm_inferer)
         self.add_flow(lstm_inferer, tool_tracking_postprocessor, {("tensor", "in")})
-        self.add_flow(
-            tool_tracking_postprocessor,
-            visualizer,
-            {("out_coords", "receivers"), ("out_mask", "receivers")},
-        )
+        self.add_flow(tool_tracking_postprocessor, visualizer, {("out", "receivers")})
 
         if record_output:
             encoder_async_condition = AsynchronousCondition(self, "encoder_async_condition")

--- a/gxf_extensions/lstm_tensor_rt_inference/tensor_rt_inference.cpp
+++ b/gxf_extensions/lstm_tensor_rt_inference/tensor_rt_inference.cpp
@@ -289,12 +289,6 @@ gxf_result_t TensorRtInference::registerInterface(gxf::Registrar* registrar) {
                                  "Relaxed Dimension Check",
                                  "Ignore dimensions of 1 for input tensor dimension check.",
                                  true);
-  result &= registrar->parameter(clock_,
-                                 "clock",
-                                 "Clock",
-                                 "Instance of clock for publish time.",
-                                 gxf::Registrar::NoDefaultParameter(),
-                                 GXF_PARAMETER_FLAGS_OPTIONAL);
 
   result &= registrar->parameter(rx_, "rx", "RX", "List of receivers to take input tensors");
   result &= registrar->parameter(tx_, "tx", "TX", "Transmitter to publish output tensors");

--- a/gxf_extensions/lstm_tensor_rt_inference/tensor_rt_inference.hpp
+++ b/gxf_extensions/lstm_tensor_rt_inference/tensor_rt_inference.hpp
@@ -32,7 +32,6 @@
 #include "gxf/cuda/cuda_stream.hpp"
 #include "gxf/cuda/cuda_stream_pool.hpp"
 #include "gxf/std/allocator.hpp"
-#include "gxf/std/clock.hpp"
 #include "gxf/std/codelet.hpp"
 #include "gxf/std/receiver.hpp"
 #include "gxf/std/tensor.hpp"
@@ -110,12 +109,11 @@ class TensorRtInference : public gxf::Codelet {
   gxf::Parameter<gxf::Handle<gxf::Allocator>> pool_;
   gxf::Parameter<gxf::Handle<gxf::CudaStreamPool>> cuda_stream_pool_;
   gxf::Parameter<int64_t> max_workspace_size_;
-  gxf::Parameter<int64_t> dla_core_;
+  gxf::Parameter<int32_t> dla_core_;
   gxf::Parameter<int32_t> max_batch_size_;
   gxf::Parameter<bool> enable_fp16_;
   gxf::Parameter<bool> relaxed_dimension_check_;
   gxf::Parameter<bool> verbose_;
-  gxf::Parameter<gxf::Handle<gxf::Clock>> clock_;
 
   gxf::Parameter<std::vector<gxf::Handle<gxf::Receiver>>> rx_;
   gxf::Parameter<gxf::Handle<gxf::Transmitter>> tx_;

--- a/operators/lstm_tensor_rt_inference/README.md
+++ b/operators/lstm_tensor_rt_inference/README.md
@@ -38,7 +38,7 @@ This implementation is based on `nvidia::gxf::TensorRtInference`.
 - **`max_workspace_size`**: Size of working space in bytes (default: `67108864l` (64MB))
   - type: `int64_t`
 - **`dla_core`**: DLA Core to use. Fallback to GPU is always enabled. Default to use GPU only (`optional`)
-  - type: `int64_t`
+  - type: `int32_t`
 - **`max_batch_size`**: Maximum possible batch size in case the first dimension is dynamic and used as batch size (default: `1`)
   - type: `int32_t`
 - **`enable_fp16_`**: Enable inference with FP16 and FP32 fallback (default: `false`)
@@ -47,8 +47,6 @@ This implementation is based on `nvidia::gxf::TensorRtInference`.
   - type: `bool`
 - **`relaxed_dimension_check`**: Ignore dimensions of 1 for input tensor dimension check (default: `true`)
   - type: `bool`
-- **`clock`**: Instance of clock for publish time (`optional`)
-  - type: `gxf::Handle<gxf::Clock>`
 - **`rx`**: List of receivers to take input tensors
   - type: `std::vector<gxf::Handle<gxf::Receiver>>`
 - **`tx`**: Transmitter to publish output tensors

--- a/operators/lstm_tensor_rt_inference/lstm_tensor_rt_inference.cpp
+++ b/operators/lstm_tensor_rt_inference/lstm_tensor_rt_inference.cpp
@@ -94,7 +94,8 @@ void LSTMTensorRTInferenceOp::setup(OperatorSpec& spec) {
              "dla_core",
              "DLA Core",
              "DLA Core to use. Fallback to GPU is always enabled. "
-             "Default to use GPU only.");
+             "Default to use GPU only.",
+             ParameterFlag::kOptional);
   spec.param(max_batch_size_,
              "max_batch_size",
              "Max Batch Size",
@@ -117,7 +118,6 @@ void LSTMTensorRTInferenceOp::setup(OperatorSpec& spec) {
              "Relaxed Dimension Check",
              "Ignore dimensions of 1 for input tensor dimension check.",
              true);
-  spec.param(clock_, "clock", "Clock", "Instance of clock for publish time.");
 
   spec.param(rx_, "rx", "RX", "List of receivers to take input tensors", {&in_tensor});
   spec.param(tx_, "tx", "TX", "Transmitter to publish output tensors", &out_tensor);

--- a/operators/lstm_tensor_rt_inference/lstm_tensor_rt_inference.hpp
+++ b/operators/lstm_tensor_rt_inference/lstm_tensor_rt_inference.hpp
@@ -58,12 +58,11 @@ class LSTMTensorRTInferenceOp : public holoscan::ops::GXFOperator {
   Parameter<std::shared_ptr<Allocator>> pool_;
   Parameter<std::shared_ptr<CudaStreamPool>> cuda_stream_pool_;
   Parameter<int64_t> max_workspace_size_;
-  Parameter<int64_t> dla_core_;
+  Parameter<int32_t> dla_core_;
   Parameter<int32_t> max_batch_size_;
   Parameter<bool> enable_fp16_;
   Parameter<bool> relaxed_dimension_check_;
   Parameter<bool> verbose_;
-  Parameter<std::shared_ptr<Resource>> clock_;
 
   Parameter<std::vector<IOSpec*>> rx_;
   Parameter<IOSpec*> tx_;

--- a/operators/lstm_tensor_rt_inference/python/lstm_tensor_rt_inference.cpp
+++ b/operators/lstm_tensor_rt_inference/python/lstm_tensor_rt_inference.cpp
@@ -25,11 +25,11 @@
 #include <memory>
 #include <string>
 
-#include "../../operator_util.hpp"
 #include <holoscan/core/fragment.hpp>
 #include <holoscan/core/operator.hpp>
 #include <holoscan/core/operator_spec.hpp>
 #include <holoscan/core/resources/gxf/allocator.hpp>
+#include "../../operator_util.hpp"
 #include "holoscan/core/resources/gxf/cuda_stream_pool.hpp"
 
 using std::string_literals::operator""s;
@@ -63,11 +63,8 @@ class PyLSTMTensorRTInferenceOp : public LSTMTensorRTInferenceOp {
       const std::vector<std::string>& output_tensor_names,
       const std::vector<std::string>& input_binding_names,
       const std::vector<std::string>& output_binding_names, const std::string& model_file_path,
-      const std::string& engine_cache_dir,
-      // int64_t dla_core,
-      std::shared_ptr<holoscan::Allocator> pool,
-      std::shared_ptr<holoscan::CudaStreamPool> cuda_stream_pool,
-      // std::shared_ptr<holoscan::Resource> clock,
+      const std::string& engine_cache_dir, std::shared_ptr<holoscan::Allocator> pool,
+      std::shared_ptr<holoscan::CudaStreamPool> cuda_stream_pool, std::optional<int32_t> dla_core,
       const std::string& plugins_lib_namespace = "",
       const std::vector<std::string>& input_state_tensor_names = std::vector<std::string>{},
       const std::vector<std::string>& output_state_tensor_names = std::vector<std::string>{},
@@ -80,10 +77,8 @@ class PyLSTMTensorRTInferenceOp : public LSTMTensorRTInferenceOp {
                                         Arg{"output_binding_names", output_binding_names},
                                         Arg{"model_file_path", model_file_path},
                                         Arg{"engine_cache_dir", engine_cache_dir},
-                                        // Arg{"dla_core", dla_core},
                                         Arg{"pool", pool},
                                         Arg{"cuda_stream_pool", cuda_stream_pool},
-                                        // Arg{"clock", clock},
                                         Arg{"plugins_lib_namespace", plugins_lib_namespace},
                                         Arg{"input_state_tensor_names", input_state_tensor_names},
                                         Arg{"output_state_tensor_names", output_state_tensor_names},
@@ -93,6 +88,7 @@ class PyLSTMTensorRTInferenceOp : public LSTMTensorRTInferenceOp {
                                         Arg{"relaxed_dimension_check", relaxed_dimension_check},
                                         Arg{"max_workspace_size", max_workspace_size},
                                         Arg{"max_batch_size", max_batch_size}}) {
+    if (dla_core.has_value()) { add_arg(Arg{"dla_core", dla_core.value()}); }
     add_positional_condition_and_resource_args(this, args);
     name_ = name;
     fragment_ = fragment;
@@ -131,10 +127,9 @@ PYBIND11_MODULE(_lstm_tensor_rt_inference, m) {
                     const std::vector<std::string>&,
                     const std::string&,
                     const std::string&,
-                    // int64_t,  // dla_core
                     std::shared_ptr<holoscan::Allocator>,
                     std::shared_ptr<holoscan::CudaStreamPool>,
-                    // std::shared_ptr<holoscan::Resource>,  // clock
+                    std::optional<int32_t>,
                     const std::string&,
                     const std::vector<std::string>&,
                     const std::vector<std::string>&,
@@ -152,10 +147,9 @@ PYBIND11_MODULE(_lstm_tensor_rt_inference, m) {
            "output_binding_names"_a,
            "model_file_path"_a,
            "engine_cache_dir"_a,
-           // "dla_core"_a,
            "pool"_a,
            "cuda_stream_pool"_a,
-           // "clock"_a,
+           "dla_core"_a = py::none(),
            "plugins_lib_namespace"_a = "",
            "input_state_tensor_names"_a = std::vector<std::string>{},
            "output_state_tensor_names"_a = std::vector<std::string>{},

--- a/operators/tool_tracking_postprocessor/CMakeLists.txt
+++ b/operators/tool_tracking_postprocessor/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2034 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/operators/tool_tracking_postprocessor/CMakeLists.txt
+++ b/operators/tool_tracking_postprocessor/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2034 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 cmake_minimum_required(VERSION 3.20)
+
 project(tool_tracking_postprocessor LANGUAGES CXX CUDA)
 
 find_package(holoscan REQUIRED CONFIG
@@ -25,10 +26,21 @@ add_library(tool_tracking_postprocessor SHARED
   tool_tracking_postprocessor.cuh
   )
 
-set_target_properties(tool_tracking_postprocessor PROPERTIES CUDA_ARCHITECTURES "70;80")
+set_target_properties(tool_tracking_postprocessor
+  PROPERTIES
+    # separable compilation is required since we launch kernels from within kernels
+    CUDA_SEPARABLE_COMPILATION ON
+  )
 
-target_link_libraries(tool_tracking_postprocessor holoscan::core)
-target_include_directories(tool_tracking_postprocessor INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(tool_tracking_postprocessor
+  PUBLIC
+    holoscan::core
+  )
+
+target_include_directories(tool_tracking_postprocessor
+  INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+  )
 
 if(HOLOHUB_BUILD_PYTHON)
     add_subdirectory(python)

--- a/operators/tool_tracking_postprocessor/README.md
+++ b/operators/tool_tracking_postprocessor/README.md
@@ -17,8 +17,6 @@ Tool tracking postprocessor codelet
   - type: `float`
 - **`overlay_img_colors`**: Color of the image overlays, a list of RGB values with components between 0 and 1, (default: 12 qualitative classes color scheme from colorbrewer2)
   - type: `std::vector<std::vector<float>>`
-- **`host_allocator`**: Output Allocator
-  - type: `gxf::Handle<gxf::Allocator>`
 - **`device_allocator`**: Output Allocator
   - type: `gxf::Handle<gxf::Allocator>`
 - **`cuda_stream_pool`**: Instance of gxf::CudaStreamPool

--- a/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor.cpp
+++ b/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor.cpp
@@ -73,12 +73,11 @@ class PyToolTrackingPostprocessorOp : public ToolTrackingPostprocessorOp {
   // Define a constructor that fully initializes the object.
   PyToolTrackingPostprocessorOp(
       Fragment* fragment, const py::args& args, std::shared_ptr<Allocator> device_allocator,
-      std::shared_ptr<Allocator> host_allocator, float min_prob = 0.5f,
+      float min_prob = 0.5f,
       std::vector<std::vector<float>> overlay_img_colors = VIZ_TOOL_DEFAULT_COLORS,
       std::shared_ptr<holoscan::CudaStreamPool> cuda_stream_pool = nullptr,
       const std::string& name = "tool_tracking_postprocessor")
       : ToolTrackingPostprocessorOp(ArgList{Arg{"device_allocator", device_allocator},
-                                            Arg{"host_allocator", host_allocator},
                                             Arg{"min_prob", min_prob},
                                             Arg{"overlay_img_colors", overlay_img_colors}}) {
     if (cuda_stream_pool) { this->add_arg(Arg{"cuda_stream_pool", cuda_stream_pool}); }
@@ -116,14 +115,12 @@ PYBIND11_MODULE(_tool_tracking_postprocessor, m) {
       .def(py::init<Fragment*,
                     const py::args&,
                     std::shared_ptr<Allocator>,
-                    std::shared_ptr<Allocator>,
                     float,
                     std::vector<std::vector<float>>,
                     std::shared_ptr<holoscan::CudaStreamPool>,
                     const std::string&>(),
            "fragment"_a,
            "device_allocator"_a,
-           "host_allocator"_a,
            "min_prob"_a = 0.5f,
            "overlay_img_colors"_a = VIZ_TOOL_DEFAULT_COLORS,
            "cuda_stream_pool"_a = py::none(),

--- a/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor_pydoc.hpp
+++ b/operators/tool_tracking_postprocessor/python/tool_tracking_postprocessor_pydoc.hpp
@@ -39,11 +39,8 @@ Operator performing post-processing for the endoscopy tool tracking demo.
 
 **==Named Outputs==**
 
-    out_coords : nvidia::gxf::Tensor
-        Coordinates tensor, stored on the host (CPU).
-
-    out_mask : nvidia::gxf::Tensor
-        Binary mask tensor, stored on device (GPU).
+    out : nvidia::gxf::Tensor
+        Binary mask and coordinates tensor, stored on the device (GPU).
 
 Parameters
 ----------
@@ -51,8 +48,6 @@ fragment : Fragment
     The fragment that the operator belongs to.
 device_allocator : ``holoscan.resources.Allocator``
     Output allocator used on the device side.
-host_allocator : ``holoscan.resources.Allocator``
-    Output allocator used on the host side.
 min_prob : float, optional
     Minimum probability (in range [0, 1]). Default value is 0.5.
 overlay_img_colors : sequence of sequence of float, optional

--- a/operators/tool_tracking_postprocessor/tool_tracking_postprocessor.cu
+++ b/operators/tool_tracking_postprocessor/tool_tracking_postprocessor.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,16 +20,20 @@
 #include "tool_tracking_postprocessor.cuh"
 
 namespace holoscan::ops {
-namespace tool_tracking_postprocessor {
 
-__global__ void postprocessing_kernel(uint32_t width, uint32_t height, const float3 color,
-                                      bool first, const float* input, float4* output) {
+static __device__ __host__ uint32_t ceil_div(uint32_t numerator, uint32_t denominator) {
+  return (numerator + denominator - 1) / denominator;
+}
+
+__global__ void filter_binary_mask_kernel(uint32_t width, uint32_t height, uint32_t index,
+                                          const float3* colors, const float* binary_mask,
+                                          float4* colored_mask) {
   const uint32_t x = blockIdx.x * blockDim.x + threadIdx.x;
   const uint32_t y = blockIdx.y * blockDim.y + threadIdx.y;
 
   if ((x >= width) || (y >= height)) { return; }
 
-  float value = input[y * width + x];
+  float value = binary_mask[((index * height) + y) * width + x];
 
   const float minV = 0.3f;
   const float maxV = 0.99f;
@@ -39,25 +43,57 @@ __global__ void postprocessing_kernel(uint32_t width, uint32_t height, const flo
   value /= range;
   value *= 0.7f;
 
-  const float4 dst = first ? make_float4(0.f, 0.f, 0.f, 0.f) : output[y * width + x];
-  output[y * width + x] = make_float4((1.0f - value) * dst.x + color.x * value,
-                                      (1.0f - value) * dst.y + color.y * value,
-                                      (1.0f - value) * dst.z + color.z * value,
-                                      (1.0f - value) * dst.w + 1.f * value);
+  const float4 dst = colored_mask[y * width + x];
+  colored_mask[y * width + x] = make_float4((1.0f - value) * dst.x + colors[index].x * value,
+                                            (1.0f - value) * dst.y + colors[index].y * value,
+                                            (1.0f - value) * dst.z + colors[index].z * value,
+                                            (1.0f - value) * dst.w + 1.f * value);
 }
 
-uint16_t ceil_div(uint16_t numerator, uint16_t denominator) {
-  uint32_t accumulator = numerator + denominator - 1;
-  return accumulator / denominator;
+__global__ void filter_coordinates_kernel(uint32_t count, float min_prob, const float* probs,
+                                          const float2* scaled_coords,
+                                          float3* filtered_scaled_coords, uint32_t width,
+                                          uint32_t height, const float3* colors,
+                                          const float* binary_mask, float4* colored_mask) {
+  const uint32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  // the third component of the coordinate is the size of the crosses and the text
+  constexpr float ITEM_SIZE = 0.05f;
+
+  if (index > count) { return; }
+
+  // check if the probability meets the minimum probability
+  if (probs[index] > min_prob) {
+    filtered_scaled_coords[index] =
+        make_float3(scaled_coords[index].x, scaled_coords[index].y, ITEM_SIZE);
+    // add the binary mask to the result only if probabiliy is met
+    const dim3 block(32, 32, 1);
+    const dim3 grid(ceil_div(width, block.x), ceil_div(height, block.y), 1);
+    filter_binary_mask_kernel<<<grid, block>>>(
+        width, height, index, colors, binary_mask, colored_mask);
+  } else {
+    // move outside of the screen
+    filtered_scaled_coords[index] = make_float3(-1.f, -1.f, ITEM_SIZE);
+  }
+}
+void cuda_postprocess(uint32_t count, float min_prob, const float* probs,
+                      const float2* scaled_coords, float3* filtered_scaled_coords, uint32_t width,
+                      uint32_t height, const float3* colors, const float* binary_mask,
+                      float4* colored_mask, cudaStream_t cuda_stream) {
+  // initialize the output mask to zero
+  CUDA_TRY(cudaMemsetAsync(colored_mask, 0, width * height * sizeof(float4)));
+
+  const dim3 block(32, 1, 1);
+  const dim3 grid(ceil_div(count, block.x), 1, 1);
+  filter_coordinates_kernel<<<grid, block, 0, cuda_stream>>>(count,
+                                                             min_prob,
+                                                             probs,
+                                                             scaled_coords,
+                                                             filtered_scaled_coords,
+                                                             width,
+                                                             height,
+                                                             colors,
+                                                             binary_mask,
+                                                             colored_mask);
 }
 
-void cuda_postprocess(uint32_t width, uint32_t height, const std::array<float, 3>& color,
-                      bool first, const float* input, float4* output, cudaStream_t cuda_stream) {
-  const dim3 block(32, 32, 1);
-  const dim3 grid(ceil_div(width, block.x), ceil_div(height, block.y), 1);
-  postprocessing_kernel<<<grid, block, 0, cuda_stream>>>(
-      width, height, make_float3(color[0], color[1], color[2]), first, input, output);
-}
-
-}  // namespace tool_tracking_postprocessor
 }  // namespace holoscan::ops

--- a/operators/tool_tracking_postprocessor/tool_tracking_postprocessor.cuh
+++ b/operators/tool_tracking_postprocessor/tool_tracking_postprocessor.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,11 +20,27 @@
 #include <array>
 #include <cstdint>
 
+#include <holoscan/logger/logger.hpp>
+
+#define CUDA_TRY(stmt)                                                                        \
+  ({                                                                                          \
+    cudaError_t _holoscan_cuda_err = stmt;                                                    \
+    if (cudaSuccess != _holoscan_cuda_err) {                                                  \
+      HOLOSCAN_LOG_ERROR("CUDA Runtime call {} in line {} of file {} failed with '{}' ({}).", \
+                         #stmt,                                                               \
+                         __LINE__,                                                            \
+                         __FILE__,                                                            \
+                         cudaGetErrorString(_holoscan_cuda_err),                              \
+                         static_cast<int>(_holoscan_cuda_err));                               \
+    }                                                                                         \
+    _holoscan_cuda_err;                                                                       \
+  })
+
 namespace holoscan::ops {
-namespace tool_tracking_postprocessor {
 
-void cuda_postprocess(uint32_t width, uint32_t height, const std::array<float, 3>& color,
-                      bool first, const float* input, float4* output, cudaStream_t cuda_stream);
+void cuda_postprocess(uint32_t count, float min_prob, const float* probs,
+                      const float2* scaled_coords, float3* filtered_scaled_coords, uint32_t width,
+                      uint32_t height, const float3 *colors, const float* binary_mask,
+                      float4* colored_mask, cudaStream_t cuda_stream);
 
-}  // namespace tool_tracking_postprocessor
 }  // namespace holoscan::ops

--- a/operators/tool_tracking_postprocessor/tool_tracking_postprocessor.hpp
+++ b/operators/tool_tracking_postprocessor/tool_tracking_postprocessor.hpp
@@ -22,8 +22,6 @@
 #include <string>
 #include <vector>
 
-#include "tool_tracking_postprocessor.cuh"
-
 #include "holoscan/core/gxf/gxf_operator.hpp"
 #include "holoscan/utils/cuda_stream_handler.hpp"
 
@@ -41,18 +39,13 @@ namespace holoscan::ops {
  *
  * ==Named Outputs==
  *
- * - **out_coords** : `nvidia::gxf::Tensor`
- *   - Coordinates tensor, stored on the host (CPU).
- *
- * - **out_mask** : `nvidia::gxf::Tensor`
- *   - Binary mask tensor, stored on device (GPU).
+ * - **out** : `nvidia::gxf::Tensor`
+ *   - Binary mask and coordinates tensor, stored on the device (GPU).
  *
  * ==Parameters==
  *
- * - **host_allocator**: The holoscan::Allocator class (e.g. UnboundedAllocator) use for host
- *   memory allocation of the `out_coords` tensor.
  * - **device_allocator**: The holoscan::Allocator class (e.g. UnboundedAllocator or
- *   BlockMemoryPool) used for device memory allocation for the `out_mask` tensor.
+ *   BlockMemoryPool) used for device memory allocation for the output tensors.
  * - **min_prob**: Minimum probability threshold used by the operator.
  *   Optional (default: 0.5).
  * - **overlay_img_colors**: A `vector<vector<float>>` where each inner vector is a set of three
@@ -68,21 +61,23 @@ class ToolTrackingPostprocessorOp : public holoscan::Operator {
   ToolTrackingPostprocessorOp() = default;
 
   void setup(OperatorSpec& spec) override;
+  void stop() override;
   void compute(InputContext& op_input, OutputContext& op_output,
                ExecutionContext& context) override;
 
  private:
   Parameter<holoscan::IOSpec*> in_;
-  Parameter<holoscan::IOSpec*> out_coords_;
-  Parameter<holoscan::IOSpec*> out_mask_;
+  Parameter<holoscan::IOSpec*> out_;
 
   Parameter<float> min_prob_;
   Parameter<std::vector<std::vector<float>>> overlay_img_colors_;
 
-  Parameter<std::shared_ptr<Allocator>> host_allocator_;
   Parameter<std::shared_ptr<Allocator>> device_allocator_;
 
   CudaStreamHandler cuda_stream_handler_;
+
+  uint32_t num_colors_ = 0;
+  void *dev_colors_ = nullptr;
 };
 
 }  // namespace holoscan::ops

--- a/operators/vtk_renderer/vtk_renderer.cpp
+++ b/operators/vtk_renderer/vtk_renderer.cpp
@@ -145,11 +145,11 @@ void VtkRendererOp::compute(InputContext& op_input, OutputContext&, ExecutionCon
 
     this->internals->foreground_renderer->RemoveAllViewProps();
 
-    // scale_coords comes in the format [X0 Y0 X1 Y1 ... Xn Yn]
+    // scale_coords comes in the format [X0 Y0 S0 X1 Y1 S1 ... Xn Yn Sn]
     // each numbered tuple represent a label (scissors, clipper...)
-    for (int i = 0; i < scaled_coords.size(); i += 2) {
+    for (int i = 0; i < scaled_coords.size(); i += 3) {
       if (scaled_coords[i] > 0) {
-        std::string label = labels.get()[i / 2];
+        std::string label = labels.get()[i / 3];
         float x = scaled_coords[i];
         float y = scaled_coords[i + 1];
         render_text_at_location(label, x, y, this->internals->foreground_renderer);


### PR DESCRIPTION
Optimize endoscopy tool tracking app

Modify ToolTrackingPostProcessorOp to generate coordinates using
CUDA. This avoids the roundtrip from GPU to CPU memory and back.

Use RMMAllocator for video replayer.

Fix type  of `dla_core` parameter of TensorRtInference.

Remove unused `clock` parameter.

Use single `out` port instead of `out_coords` and `out_mask` since
both outputs are now in device memory.

Latency measured with flow benchmarking on x86 with RTX 6000 Ada
and replayer `realtime`set to `false`:
before optimization 4.8 ms, after optimization 3.09 ms.