### PR TITLE
Fix run list for non-cmake targets

### DIFF
--- a/run
+++ b/run
@@ -690,13 +690,13 @@ build() {
   opt_prefix=""
   is_app=false
   is_pkg=false
-  if list_packages | grep -Fxq "$project"; then
+  if list_packages | awk '{print $1}' | grep -Fxq "$project"; then
     opt_prefix="-D PKG_"
     is_pkg=true
-  elif list_apps | grep -Fxq "$project"; then
+  elif list_apps | awk '{print $1}' | grep -Fxq "$project"; then
     opt_prefix="-D APP_"
     is_app=true
-  elif list_operators | grep -Fxq "$project"; then
+  elif list_operators | awk '{print $1}' | grep -Fxq "$project"; then
     opt_prefix="-D OP_"
   else
     print_error "Unknown package, application, or operator: $1"
@@ -939,12 +939,29 @@ list_cmake_dir_options() {
   echo "$cmake_add_dir" | sed -n "s|$cmake_function([[:space:]]*\([^[:space:])]*\).*|\1|p" | sort
 }
 
+list_metadata_json_dir() {
+  json_list=$(find $@ -name 'metadata.json' | sort -d)
+
+  for json in ${json_list}; do
+    local json_path=$(dirname "$json")
+    local json_dir=$(basename "$json_path")
+    if [[ ${json_dir} != "cpp" ]] && [[ ${json_dir} != "python" ]]; then
+      language=""
+      name="${json_dir}"
+    else
+      language="(${json_dir})"
+      name=$(basename $(dirname "$json_path"))
+    fi
+    echo $name $language
+  done
+}
+
 list_apps() {
-  list_cmake_dir_options add_holohub_application
+  list_metadata_json_dir ${SCRIPT_DIR}/applications ${SCRIPT_DIR}/benchmarks
 }
 
 list_operators() {
-  list_cmake_dir_options add_holohub_operator
+  list_metadata_json_dir ${SCRIPT_DIR}/operators
 }
 
 list_packages() {

--- a/run
+++ b/run
@@ -941,16 +941,18 @@ list_cmake_dir_options() {
 
 list_metadata_json_dir() {
   json_list=$(find $@ -name 'metadata.json' | sort -d)
-
   for json in ${json_list}; do
     local json_path=$(dirname "$json")
     local json_dir=$(basename "$json_path")
-    if [[ ${json_dir} != "cpp" ]] && [[ ${json_dir} != "python" ]]; then
-      language=""
-      name="${json_dir}"
-    else
+    if [[ "${json_dir}" =~ \{\{[^}]+\}\} ]]; then
+      # skip templates like {{ foo }}
+      continue
+    elif [[ ${json_dir} == "cpp" ]] || [[ ${json_dir} == "python" ]]; then
       language="(${json_dir})"
       name=$(basename $(dirname "$json_path"))
+    else
+      language=""
+      name="${json_dir}"
     fi
     echo $name $language
   done


### PR DESCRIPTION
Regression introduced in https://github.com/nvidia-holoscan/holohub/pull/639

was only looking for cmake targets, did not account for pure python targets

Before: 53 apps.
After: ~~97~~ 96 apps.