### PR TITLE
App: Update XR Volume Rendering build for dashboard testing

### DIFF
--- a/applications/volume_rendering_xr/CMakeLists.txt
+++ b/applications/volume_rendering_xr/CMakeLists.txt
@@ -39,11 +39,14 @@ find_package(holoscan 2.0 REQUIRED CONFIG
 find_package(Vulkan REQUIRED)
 find_package(CUDAToolkit REQUIRED)
 
+set(HOLOHUB_BUILD_TESTING ${BUILD_TESTING})
+set(BUILD_TESTING OFF)
 FetchContent_Declare(
   Eigen3
   URL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
 )
 FetchContent_MakeAvailable(Eigen3)
+set(BUILD_TESTING ${HOLOHUB_BUILD_TESTING})
 
 
 add_executable(volume_rendering_xr

--- a/applications/volume_rendering_xr/Dockerfile
+++ b/applications/volume_rendering_xr/Dockerfile
@@ -20,6 +20,22 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as base
 
+
+############################################################
+# HoloHub run + dev dependencies setup
+############################################################
+
+RUN mkdir -p /tmp/scripts
+COPY run /tmp/scripts/
+RUN mkdir -p /tmp/scripts/utilities
+COPY utilities/holohub_autocomplete /tmp/scripts/utilities/
+RUN chmod +x /tmp/scripts/run
+RUN /tmp/scripts/run setup
+
+############################################################
+# Magic Leap base setup
+############################################################
+
 COPY /applications/volume_rendering_xr/scripts/base-setup.sh \
     /tmp/base-setup.sh
 COPY applications/volume_rendering_xr/thirdparty/magicleap/MagicLeapRemoteRendering.gpg \


### PR DESCRIPTION
Minor changes to support internal dashboard testing:
- Install `xvfb` inside the app container along with HoloHub utilities
- Disable Eigen dependency tests

Addresses observed error in internal build blocking dashboard results submission:
```
bash: line 1: xvfb-run: command not found
```