### PR TITLE
Small enhancements to ANO bench configs

### DIFF
--- a/applications/adv_networking_bench/adv_networking_bench_default_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_rx.yaml
@@ -84,9 +84,10 @@ advanced_network:
               match:
                 udp_src: 4096 #12288
                 udp_dst: 4096 #12288
+
 bench_rx:
-  split_boundary: true
-  gpu_direct: true
+  gpu_direct: true        # Set to true if using a GPU region for the Rx queues.
+  split_boundary: true    # Whether header and data is split (Header to CPU)
   batch_size: 10240
   max_packet_size: 1064
   header_size: 64

--- a/applications/adv_networking_bench/adv_networking_bench_default_tx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx.yaml
@@ -56,16 +56,15 @@ advanced_network:
             offloads:
               - "tx_eth_src"
 
-
 bench_tx:
-  eth_dst_addr: 48:b0:2d:ed:d0:20   # Destination MAC
-  udp_dst_port: 4096                  # UDP destination port
-  udp_src_port: 4096                  # UDP source port
-  gpu_direct: false
-  split_boundary: 0
+  gpu_direct: false       # Set to true if using a GPU region for the Tx queues.
+  split_boundary: 0       # Byte boundary where header and data is split, 0 if no split
   batch_size: 10000
   payload_size: 1000
   header_size: 64
-  ip_src_addr: 192.168.100.5          # Source IP send from
-  ip_dst_addr: 10.10.100.4          # Destination IP to send to
-  address: 0005:03:00.0
+  eth_dst_addr: <00:00:00:00:00:00> # Destination MAC address - required when Rx flow_isolation=true
+  ip_src_addr: <1.2.3.4>  # Source IP address - required on layer 3 network
+  ip_dst_addr: <5.6.7.8>  # Destination IP address - required on layer 3 network
+  udp_src_port: 4096      # UDP source port
+  udp_dst_port: 4096      # UDP destination port
+  address: <0000:00:00.0> # Source NIC Bus ID. Should match the address of the Tx above

--- a/applications/adv_networking_bench/adv_networking_bench_default_tx_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx_rx.yaml
@@ -48,13 +48,6 @@ advanced_network:
         - local
       num_bufs: 51200
       buf_size: 9000
-    - name: "Default_RX_GPU2"
-      kind: "device"
-      affinity: 0
-      access:
-        - local
-      num_bufs: 51200
-      buf_size: 9000      
     - name: "Data_RX_GPU"
       kind: "device"
       affinity: 0
@@ -104,15 +97,6 @@ advanced_network:
               udp_src: 4096 #12288
               udp_dst: 4096 #12288
               ipv4_len: 1050
-          - name: "ADC Samples2"
-            id: 1
-            action:
-              type: queue
-              id: 1
-            match:
-              udp_src: 4095 #12288
-              udp_dst: 4095 #12288
-              ipv4_len: 1050              
 
 bench_rx:
   split_boundary: false

--- a/applications/adv_networking_bench/adv_networking_bench_default_tx_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx_rx.yaml
@@ -71,6 +71,7 @@ advanced_network:
               - "tx_eth_src"
     - name: data2
       address: 0005:03:00.1
+      flow_isolation: false
       rx:
         - queues:
           - name: "Default"
@@ -99,21 +100,21 @@ advanced_network:
               ipv4_len: 1050
 
 bench_rx:
-  split_boundary: false
-  gpu_direct: true
+  gpu_direct: true        # Set to true if using a GPU region for the Rx queues.
+  split_boundary: false   # Whether header and data is split (Header to CPU)
   batch_size: 10240
   max_packet_size: 1064
   header_size: 64
 
 bench_tx:
-  eth_dst_addr: 48:b0:2d:f4:04:48   # Destination MAC
-  udp_dst_port: 4096                  # UDP destination port
-  udp_src_port: 4096                  # UDP source port
-  gpu_direct: true
-  split_boundary: 0
+  gpu_direct: true        # Set to true if using a GPU region for the Tx queues.
+  split_boundary: 0       # Byte boundary where header and data is split, 0 if no split
   batch_size: 10000
   payload_size: 1000
   header_size: 64
