### PR TITLE
Update PyTorch Install for VILA_Live and Florence 2

### DIFF
--- a/applications/florence-2-vision/Dockerfile
+++ b/applications/florence-2-vision/Dockerfile
@@ -19,11 +19,6 @@ ARG BASE_IMAGE
 ARG GPU_TYPE
 ARG COMPUTE_CAPACITY
 ############################################################
-# Torch image (Used to extract the ARM64 dGPU pytorch wheel)
-############################################################
-FROM nvcr.io/nvidia/pytorch:23.10-py3 as pytorch
-
-############################################################
 # Base image
 ############################################################
 FROM ${BASE_IMAGE} as base
@@ -40,24 +35,8 @@ COPY applications/florence-2-vision/requirements.txt /tmp/requirements.txt
 
 # Install setuptools prior to all other requirements to avoid install errors
 RUN python3 -m pip install --no-cache-dir setuptools && \
+    python3 -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cu124 && \
     python3 -m pip install --no-cache-dir -r /tmp/requirements.txt
-
-# Copy the Torch wheel from the PyTorch image. This is necessary because the PyTorch wheel is not available for ARM64 on PyPI.
-WORKDIR /tmp/pip/
-COPY --from=pytorch /tmp/pip/torch*.whl /tmp/pip/
-
-# Install the Torch wheel based on the target architecture
-ARG TARGETARCH
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        echo "Building for x86 (AMD64) architecture"; \
-        python3 -m pip install torch==2.1.0; \
-    elif [ "$TARGETARCH" = "arm64" ]; then \
-        echo "Building for ARM64 architecture"; \
-        python3 -m pip install /tmp/pip/torch-2.1.0a0+32f93b1-cp310-cp310-linux_aarch64.whl; \
-    else \
-        echo "Unknown architecture: $TARGETARCH"; \
-        exit 1; \
-    fi
 
 # Download the Florence-2 model
 RUN huggingface-cli download microsoft/Florence-2-large-ft \
@@ -65,7 +44,7 @@ RUN huggingface-cli download microsoft/Florence-2-large-ft \
 
 # Build/install flash-attention 2 (NOTE: on Arm64 this will take between 1-1.5 hours)
 # MAX_JOBS is set to 4 to avoid running out of memory
-RUN MAX_JOBS=4 python3 -m pip install --no-cache-dir --no-build-isolation flash-attn
+RUN MAX_JOBS=4 python3 -m pip install --no-cache-dir --no-build-isolation flash-attn~=2.5
 
 # Install QT dependencies
 RUN apt-get install -y \

--- a/applications/florence-2-vision/requirements.txt
+++ b/applications/florence-2-vision/requirements.txt
@@ -1,7 +1,6 @@
 pillow==10.3.0
-torchvision==0.16
 timm==1.0.7
-einops==0.8.0
+einops
 transformers
 huggingface_hub[cli]
 PySide6

--- a/applications/vila_live/Dockerfile
+++ b/applications/vila_live/Dockerfile
@@ -19,11 +19,6 @@ ARG BASE_IMAGE
 ARG GPU_TYPE
 ARG COMPUTE_CAPACITY
 ############################################################
-# Torch image (Used to extract the ARM64 dGPU pytorch wheel)
-############################################################
-FROM nvcr.io/nvidia/pytorch:23.10-py3 as pytorch
-
-############################################################
 # Base image
 ############################################################
 FROM ${BASE_IMAGE} as base
@@ -40,28 +35,12 @@ COPY applications/vila_live/requirements.txt /tmp/requirements.txt
 
 # Install setuptools prior to all other requirements to avoid install errors
 RUN python3 -m pip install --no-cache-dir setuptools && \
+    python3 -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cu124 && \
     python3 -m pip install --no-cache-dir -r /tmp/requirements.txt
-
-# Copy the Torch wheel from the PyTorch image. This is necessary because the PyTorch wheel is not available for ARM64 on PyPI.
-WORKDIR /tmp/pip/
-COPY --from=pytorch /tmp/pip/torch*.whl /tmp/pip/
-
-# Install the Torch wheel based on the target architecture
-ARG TARGETARCH
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        echo "Building for x86 (AMD64) architecture"; \
-        python3 -m pip install torch==2.1.0; \
-    elif [ "$TARGETARCH" = "arm64" ]; then \
-        echo "Building for ARM64 architecture"; \
-        python3 -m pip install /tmp/pip/torch-2.1.0a0+32f93b1-cp310-cp310-linux_aarch64.whl; \
-    else \
-        echo "Unknown architecture: $TARGETARCH"; \
-        exit 1; \
-    fi
 
 # Build/install flash-attention 2 (NOTE: on Arm64 this will take between 1-1.5 hours)
 # MAX_JOBS is set to 4 to avoid running out of memory
-RUN MAX_JOBS=4 python3 -m pip install --no-cache-dir --no-build-isolation flash-attn
+RUN MAX_JOBS=4 python3 -m pip install --no-cache-dir --no-build-isolation flash-attn~=2.5
 
 # Clone AWQ and VILA repositories and install them based on the GPU's compute capacity
 WORKDIR /workspace
@@ -69,8 +48,9 @@ ARG COMPUTE_CAPACITY
 RUN git clone https://github.com/mit-han-lab/llm-awq \
     && cd llm-awq \
     && git checkout 41d7e704932b7eaf8b3dcfb21e1fe49fd296d894 \
-    # Remove torch from pyproject.toml to avoid conflicts with the installed torch version
+    # Remove torch and transformers from pyproject.toml to avoid conflicts with installed versions
     && sed -i '/torch/d' pyproject.toml \
+    && sed -i '/transformers/d' pyproject.toml \
     && python3 -m pip install --no-cache-dir -e . \
     && cd awq/kernels \
     && TORCH_CUDA_ARCH_LIST="${COMPUTE_CAPACITY}+PTX" \
@@ -78,9 +58,10 @@ RUN git clone https://github.com/mit-han-lab/llm-awq \
     && cd ../.. \
     && git clone https://github.com/Efficient-Large-Model/VILA.git \
     && cd VILA \
-    && git checkout 0085724ca3363dc62eaa0d7ef1a30ad20df5c8da \
-    # Remove torch from pyproject.toml to avoid conflicts with the installed torch version
+    && git checkout ec7fb2c264920bf004fd9fa37f1ec36ea0942db5 \
+    # Remove torch and transformers from pyproject.toml to avoid conflicts with installed versions
     && sed -i '/torch/d' pyproject.toml \
+    && sed -i '/transformers/d' pyproject.toml \
     && python3 -m pip install --no-cache-dir --no-deps -e .
 
 # Download the AWQ-quantized VILA model

--- a/applications/vila_live/requirements.txt
+++ b/applications/vila_live/requirements.txt
@@ -2,8 +2,9 @@ flask==3.0.2
 websockets==12.0
 asyncio==3.4.3
 pillow==10.3.0
-torchvision==0.16
-ninja
+transformers~=4.46
+ninja~=1.11
+deepspeed~=0.16
+pydantic~=2.10
 huggingface-hub[cli]
 s2wrapper@git+https://github.com/bfshi/scaling_on_scales
-


### PR DESCRIPTION
With the upgrade to HSDK 2.6 using CUDA 12.6, building the VILA_Live and Florence-2 Dockerfiles resulted in errors during the building of Flash-attn 2. This is because Flash-attn 2 uses PyTorch during the build process, and the installed PyTorch used an older version of CUDA than the local 12.6. This MR simplifies the PyTorch install to use the public indexurl. It has been tested for x86 w/ dGPU & IGX w/ dGPU, but iGPU still needs to be verified.