### PR TITLE
Build: Set default `CUDA_ARCHITECTURES` for builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,11 @@ set(HOLOHUB_DATA_DIR "${CMAKE_BINARY_DIR}/data" CACHE PATH "Data Download direct
 set(CMAKE_INSTALL_RPATH
     "\$ORIGIN:\$ORIGIN/../../../lib:\$ORIGIN/../../lib:/opt/nvidia/holoscan/lib/")
 
+# Set the default CUDA target platforms
+if(NOT CMAKE_CUDA_ARCHITECTURES)
+  set(CMAKE_CUDA_ARCHITECTURES "native")
+endif()
+
 # Build packaging
 add_subdirectory(pkg)
 


### PR DESCRIPTION
Set a default `CMAKE_CUDA_ARCHITECTURES` list for builds to inherit that covers the native build architecture directly.

Addresses an observed issue on IGX OS 1.1 (dGPU) where PTX just-in-time compilation fails due to compute stack mismatch among 12.2 drivers and 12.6 CUDA Toolkit version. The NVCC target of "52" does not generate CUBIN for supported IGX dGPUs (typically 8.6 compute capability).

Setting the default as "native" results in better compatibility with the build environment's dGPU and aligns with HoloHub defaults that assume the build and target platform are the same.

HoloHub projects requiring portability should override this default value.