### PR TITLE
Address RMMAllocator error for UCX Endoscopy Tool Tracking application

### DIFF
--- a/applications/distributed/ucx/ucx_endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
+++ b/applications/distributed/ucx/ucx_endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
@@ -21,10 +21,17 @@ extensions:
   - libgxf_serialization.so
   - lib/gxf_extensions/libgxf_lstm_tensor_rt_inference.so
 
+application:
+  title: Endoscopy Tool Tracking - UCX
+  version: 1.0
+  inputFormats: []
+  outputFormats: ["screen"]
+  benchmarking: true # default: false, true to enable Data Flow Benchmarking, false otherwise
+
 replayer:
   basename: "surgical_video"
   frame_rate: 0   # as specified in timestamps
-  repeat: true    # default: false
+  repeat: false    # default: false
   realtime: true  # default: true
   count: 0        # default: 0 (no frame count restriction)
 

--- a/applications/distributed/ucx/ucx_endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
+++ b/applications/distributed/ucx/ucx_endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
@@ -26,14 +26,14 @@ application:
   version: 1.0
   inputFormats: []
   outputFormats: ["screen"]
-  benchmarking: true # default: false, true to enable Data Flow Benchmarking, false otherwise
+  benchmarking: false   # default: false, true to enable Data Flow Benchmarking, false otherwise
 
 replayer:
   basename: "surgical_video"
-  frame_rate: 0   # as specified in timestamps
-  repeat: false    # default: false
-  realtime: true  # default: true
-  count: 0        # default: 0 (no frame count restriction)
+  frame_rate: 0         # as specified in timestamps
+  repeat: true          # default: true
+  realtime: true        # default: true
+  count: 0              # default: 0 (no frame count restriction)
 
 format_converter:
   out_tensor_name: source_video

--- a/applications/distributed/ucx/ucx_endoscopy_tool_tracking/cpp/main.cpp
+++ b/applications/distributed/ucx/ucx_endoscopy_tool_tracking/cpp/main.cpp
@@ -40,7 +40,10 @@ class VideoInputFragment : public holoscan::Fragment {
 
     auto replayer = make_operator<ops::VideoStreamReplayerOp>(
         "replayer",
-        Arg("allocator", make_resource<RMMAllocator>("video_replayer_allocator")),
+        Arg("allocator",
+            make_resource<RMMAllocator>("video_replayer_allocator",
+                                        Arg("device_memory_max_size") = std::string("256MB"),
+                                        Arg("device_memory_initial_size") = std::string("256MB"))),
         from_config("replayer"),
         args);
 
@@ -207,7 +210,12 @@ int main(int argc, char** argv) {
   auto app = holoscan::make_application<App>();
   app->config(config_path);
   app->set_datapath(data_directory);
-  app->run();
 
+  auto trackers = app->track_distributed();
+  app->run();
+  for (const auto& [name, tracker] : trackers) {
+    std::cout << "Fragment: " << name << std::endl;
+    tracker->print();
+  }
   return 0;
 }


### PR DESCRIPTION
This PR addresses a `RMMAllocator` crash when running the application with `realtime` set to `false` (play the video as fast as possible).


```bash
[error] [rmm_allocator.cpp:190] Unexpected error while allocating memory [00007]('video_replayer_allocator') : std::bad_alloc: out_of_memory: RMM failure at:bazel-out/k8-opt/bin/external/rmm/_virtual_includes/rmm/rmm/mr/device/pool_memory_resource.hpp:424: Maximum pool size exceeded
[error] [memory_buffer.hpp:79] video_replayer_allocator Failed to allocate 1229760 size of memory of type 1. Error code: GXF_FAILURE
```

As @grlee77 suggested, the fix is to explicitly set the RMM Allocator's initial and maximum sizes.

Adds the ability to enable/disable data flow benchmarking through configuration.