### PR TITLE
App: Address XR Volume Rendering CMake warning

### DIFF
--- a/applications/volume_rendering_xr/CMakeLists.txt
+++ b/applications/volume_rendering_xr/CMakeLists.txt
@@ -44,6 +44,7 @@ set(BUILD_TESTING OFF)
 FetchContent_Declare(
   Eigen3
   URL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(Eigen3)
 set(BUILD_TESTING ${HOLOHUB_BUILD_TESTING})

--- a/applications/xr_hello_holoscan/CMakeLists.txt
+++ b/applications/xr_hello_holoscan/CMakeLists.txt
@@ -25,6 +25,7 @@ set(CMAKE_CUDA_ARCHITECTURES 75)
 FetchContent_Declare(
   Eigen3
   URL https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(Eigen3)
 


### PR DESCRIPTION
Addresses warning where `DOWNLOAD_EXTRACT_TIMESTAMP` was not explicitly specified for `FetchContent` relying on a release archive URL.

Resolves:
```
CMake Warning (dev) at /usr/local/share/cmake-3.24/Modules/FetchContent.cmake:1264 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  applications/volume_rendering_xr/CMakeLists.txt:44 (FetchContent_Declare)
This warning is for project developers.  Use -Wno-dev to suppress it.
```