### PR TITLE
Ext: Link DLPack dependency in GXF Emergent Source extension

### DIFF
--- a/gxf_extensions/emergent_source/CMakeLists.txt
+++ b/gxf_extensions/emergent_source/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(gxf_emergent_source_lib
   CUDA::cuda_driver
   GXF::multimedia
   GXF::std
+  holoscan::core
   yaml-cpp
   EmergentCamera
 )


### PR DESCRIPTION
Link the `holoscan::core` CMake target in the Emergent Source extension to ensure that DLPack is found.

`holoscan::core` implicitly provides third party include paths for dependencies packaged with the Holoscan SDK distribution.

Addresses GitHub issue #606.

Verified build error #606 is resolved. Note that this is not fully tested as I do not have access to the Emergent SDK.