### PR TITLE
Benchmark: Fixup for EBS flow tracking in Python apps

### DIFF
--- a/benchmarks/holoscan_flow_benchmarking/benchmarked_application.py
+++ b/benchmarks/holoscan_flow_benchmarking/benchmarked_application.py
@@ -43,7 +43,7 @@ class BenchmarkedApplication(Application):
                 check_recession_period_ms=0,
                 max_duration_ms=100000,
             )
-        elif scheduler_str and scheduler_str == "multithread":
+        elif scheduler_str and scheduler_str == "eventbased":
             num_threads = os.environ.get("HOLOSCAN_EVENTBASED_WORKER_THREADS", None)
             scheduler = EventBasedScheduler(
                 self,


### PR DESCRIPTION
Small fix for event-based scheduler tracking in Python apps to match expected argument string in `benchmark.py` or C++ `benchmark.hpp`.

Under previous behavior, setting `HOLOSCAN_SCHEDULER=eventbased` would use `EventBasedScheduler` for C++ apps but would fall back to `GreedyScheduler` for Python apps.