### PR TITLE
Enforce use of jammy for github actions

### DIFF
--- a/.github/workflows/check_lint.yml
+++ b/.github/workflows/check_lint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/check_metadata.yml
+++ b/.github/workflows/check_metadata.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-metadata:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## Context

We currently install some linter deps with `apt install` and pinned versions, but the CI ubuntu version is not pinned, which can create this error when `noble` is used:

```
[command] apt install --no-install-recommends -y clang-format=1:14.0*

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
Package clang-format is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Version '1:14.0*' for 'clang-format' was not found
```

## Changes

Ping CI actions to run on `jammy` 

## Results

Confirm that CI passes