### PR TITLE
App: H264 metadata updates

### DIFF
--- a/applications/h264/h264_endoscopy_tool_tracking/README.md
+++ b/applications/h264/h264_endoscopy_tool_tracking/README.md
@@ -31,10 +31,10 @@ The data is automatically downloaded when building the application.
 
 ```bash
 # C++ version
-./dev_container build_and_run h264_endoscopy_tool_tracking --docker_file applications/h264/Dockerfile --language cpp
+./dev_container build_and_run h264_endoscopy_tool_tracking --language cpp
 
 # Python version
-./dev_container build_and_run h264_endoscopy_tool_tracking --docker_file applications/h264/Dockerfile --language python
+./dev_container build_and_run h264_endoscopy_tool_tracking --language python
 ```
 
 Important: on aarch64, applications also need tegra folder mounted inside the container and

--- a/applications/h264/h264_endoscopy_tool_tracking/cpp/metadata.json
+++ b/applications/h264/h264_endoscopy_tool_tracking/cpp/metadata.json
@@ -14,6 +14,7 @@
       "2.0": "Upgrade to GXF 4.0",
       "2.1": "Import h.264 GXF Codelets/Components as Holoscan Operators/Resources"
     },
+    "dockerfile": "applications/h264/Dockerfile",
     "holoscan_sdk": {
       "minimum_required_version": "2.6.0",
       "tested_versions": ["2.6.0"]

--- a/applications/h264/h264_endoscopy_tool_tracking/cpp/metadata.json
+++ b/applications/h264/h264_endoscopy_tool_tracking/cpp/metadata.json
@@ -15,8 +15,8 @@
       "2.1": "Import h.264 GXF Codelets/Components as Holoscan Operators/Resources"
     },
     "holoscan_sdk": {
-      "minimum_required_version": "2.1.0",
-      "tested_versions": ["2.1.0"]
+      "minimum_required_version": "2.6.0",
+      "tested_versions": ["2.6.0"]
     },
     "platforms": ["amd64", "arm64"],
     "tags": ["Endoscopy", "Video Decoding", "Video Encoding"],

--- a/applications/h264/h264_endoscopy_tool_tracking/python/metadata.json
+++ b/applications/h264/h264_endoscopy_tool_tracking/python/metadata.json
@@ -13,8 +13,8 @@
       "1.0": "Initial Release"
     },
     "holoscan_sdk": {
-      "minimum_required_version": "2.1.0",
-      "tested_versions": ["2.1.0"]
+      "minimum_required_version": "2.6.0",
+      "tested_versions": ["2.6.0"]
     },
     "platforms": ["amd64", "arm64"],
     "tags": ["Endoscopy", "Video Decoding", "Video Encoding"],

--- a/applications/h264/h264_endoscopy_tool_tracking/python/metadata.json
+++ b/applications/h264/h264_endoscopy_tool_tracking/python/metadata.json
@@ -12,6 +12,7 @@
     "changelog": {
       "1.0": "Initial Release"
     },
