### PR TITLE
Limit the number of CMake jobs to one less than the host CPU count

### DIFF
--- a/dev_container
+++ b/dev_container
@@ -874,6 +874,7 @@ build_and_run_desc() { c_echo 'Build and run a requested application in a Docker
         --run_args : Run the app with additional args
         --verbose : Print extra output to console
         --dryrun : View build and run commands without doing anything
+        --parallel_jobs: Set the # of parallel build jobs, e.g. $(($(nproc)-1))
     '
 }
 
@@ -892,6 +893,7 @@ build_and_run() {
     local run_app=1
     local install=""
     local configure_args=""
+    local parallel_jobs=""
 
     # Parse CLI arguments next
     while [[ $# -gt 0 ]]; do
@@ -1014,6 +1016,16 @@ build_and_run() {
                 exit 1
             fi
             ;;
+        --parallel_jobs)
+            if [[ -n "$2" ]]; then
+                parallel_jobs="--parallel '$2'"
+                shift 2
+            else
+                echo "Error: --parallel_jobs requires a value"
+                build_and_run_desc
+                exit 1
+            fi
+            ;;
         *)
             if [[ -z "$app_name" ]]; then
                 app_name="$1"
@@ -1057,7 +1069,7 @@ build_and_run() {
     run_command  ${SCRIPT_DIR}/dev_container build "${container_build_args[@]}"
     if [[ $build_app == 1 ]]; then
         c_echo "Building application..."
-        run_command ${SCRIPT_DIR}/dev_container launch $container_launch_args --docker_opts "$docker_opts" -- -c "./run build $app_name $install $extra_build_with $extra_build_args"
+        run_command ${SCRIPT_DIR}/dev_container launch $container_launch_args --docker_opts "$docker_opts" -- -c "./run build $app_name $install $parallel_jobs $extra_build_with $extra_build_args"
     fi
 
     if [[ $run_app == 1 ]]; then

--- a/run
+++ b/run
@@ -692,7 +692,9 @@ build() {
   run_command cmake -S . -B ${build_path} ${cmake_extra_args} -DCMAKE_BUILD_TYPE=${build_type} ${holoscan_sdk} ${application}
   ret=$?
   check_exit_code $ret "Error building application."
-  run_command cmake --build ${build_path} -j
+  # Run jobs in parallel with # one less than that of CPUs
+  JOBS=$(($(nproc) - 1))
+  run_command cmake --build ${build_path} -j${JOBS}
   ret=$?
   check_exit_code $ret "Error building application."
 

--- a/run
+++ b/run
@@ -557,6 +557,9 @@ build_desc() {
   echo "   --configure-args <extra_args>        : Additional configuration arguments"
   echo "                                          multiple arguments can be passed between quotes"
   echo "                                          or using several --configure-args in the command line"
+  echo "   --parallel <jobs>                    : Build in parallel using the given number of jobs."
+  echo "                                          Only needed to override the native build tool's default."
+  echo "                                          Example: --parallel $(($(nproc)-1))"
   echo ""
   echo "Prior to the first build use './run setup' to install the required dependencies"
   echo ""
@@ -619,6 +622,7 @@ build() {
   local build_path="${CMAKE_BUILD_PATH}"
   local benchmark=false
   local install=false
+  local parallel_jobs=""
 
   for i in "${!ARGS[@]}"; do
       arg="${ARGS[i]}"
@@ -649,6 +653,10 @@ build() {
          skipnext=1
       elif [ "$arg" = "--buildpath" ]; then
          build_path="${ARGS[i+1]}"
+         skipnext=1
+      elif [ "$arg" = "--parallel" ]; then
+         parallel_jobs="${ARGS[i+1]}"
+         echo "Setting the number of parallel build jobs: ${ARGS[i+1]}"
          skipnext=1
       elif [[ $arg = -* ]]; then
         print_error "Unknown option $arg"
@@ -692,9 +700,8 @@ build() {
   run_command cmake -S . -B ${build_path} ${cmake_extra_args} -DCMAKE_BUILD_TYPE=${build_type} ${holoscan_sdk} ${application}
   ret=$?
   check_exit_code $ret "Error building application."
-  # Run jobs in parallel with # one less than that of CPUs
-  JOBS=$(($(nproc) - 1))
-  run_command cmake --build ${build_path} -j${JOBS}
+  # Job concurrency determined by the underlying build tool unless a number is specified
+  run_command cmake --build ${build_path} -j ${parallel_jobs}
   ret=$?
   check_exit_code $ret "Error building application."
 


### PR DESCRIPTION
In the `run` script, `cmake --build` option `-j` does not cap the # of jobs to run in parallel, which leaves it to the underlying build tool to determine build job concurrency on a specific system. This seems to have worked well till the gRPC distributed Endoscopy Tool Tracking app. Without capping the # of jobs, building this app locks up the host system with 100% CPU usage for all cores and likely 100% of mem too (system locked up when monitor shows over 85% of mem usage) 

This PR adds the actual max number, which can be set with a new command line option of the run and dev_container build_and_run script.

Alternatives, e.g. using the CMakeList.txt of an app to dynamically set the max # of jobs, were discussed in the review comments, and could be considered too in separate PRs.   