### PR TITLE
logger.info error in benchmark.py

### DIFF
--- a/benchmarks/holoscan_flow_benchmarking/benchmark.py
+++ b/benchmarks/holoscan_flow_benchmarking/benchmark.py
@@ -210,8 +210,7 @@ assignment in Holoscan's Inference operator.",
         log_directory = args.log_directory
         if not os.path.isdir(log_directory):
             logger.info(
-                "Log directory is not found. Creating a new directory at",
-                os.path.abspath(log_directory),
+                f"Log directory is not found. Creating a new directory at {os.path.abspath(log_directory)}",
             )
             os.mkdir(os.path.abspath(log_directory))
 


### PR DESCRIPTION
The following error was printed because of formatting issues in `logger.info`

```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.10/logging/__init__.py", line 1100, in emit
    msg = self.format(record)
  File "/usr/lib/python3.10/logging/__init__.py", line 943, in format
    return fmt.format(record)
  File "/usr/lib/python3.10/logging/__init__.py", line 678, in format
    record.message = record.getMessage()
  File "/usr/lib/python3.10/logging/__init__.py", line 368, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "/workspace/holohub/benchmarks/holoscan_flow_benchmarking/benchmark.py", line 328, in <module>
    main()
  File "/workspace/holohub/benchmarks/holoscan_flow_benchmarking/benchmark.py", line 212, in main
    logger.info(
Message: 'Log directory is not found. Creating a new directory at'
Arguments: ('/workspace/holohub/multiflex_exp/multiflex/bgapp3',)
2024-11-14 00:29:26,281 INFO: Run 1 started for greedy scheduler.
```