### PR TITLE
XR Volume Rendering: Update socket check in `ml_start.sh`

### DIFF
--- a/applications/volume_rendering_xr/thirdparty/magicleap/ml_start.sh
+++ b/applications/volume_rendering_xr/thirdparty/magicleap/ml_start.sh
@@ -33,7 +33,7 @@ if ! ps -p $! > /dev/null; then
     exit 1
 fi
 # wait for service startup
-until [ -e /tmp/windrunner_comp_ipc ]
+until [ -e /tmp/windrunner_comp_ipc ] || [ -e /run/user/$(id -u)/windrunner_comp_ipc ];
 do
      echo "Waiting for windrunner-service"
      sleep 1


### PR DESCRIPTION
`ml_start.sh` expects a socket file to be created when the Windrunner OpenXR backend is initialized and ready. We update the `ml_start.sh` script to check in two possible places for the socket file.

Addresses issue where `ml_start.sh` endlessly checked only the `/tmp` path and never returned, preventing the Holoscan pipeline from starting and displaying only the default pink background in the debug GUI. Verified that volume rendering scene is viewable in my local container with this change applied.

Confirmed that installed `windrunner` package version matches expected (1.11.74-5b8fe25-1~20240426ubuntu2204). Root cause of new behavior is not immediately clear.

NVBug 4970896