### PR TITLE
replayer option in model_benchmarking

### DIFF
--- a/benchmarks/model_benchmarking/cpp/CMakeLists.txt
+++ b/benchmarks/model_benchmarking/cpp/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(model_benchmarking
     holoscan::ops::holoviz
     holoscan::ops::inference
     holoscan::ops::segmentation_postprocessor
+    holoscan::ops::video_stream_replayer
 )
 
 # Copy config file

--- a/benchmarks/model_benchmarking/cpp/model_benchmarking.yaml
+++ b/benchmarks/model_benchmarking/cpp/model_benchmarking.yaml
@@ -17,6 +17,13 @@
 source:
   device: "/dev/video6"
 
+replayer:
+  basename: "ultrasound_256x256"
+  frame_rate:
+  repeat: true
+  realtime: false
+  count: 0
+
 preprocessor:  # FormatConverter
   out_tensor_name: source_video
   out_dtype: "float32"


### PR DESCRIPTION
added support for replayer in model_benchmarking.

The following command enables running with a replayer instead of V4L2 player: `./run launch model_benchmarking --extra_args "-r"`