### PR TITLE
Update package prerequisite documentation

### DIFF
--- a/doc/developer.md
+++ b/doc/developer.md
@@ -23,19 +23,22 @@ Install the package dependencies for HoloHub on your host system. The easiest wa
   sudo ./run setup
 ```
 
-If you prefer you can also install the dependencies manually:
+If you prefer you can also install the dependencies manually, typically including the following:
 - [CMake](https://www.cmake.org): 3.24.0+
-- Python interpreter: 3.8 to 3.11
-- Python dev: 3.8 to 3.11 (matching version of the interpreter)
+- Python interpreter: 3.9 to 3.12
+- Python dev: 3.9 to 3.12 (matching version of the interpreter)
 - ffmpeg runtime
 - [ngc-cli](https://ngc.nvidia.com/setup/installers/cli)
 - wget
-- CUDA: 11.6 or 11.8 (CUDA 12 is not supported yet)
-- libcudnn8
-- libcudnn8-dev
+- CUDA Toolkit: 12.6
+- libcudnn9-cuda-12
+- libcudnn9-dev-cuda-12
 - libnvinfer-dev
 - libnvinfer-plugin-dev
 - libnvonnxparsers-dev
+
+Visit the [Holoscan SDK User Guide](https://docs.nvidia.com/holoscan/sdk-user-guide/sdk_installation.html) for the latest
+details on dependency versions and custom installation.
 
 *Note: the run script setup installs the minimal set of dependencies required to run the sample applications. Other applications might require more dependencies. Please refer to the README of each application for more information.*
 

--- a/run
+++ b/run
@@ -304,14 +304,14 @@ setup() {
 
   # Install python dev
   python3_dev_version=$(dpkg --status python3-dev  2>/dev/null | grep -Po '^Version: \K[^-]*')
-  python3_min_version=$(compare_version ${python3_dev_version} "3.8.0")
+  python3_min_version=$(compare_version ${python3_dev_version} "3.9.0")
 
   # Python 3.8 to 3.11 are supported
   if [[ $python3_dev_version == "" ]] || [[ $python3_min_version == "2" ]]; then
     echo "Installing python"
     apt install --no-install-recommends -y python3 python3-dev
     python3_dev_version=$(dpkg --status python3-dev  2>/dev/null | grep -Po '^Version: \K[^-]*')
-    python3_min_version=$(compare_version ${python3_dev_version} "3.8.0")
+    python3_min_version=$(compare_version ${python3_dev_version} "3.9.0")
   fi
 
   # If python version is too high


### PR DESCRIPTION
Changes:
- Update `./run setup` to drop Python 3.8 following Holoscan SDK dropping support in the 2.6.0 release
- Update package prerequisite documentation to reflect latest state of HoloHub `./run setup` following stack updates in the Holoscan SDK 2.6.0 release