### PR TITLE
multiai_ultrasound: use RMMAllocator for VideoStreamReplayer

### DIFF
--- a/applications/multiai_ultrasound/cpp/main.cpp
+++ b/applications/multiai_ultrasound/cpp/main.cpp
@@ -66,6 +66,10 @@ class App : public holoscan::Application {
     } else {
       source = make_operator<ops::VideoStreamReplayerOp>(
           "replayer", from_config("replayer"), Arg("directory", datapath));
+#if HOLOSCAN_VERSION >= 20600
+      // the RMMAllocator supported since v2.6 is much faster than the default UnboundAllocator
+      source->add_arg(Arg("allocator", make_resource<RMMAllocator>("video_replayer_allocator")));
+#endif
     }
 
     auto in_dtype = is_aja_source_ ? std::string("rgba8888") : std::string("rgb888");

--- a/applications/multiai_ultrasound/python/multiai_ultrasound.py
+++ b/applications/multiai_ultrasound/python/multiai_ultrasound.py
@@ -69,6 +69,13 @@ class MultiAIICardio(Application):
             if not os.path.exists(video_dir):
                 raise ValueError(f"Could not find video data: {video_dir=}")
             source_kwargs["directory"] = video_dir
+            # the RMMAllocator supported since v2.6 is much faster than the default UnboundAllocator
+            try:
+                from holoscan.resources import RMMAllocator
+
+                source_kwargs["allocator"] = RMMAllocator(self, name="video_replayer_allocator")
+            except Exception:
+                pass
         source = SourceClass(self, name=self.source, **source_kwargs)
 
         in_dtype = "rgba8888" if is_aja else "rgb888"


### PR DESCRIPTION
This is faster than using the default UnboundAllocator.