### PR TITLE
Fix variable name in error check

### DIFF
--- a/operators/advanced_network/managers/adv_network_mgr.cpp
+++ b/operators/advanced_network/managers/adv_network_mgr.cpp
@@ -145,7 +145,7 @@ AdvNetStatus ANOMgr::allocate_memory_regions() {
 
           if (alloc_res != CUDA_SUCCESS) {
             const char* err_str = nullptr;
-            cuGetErrorString(result, &err_str);
+            cuGetErrorString(alloc_res, &err_str);
             HOLOSCAN_LOG_CRITICAL("Could not allocate {:.2f}MB of GPU memory. Error: {}",
                                   align / 1e6,
                                   err_str);


### PR DESCRIPTION
Fix build error introduced in [cbc8ba5](https://github.com/nvidia-holoscan/holohub/commit/cbc8ba5c0bd35f79e32979466b4b724b9ef95b20).

```
/workspace/holohub/operators/advanced_network/managers/adv_network_mgr.cpp: In member function 'virtual holoscan::ops::AdvNetStatus holoscan::ops::ANOMgr::allocate_memory_regions()':
/workspace/holohub/operators/advanced_network/managers/adv_network_mgr.cpp:148:30: error: 'result' was not declared in this scope; did you mean 'CUresult'?
  148 |             cuGetErrorString(result, &err_str);
      |                              ^~~~~~
      |                              CUresult
gmake[2]: *** [operators/advanced_network/CMakeFiles/advanced_network_common.dir/build.make:104: operators/advanced_network/CMakeFiles/advanced_network_common.dir/managers/adv_network_mgr.cpp.o] Error 1
```