-  ip_src_addr: 10.10.100.1          # Source IP send from
-  ip_dst_addr: 10.10.100.2          # Destination IP to send to
-  address: 0005:03:00.0
+  eth_dst_addr: <00:00:00:00:00:00> # Destination MAC address - required when Rx flow_isolation=true
+  ip_src_addr: <1.2.3.4>  # Source IP address - required on layer 3 network
+  ip_dst_addr: <5.6.7.8>  # Destination IP address - required on layer 3 network
+  udp_src_port: 4096      # UDP source port
+  udp_dst_port: 4096      # UDP destination port
+  address: <0000:00:00.0> # Source NIC Bus ID. Should match the address of the Tx above

--- a/applications/adv_networking_bench/adv_networking_bench_doca_tx_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_doca_tx_rx.yaml
@@ -57,6 +57,7 @@ advanced_network:
     interfaces:
     - name: data1
       address: 0000:ca:00.0
+      flow_isolation: false
       tx:
         - queues:
           - name: "ADC Samples"
@@ -92,20 +93,18 @@ advanced_network:
                 udp_src: 4096 #12288
                 udp_dst: 4096 #12288
 
-bench_tx:
-  eth_dst_addr: 48:b0:2d:e8:cb:17   # Destination MAC
-  udp_dst_port: 4096                  # UDP destination port
-  udp_src_port: 4096                  # UDP source port
-  gpu_direct: true
-  batch_size: 10000
-  payload_size: 1000
-  header_size: 64
-  ip_src_addr: 192.168.100.1          # Source IP send from
-  ip_dst_addr: 10.10.100.1          # Destination IP to send to
-  address: ca:00.0
-
 bench_rx:
-  gpu_direct: true
   batch_size: 10240
   max_packet_size: 1064
   header_size: 64
+
+bench_tx:
+  batch_size: 10000
+  payload_size: 1000
+  header_size: 64
+  eth_dst_addr: <00:00:00:00:00:00> # Destination MAC address - required when Rx flow_isolation=true
+  ip_src_addr: <1.2.3.4>  # Source IP address - required on layer 3 network
+  ip_dst_addr: <5.6.7.8>  # Destination IP address - required on layer 3 network
+  udp_src_port: 4096      # UDP source port
+  udp_dst_port: 4096      # UDP destination port
+  address: <0000:00:00.0> # Source NIC Bus ID. Should match the address of the Tx above

--- a/applications/adv_networking_bench/adv_networking_bench_rmax_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_rmax_rx.yaml
@@ -49,7 +49,7 @@ advanced_network:
       buf_size: 1200
     interfaces:
     - name: data1
-      address:  cc:00.1           
+      address:  cc:00.1
       rx:
         - queues:
           - name: "Data"
@@ -57,7 +57,7 @@ advanced_network:
             cpu_core:  "11,12,13"
             batch_size: 4320
             output_port: "bench_rx_out_1"
-            memory_regions: 
+            memory_regions:
             - "Data_RX_CPU"
             - "Data_RX_GPU"
             rmax_rx_settings:
@@ -82,8 +82,8 @@ advanced_network:
               rx_stats_period_report_ms: 3000
               send_packet_ext_info: true
 bench_rx:
-  split_boundary: true
-  gpu_direct: true
+  gpu_direct: true        # Set to true if using a GPU region for the Rx queues.
+  split_boundary: true    # Whether header and data is split (Header to CPU)
   batch_size: 8640
   max_packet_size: 1220
-  header_size: 20  
+  header_size: 20


### PR DESCRIPTION
Pulled out of #605 

- Add generic values for benchmark operator addresses
- Add comments for benchmark config values
- Revert unused addition of GPU memory region and flow in one config

cc: @cliffburdick 