+    "dockerfile": "applications/h264/Dockerfile",
     "holoscan_sdk": {
       "minimum_required_version": "2.6.0",
       "tested_versions": ["2.6.0"]

--- a/applications/h264/h264_endoscopy_tool_tracking_distributed/README.md
+++ b/applications/h264/h264_endoscopy_tool_tracking_distributed/README.md
@@ -25,30 +25,30 @@ The data is automatically downloaded when building the application.
 
 ```bash
 # Start the application with all three fragments
-./dev_container build_and_run h264_endoscopy_tool_tracking_distributed --docker_file applications/h264/Dockerfile --language cpp
+./dev_container build_and_run h264_endoscopy_tool_tracking_distributed --language cpp
 
 # Use the following commands to run the same application three processes:
 # Start the application with the video_in fragment
-./dev_container build_and_run h264_endoscopy_tool_tracking_distributed --docker_file applications/h264/Dockerfile --language cpp --run_args "--driver --worker --fragments video_in --address :10000 --worker-address :10001"
+./dev_container build_and_run h264_endoscopy_tool_tracking_distributed --language cpp --run_args "--driver --worker --fragments video_in --address :10000 --worker-address :10001"
 # Start the application with the inference fragment
-./dev_container build_and_run h264_endoscopy_tool_tracking_distributed --docker_file applications/h264/Dockerfile --language cpp --run_args "--worker --fragments inference --address :10000 --worker-address :10002"
+./dev_container build_and_run h264_endoscopy_tool_tracking_distributed --language cpp --run_args "--worker --fragments inference --address :10000 --worker-address :10002"
 # Start the application with the visualization fragment
-./dev_container build_and_run h264_endoscopy_tool_tracking_distributed --docker_file applications/h264/Dockerfile --language cpp --run_args "--worker --fragments viz --address :10000 --worker-address :10003"
+./dev_container build_and_run h264_endoscopy_tool_tracking_distributed --language cpp --run_args "--worker --fragments viz --address :10000 --worker-address :10003"
 ```
 
 ### Python
 
 ```bash
 # Start the application with all three fragments
-./dev_container build_and_run h264_endoscopy_tool_tracking_distributed --docker_file applications/h264/Dockerfile --language python
+./dev_container build_and_run h264_endoscopy_tool_tracking_distributed --language python
 
 # Use the following commands to run the same application three processes:
 # Start the application with the video_in fragment
-./dev_container build_and_run h264_endoscopy_tool_tracking_distributed --docker_file applications/h264/Dockerfile --language python --run_args "--driver --worker --fragments video_in --address :10000 --worker-address :10001"
+./dev_container build_and_run h264_endoscopy_tool_tracking_distributed --language python --run_args "--driver --worker --fragments video_in --address :10000 --worker-address :10001"
 # Start the application with the inference fragment
-./dev_container build_and_run h264_endoscopy_tool_tracking_distributed --docker_file applications/h264/Dockerfile --language python --run_args "--worker --fragments inference --address :10000 --worker-address :10002"
+./dev_container build_and_run h264_endoscopy_tool_tracking_distributed --language python --run_args "--worker --fragments inference --address :10000 --worker-address :10002"
 # Start the application with the visualization fragment
-./dev_container build_and_run h264_endoscopy_tool_tracking_distributed --docker_file applications/h264/Dockerfile --language python --run_args "--worker --fragments viz --address :10000 --worker-address :10003"
+./dev_container build_and_run h264_endoscopy_tool_tracking_distributed --language python --run_args "--worker --fragments viz --address :10000 --worker-address :10003"
 ```
 
 Important: on aarch64, applications also need tegra folder mounted inside the container and

--- a/applications/h264/h264_endoscopy_tool_tracking_distributed/cpp/metadata.json
+++ b/applications/h264/h264_endoscopy_tool_tracking_distributed/cpp/metadata.json
@@ -13,9 +13,9 @@
 			"1.0": "Initial Release"
 		},
 		"holoscan_sdk": {
-			"minimum_required_version": "2.5.0",
+			"minimum_required_version": "2.6.0",
 			"tested_versions": [
-				"2.5.0"
+				"2.6.0"
 			]
 		},
 		"platforms": [

--- a/applications/h264/h264_endoscopy_tool_tracking_distributed/cpp/metadata.json
+++ b/applications/h264/h264_endoscopy_tool_tracking_distributed/cpp/metadata.json
@@ -12,6 +12,7 @@
 		"changelog": {
 			"1.0": "Initial Release"
 		},
+    "dockerfile": "applications/h264/Dockerfile",
 		"holoscan_sdk": {
 			"minimum_required_version": "2.6.0",
 			"tested_versions": [

--- a/applications/h264/h264_endoscopy_tool_tracking_distributed/python/metadata.json
+++ b/applications/h264/h264_endoscopy_tool_tracking_distributed/python/metadata.json
@@ -13,8 +13,8 @@
       "1.0": "Initial Release"
     },
     "holoscan_sdk": {
-      "minimum_required_version": "2.5.0",
-      "tested_versions": ["2.5.0"]
+      "minimum_required_version": "2.6.0",
+      "tested_versions": ["2.6.0"]
     },
     "platforms": ["amd64", "arm64"],
     "tags": ["Endoscopy", "Video Decoding", "Video Encoding"],

--- a/applications/h264/h264_endoscopy_tool_tracking_distributed/python/metadata.json
+++ b/applications/h264/h264_endoscopy_tool_tracking_distributed/python/metadata.json
@@ -12,6 +12,7 @@
     "changelog": {
       "1.0": "Initial Release"
     },
+    "dockerfile": "applications/h264/Dockerfile",
     "holoscan_sdk": {
       "minimum_required_version": "2.6.0",
       "tested_versions": ["2.6.0"]

--- a/applications/h264/h264_video_decode/cpp/metadata.json
+++ b/applications/h264/h264_video_decode/cpp/metadata.json
@@ -14,6 +14,7 @@
       "2.0": "Upgrade to GXF 4.0",
       "2.1": "Import h.264 GXF Codelets/Components as Holoscan Operators/Resources"
     },
+    "dockerfile": "applications/h264/Dockerfile",
     "holoscan_sdk": {
       "minimum_required_version": "2.6.0",
       "tested_versions": ["2.6.0"]

--- a/applications/h264/h264_video_decode/cpp/metadata.json
+++ b/applications/h264/h264_video_decode/cpp/metadata.json
@@ -15,8 +15,8 @@
       "2.1": "Import h.264 GXF Codelets/Components as Holoscan Operators/Resources"
     },
     "holoscan_sdk": {
-      "minimum_required_version": "2.1.0",
-      "tested_versions": ["2.1.0"]
+      "minimum_required_version": "2.6.0",
+      "tested_versions": ["2.6.0"]
     },
     "platforms": ["amd64", "arm64"],
     "tags": ["H.264", "Video Decoding"],

--- a/applications/h264/h264_video_decode/python/metadata.json
+++ b/applications/h264/h264_video_decode/python/metadata.json
@@ -13,8 +13,8 @@
       "1.0": "Initial Release"
     },
     "holoscan_sdk": {
-      "minimum_required_version": "2.1.0",
-      "tested_versions": ["2.1.0"]
+      "minimum_required_version": "2.6.0",
+      "tested_versions": ["2.6.0"]
     },
     "platforms": ["amd64", "arm64"],
     "tags": ["H264", "Video Decoding"],

--- a/applications/h264/h264_video_decode/python/metadata.json
+++ b/applications/h264/h264_video_decode/python/metadata.json
@@ -12,6 +12,7 @@
     "changelog": {
       "1.0": "Initial Release"
     },
+    "dockerfile": "applications/h264/Dockerfile",
     "holoscan_sdk": {
       "minimum_required_version": "2.6.0",
       "tested_versions": ["2.6.0"]


### PR DESCRIPTION
Changes:

- Holoscan SDK 2.6.0 updates its GXF dependency to 4.1.0. The H264
    application Dockerfile has been updated in 5622965 to fetch the
    corresponding GXF Multimedia extensions for GXF 4.1, which are not
    compatible with older versions of GXF or Holoscan SDK.

- Updates H264 application `metadata.json` files to use the HoloHub H264
    Dockerfile by default with `./dev_container build_and_run`. The H264
    Dockerfile installs GXF Multimedia 4.1 extensions and other related
    dependencies. Under previous behavior the general HoloHub Dockerfile was used for H264
    applications by default, which did not provide H264 components. It was
    previously required to pass `--docker_file` to the `build_and_run`
    requirement to construct the proper development environment.