### PR TITLE
Infra: Bump containers for Holoscan SDK v2.6.0 release

### DIFF
--- a/dev_container
+++ b/dev_container
@@ -466,11 +466,11 @@ get_host_gpu() {
 }
 
 get_default_base_img() {
-    echo -n "nvcr.io/nvidia/clara-holoscan/holoscan:v2.5.0-"$(get_host_gpu)
+    echo -n "nvcr.io/nvidia/clara-holoscan/holoscan:v2.6.0-"$(get_host_gpu)
 }
 
 get_default_img() {
-    echo -n "holohub:ngc-v2.5.0-"$(get_host_gpu)
+    echo -n "holohub:ngc-v2.6.0-"$(get_host_gpu)
 }
 
 # This function returns the compute capacity of the system's GPU (8.6, 8.9, etc.)


### PR DESCRIPTION
Bumps `dev_container` base container tags to Holoscan SDK v2.6.0