### PR TITLE
Add HOLOHUB_WHEEL_TESTING option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ include(CTest)
 # Options
 option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 option(HOLOHUB_BUILD_PYTHON "Build Holoscan SDK Python Bindings" ON)
+option(HOLOHUB_WHEEL_TESTING "Build Applications for Python Wheel Testing" OFF)
 
 # Enable flow benchmarking
 option(FLOW_BENCHMARKING "Enable Flow Benchmarking" OFF)

--- a/applications/colonoscopy_segmentation/CMakeLists.txt
+++ b/applications/colonoscopy_segmentation/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 # Add testing
 if(BUILD_TESTING)
   # To get the environment path
-  if (NOT HOLOHUB_WHEEL_TESTING)
+  if(NOT HOLOHUB_WHEEL_TESTING)
       find_package(holoscan 0.6 REQUIRED CONFIG
                    PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
   endif()

--- a/applications/colonoscopy_segmentation/CMakeLists.txt
+++ b/applications/colonoscopy_segmentation/CMakeLists.txt
@@ -36,8 +36,10 @@ endif()
 # Add testing
 if(BUILD_TESTING)
   # To get the environment path
-  find_package(holoscan 0.6 REQUIRED CONFIG
-               PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+  if (NOT HOLOHUB_WHEEL_TESTING)
+      find_package(holoscan 0.6 REQUIRED CONFIG
+                   PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+  endif()
 
   set(RECORDING_DIR ${CMAKE_CURRENT_BINARY_DIR}/recording_output)
   set(SOURCE_VIDEO_BASENAME python_colonoscopy_segmentation_output)

--- a/applications/endoscopy_tool_tracking/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/CMakeLists.txt
@@ -36,7 +36,7 @@ if(HOLOHUB_DOWNLOAD_DATASETS)
   )
 endif()
 
-if (NOT HOLOHUB_WHEEL_TESTING)
+if(NOT HOLOHUB_WHEEL_TESTING)
     add_subdirectory(cpp)
 endif()
 add_subdirectory(python)

--- a/applications/endoscopy_tool_tracking/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/CMakeLists.txt
@@ -36,5 +36,7 @@ if(HOLOHUB_DOWNLOAD_DATASETS)
   )
 endif()
 
-add_subdirectory(cpp)
+if (NOT HOLOHUB_WHEEL_TESTING)
+    add_subdirectory(cpp)
+endif()
 add_subdirectory(python)

--- a/applications/endoscopy_tool_tracking/python/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/python/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 # Add testing
 if(BUILD_TESTING)
-  if (NOT HOLOHUB_WHEEL_TESTING)
+  if(NOT HOLOHUB_WHEEL_TESTING)
       # To get the environment path
       find_package(holoscan 1.0 REQUIRED CONFIG PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
   endif()

--- a/applications/endoscopy_tool_tracking/python/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/python/CMakeLists.txt
@@ -15,8 +15,10 @@
 
 # Add testing
 if(BUILD_TESTING)
-  # To get the environment path
-  find_package(holoscan 1.0 REQUIRED CONFIG PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+  if (NOT HOLOHUB_WHEEL_TESTING)
+      # To get the environment path
+      find_package(holoscan 1.0 REQUIRED CONFIG PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+  endif()
 
   set(RECORDING_DIR ${CMAKE_CURRENT_BINARY_DIR}/recording_output)
   set(SOURCE_VIDEO_BASENAME python_endoscopy_tool_tracking_output)

--- a/applications/multiai_ultrasound/CMakeLists.txt
+++ b/applications/multiai_ultrasound/CMakeLists.txt
@@ -36,8 +36,10 @@ if(HOLOHUB_DOWNLOAD_DATASETS)
   )
 endif()
 
-add_subdirectory(operators)
-add_subdirectory(cpp)
+if (NOT HOLOHUB_WHEEL_TESTING)
+    add_subdirectory(operators)
+    add_subdirectory(cpp)
+endif()
 
 if(HOLOHUB_BUILD_PYTHON) # since using python wrapping
   add_subdirectory(python)

--- a/applications/multiai_ultrasound/CMakeLists.txt
+++ b/applications/multiai_ultrasound/CMakeLists.txt
@@ -36,7 +36,7 @@ if(HOLOHUB_DOWNLOAD_DATASETS)
   )
 endif()
 
-if (NOT HOLOHUB_WHEEL_TESTING)
+if(NOT HOLOHUB_WHEEL_TESTING)
     add_subdirectory(operators)
     add_subdirectory(cpp)
 endif()

--- a/applications/multiai_ultrasound/python/CMakeLists.txt
+++ b/applications/multiai_ultrasound/python/CMakeLists.txt
@@ -16,7 +16,10 @@
 # Add testing
 if(BUILD_TESTING)
   # To get the environment path
-  find_package(holoscan 1.0 REQUIRED CONFIG PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+  if (NOT HOLOHUB_WHEEL_TESTING)
+      find_package(holoscan 1.0 REQUIRED CONFIG
+                   PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+  endif()
 
   set(RECORDING_DIR ${CMAKE_CURRENT_BINARY_DIR}/recording_output)
   set(SOURCE_VIDEO_BASENAME python_multiai_ultrasound_output)

--- a/applications/multiai_ultrasound/python/CMakeLists.txt
+++ b/applications/multiai_ultrasound/python/CMakeLists.txt
@@ -16,7 +16,7 @@
 # Add testing
 if(BUILD_TESTING)
   # To get the environment path
-  if (NOT HOLOHUB_WHEEL_TESTING)
+  if(NOT HOLOHUB_WHEEL_TESTING)
       find_package(holoscan 1.0 REQUIRED CONFIG
                    PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
   endif()

--- a/applications/ultrasound_segmentation/CMakeLists.txt
+++ b/applications/ultrasound_segmentation/CMakeLists.txt
@@ -36,7 +36,7 @@ if(HOLOHUB_DOWNLOAD_DATASETS)
   )
 endif()
 
-if (NOT HOLOHUB_WHEEL_TESTING)
+if(NOT HOLOHUB_WHEEL_TESTING)
     add_subdirectory(cpp)
 endif()
 add_subdirectory(python)

--- a/applications/ultrasound_segmentation/CMakeLists.txt
+++ b/applications/ultrasound_segmentation/CMakeLists.txt
@@ -36,5 +36,7 @@ if(HOLOHUB_DOWNLOAD_DATASETS)
   )
 endif()
 
-add_subdirectory(cpp)
+if (NOT HOLOHUB_WHEEL_TESTING)
+    add_subdirectory(cpp)
+endif()
 add_subdirectory(python)

--- a/applications/ultrasound_segmentation/python/CMakeLists.txt
+++ b/applications/ultrasound_segmentation/python/CMakeLists.txt
@@ -16,7 +16,7 @@
 # Add testing
 if(BUILD_TESTING)
   # To get the environment path
-  if (NOT HOLOHUB_WHEEL_TESTING)
+  if(NOT HOLOHUB_WHEEL_TESTING)
       find_package(holoscan 0.6 REQUIRED CONFIG
                    PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
   endif()

--- a/applications/ultrasound_segmentation/python/CMakeLists.txt
+++ b/applications/ultrasound_segmentation/python/CMakeLists.txt
@@ -16,8 +16,10 @@
 # Add testing
 if(BUILD_TESTING)
   # To get the environment path
-  find_package(holoscan 0.6 REQUIRED CONFIG
-               PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+  if (NOT HOLOHUB_WHEEL_TESTING)
+      find_package(holoscan 0.6 REQUIRED CONFIG
+                   PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+  endif()
 
   set(RECORDING_DIR ${CMAKE_CURRENT_BINARY_DIR}/recording_output)
   set(SOURCE_VIDEO_BASENAME python_ultrasound_segmentation_output)

--- a/gxf_extensions/lstm_tensor_rt_inference/CMakeLists.txt
+++ b/gxf_extensions/lstm_tensor_rt_inference/CMakeLists.txt
@@ -12,41 +12,43 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.20)
-project(gxf_lstm_tensor_rt_inference)
+if (NOT HOLOHUB_WHEEL_TESTING)
+    cmake_minimum_required(VERSION 3.20)
+    project(gxf_lstm_tensor_rt_inference)
 
-find_package(holoscan REQUIRED CONFIG
-             PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+    find_package(holoscan REQUIRED CONFIG
+                 PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
-# Create library
-add_library(gxf_lstm_tensor_rt_inference_lib SHARED
-  tensor_rt_inference.cpp
-  tensor_rt_inference.hpp
-)
+    # Create library
+    add_library(gxf_lstm_tensor_rt_inference_lib SHARED
+      tensor_rt_inference.cpp
+      tensor_rt_inference.hpp
+    )
 
-set_target_properties(gxf_lstm_tensor_rt_inference_lib PROPERTIES CXX_STANDARD 17)
+    set_target_properties(gxf_lstm_tensor_rt_inference_lib PROPERTIES CXX_STANDARD 17)
 
-target_link_libraries(gxf_lstm_tensor_rt_inference_lib
-  PUBLIC
-    CUDA::cudart
-    GXF::cuda
-    GXF::std
-    nvinfer
-    nvinfer_plugin
-    nvonnxparser
-    yaml-cpp
-    holoscan::core  # included only as a way to find dlpack/dlpack.h for GXF::std
-)
+    target_link_libraries(gxf_lstm_tensor_rt_inference_lib
+      PUBLIC
+        CUDA::cudart
+        GXF::cuda
+        GXF::std
+        nvinfer
+        nvinfer_plugin
+        nvonnxparser
+        yaml-cpp
+        holoscan::core  # included only as a way to find dlpack/dlpack.h for GXF::std
+    )
 
-# Create extension
-add_library(gxf_lstm_tensor_rt_inference SHARED
-  lstm_tensor_rt_extension.cpp
-)
-target_link_libraries(gxf_lstm_tensor_rt_inference
-  PUBLIC gxf_lstm_tensor_rt_inference_lib
-)
+    # Create extension
+    add_library(gxf_lstm_tensor_rt_inference SHARED
+      lstm_tensor_rt_extension.cpp
+    )
+    target_link_libraries(gxf_lstm_tensor_rt_inference
+      PUBLIC gxf_lstm_tensor_rt_inference_lib
+    )
 
-install(TARGETS gxf_lstm_tensor_rt_inference_lib
-                gxf_lstm_tensor_rt_inference
-        DESTINATION lib/gxf_extensions
-                )
+    install(TARGETS gxf_lstm_tensor_rt_inference_lib
+                    gxf_lstm_tensor_rt_inference
+            DESTINATION lib/gxf_extensions
+                    )
+endif()

--- a/gxf_extensions/lstm_tensor_rt_inference/CMakeLists.txt
+++ b/gxf_extensions/lstm_tensor_rt_inference/CMakeLists.txt
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-if (NOT HOLOHUB_WHEEL_TESTING)
+if(NOT HOLOHUB_WHEEL_TESTING)
     cmake_minimum_required(VERSION 3.20)
     project(gxf_lstm_tensor_rt_inference)
 

--- a/operators/lstm_tensor_rt_inference/CMakeLists.txt
+++ b/operators/lstm_tensor_rt_inference/CMakeLists.txt
@@ -12,24 +12,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.20)
-project(lstm_tensor_rt_inference)
+if (NOT HOLOHUB_WHEEL_TESTING)
+    cmake_minimum_required(VERSION 3.20)
+    project(lstm_tensor_rt_inference)
 
-find_package(holoscan REQUIRED CONFIG
-             PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+    find_package(holoscan REQUIRED CONFIG
+                 PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
-add_library(lstm_tensor_rt_inference SHARED
-  lstm_tensor_rt_inference.cpp
-  lstm_tensor_rt_inference.hpp
-  )
+    add_library(lstm_tensor_rt_inference SHARED
+      lstm_tensor_rt_inference.cpp
+      lstm_tensor_rt_inference.hpp
+      )
 
-target_link_libraries(lstm_tensor_rt_inference holoscan::core)
-target_include_directories(lstm_tensor_rt_inference INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(lstm_tensor_rt_inference holoscan::core)
+    target_include_directories(lstm_tensor_rt_inference INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
-if(HOLOHUB_BUILD_PYTHON)
-    add_subdirectory(python)
+    if(HOLOHUB_BUILD_PYTHON)
+        add_subdirectory(python)
+    endif()
+
+    # Installation
+    install(TARGETS lstm_tensor_rt_inference)
 endif()
-
-# Installation
-install(TARGETS lstm_tensor_rt_inference)
-

--- a/operators/lstm_tensor_rt_inference/CMakeLists.txt
+++ b/operators/lstm_tensor_rt_inference/CMakeLists.txt
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-if (NOT HOLOHUB_WHEEL_TESTING)
+if(NOT HOLOHUB_WHEEL_TESTING)
     cmake_minimum_required(VERSION 3.20)
     project(lstm_tensor_rt_inference)
 

--- a/operators/tool_tracking_postprocessor/CMakeLists.txt
+++ b/operators/tool_tracking_postprocessor/CMakeLists.txt
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-if (NOT HOLOHUB_WHEEL_TESTING)
+if(NOT HOLOHUB_WHEEL_TESTING)
     cmake_minimum_required(VERSION 3.24)
 
     project(tool_tracking_postprocessor LANGUAGES CXX CUDA)

--- a/operators/tool_tracking_postprocessor/CMakeLists.txt
+++ b/operators/tool_tracking_postprocessor/CMakeLists.txt
@@ -12,41 +12,42 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.24)
+if (NOT HOLOHUB_WHEEL_TESTING)
+    cmake_minimum_required(VERSION 3.24)
 
-project(tool_tracking_postprocessor LANGUAGES CXX CUDA)
+    project(tool_tracking_postprocessor LANGUAGES CXX CUDA)
 
-find_package(holoscan REQUIRED CONFIG
+    find_package(holoscan REQUIRED CONFIG
              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
-add_library(tool_tracking_postprocessor SHARED
-  tool_tracking_postprocessor.cpp
-  tool_tracking_postprocessor.hpp
-  tool_tracking_postprocessor.cu
-  tool_tracking_postprocessor.cuh
-  )
+    add_library(tool_tracking_postprocessor SHARED
+      tool_tracking_postprocessor.cpp
+      tool_tracking_postprocessor.hpp
+      tool_tracking_postprocessor.cu
+      tool_tracking_postprocessor.cuh
+      )
 
-set_target_properties(tool_tracking_postprocessor
-  PROPERTIES
-    # separable compilation is required since we launch kernels from within kernels
-    CUDA_SEPARABLE_COMPILATION ON
-    # compile for the architecture of the current GPU
-    CUDA_ARCHITECTURES "native"
-  )
+    set_target_properties(tool_tracking_postprocessor
+      PROPERTIES
+        # separable compilation is required since we launch kernels from within kernels
+        CUDA_SEPARABLE_COMPILATION ON
+        # compile for the architecture of the current GPU
+        CUDA_ARCHITECTURES "native"
+      )
 
-target_link_libraries(tool_tracking_postprocessor
-  PUBLIC
-    holoscan::core
-  )
+    target_link_libraries(tool_tracking_postprocessor
+      PUBLIC
+        holoscan::core
+      )
 
-target_include_directories(tool_tracking_postprocessor
-  INTERFACE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-  )
+    target_include_directories(tool_tracking_postprocessor
+      INTERFACE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+      )
 
-if(HOLOHUB_BUILD_PYTHON)
-    add_subdirectory(python)
+    if(HOLOHUB_BUILD_PYTHON)
+        add_subdirectory(python)
+    endif()
+
+    install(TARGETS tool_tracking_postprocessor)
 endif()
-
-install(TARGETS tool_tracking_postprocessor)
-


### PR DESCRIPTION
Update holohub applications that are tested by nightly CI for python wheels flow.

When this option is enabled:
* no need to the holoscan package with `find_package`
* don't build cpp application and it's operators