### PR TITLE
Add fix for pybind11 to support python3.12

### DIFF
--- a/cmake/pybind11_add_holohub_module.cmake
+++ b/cmake/pybind11_add_holohub_module.cmake
@@ -21,7 +21,7 @@ find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 include(FetchContent)
 FetchContent_Declare(pybind11
   GIT_REPOSITORY https://github.com/pybind/pybind11
-  GIT_TAG v2.10.1
+  GIT_TAG v2.13.6
   GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(pybind11)


### PR DESCRIPTION
Got an error running `endoscopy_tool_tracking` when using python3.12 wheels.  

```shell
[command] python3 /workspace/holohub/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py --data /workspace/holohub/data/endoscopy
Traceback (most recent call last):
  File "/workspace/holohub/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py", line 29, in <module>
    from holohub.lstm_tensor_rt_inference import LSTMTensorRTInferenceOp
  File "/workspace/holohub/build/endoscopy_tool_tracking/python/lib/holohub/lstm_tensor_rt_inference/__init__.py", line 21, in <module>
    from ._lstm_tensor_rt_inference import LSTMTensorRTInferenceOp
ImportError: generic_type: type "LSTMTensorRTInferenceOp" referenced unknown base type "holoscan::ops::GXFOperator"
[command] export PYTHONPATH=/workspace/holohub/venv/lib64/python3.12/site-packages/ && export HOLOHUB_DATA_PATH="" && export HOLOSCAN_INPUT_PATH="/workspace/holohub/data"
``` 

@grlee77 mentioned that pybind v2.11.0 was the first version to nominally support Python 3.12 so it is not surprising to see this failure. 

In this PR, update the pybind11 version to the same version used in Holoscan SDK which is v2.13.6 as suggested by Greg.