### PR TITLE
Remove unnecessary find_project

### DIFF
--- a/applications/laser_detection_latency/CMakeLists.txt
+++ b/applications/laser_detection_latency/CMakeLists.txt
@@ -16,9 +16,6 @@
 cmake_minimum_required(VERSION 3.24)
 project(laser_detection_apps LANGUAGES NONE)
 
-find_package(holoscan 2.0 REQUIRED CONFIG
-             PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
-
 set(HOLOSCAN_OPERATORS
   apriltag_detector
   emergent_source


### PR DESCRIPTION
The `find_project` in the laser_detection_latency app is picked up when building any application since we are using add subdirectory to include the laser detection latency app with: `add_subdirectory(laser_detection_latency)`
 
Other applications should not be constrained by the Holoscan SDK version required by this app.