### PR TITLE
Address warnings in ano dpdk manager cmakelists.txt

### DIFF
--- a/operators/advanced_network/managers/dpdk/CMakeLists.txt
+++ b/operators/advanced_network/managers/dpdk/CMakeLists.txt
@@ -33,7 +33,8 @@ if(NOT DPDK_FOUND)
   target_link_libraries(${PROJECT_NAME} PUBLIC holoscan::core ${DPDK_LDFLAGS_OTHER} ${DPDK_LIBRARIES})
 else() # Upstream DPDK
   set(DPDK_EXTRA_LIBS -Wl,--no-whole-archive -lmlx5 -libverbs -pthread -lnuma -ldl)
-  target_link_libraries(${PROJECT_NAME} PUBLIC holoscan::core -L${DPDK_LIBRARY_DIRS} ${DPDK_EXTRA_LIBS} ${DPDK_LIBRARIES})
+  target_link_directories(${PROJECT_NAME} PUBLIC ${DPDK_LIBRARY_DIRS})
+  target_link_libraries(${PROJECT_NAME} PUBLIC holoscan::core ${DPDK_EXTRA_LIBS} ${DPDK_LIBRARIES})
 endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES CUDA_SEPARABLE_COMPILATION ON)


### PR DESCRIPTION
linking dir as target

address:
```
-- Configuring done
CMake Warning at operators/advanced_network/managers/CMakeLists.txt:24 (add_subdirectory):
  Target "advanced_network_common" requests linking to directory
  "/usr/lib/x86_64-linux-gnu".  Targets may link only to libraries.  CMake is
  dropping the item.


CMake Warning at operators/advanced_network/managers/CMakeLists.txt:24 (add_subdirectory):
  Target "ano_manager_dpdk" requests linking to directory
  "/usr/lib/x86_64-linux-gnu".  Targets may link only to libraries.  CMake is
  dropping the item.


-- Generating done
```