### PR TITLE
Update holoscan version

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ Check to verify that the image is created:
 $ docker images
 REPOSITORY      TAG               IMAGE ID       CREATED         SIZE
 ...
-holohub         ngc-v2.1.0-dgpu   17e3aa51f129   13 days ago     13.2GB
+holohub         ngc-v2.8.0-dgpu   17e3aa51f129   13 days ago     13.2GB
 ...
 ```
 
-***Note:*** The development container script ```dev_container``` will by default detect if the system is using an iGPU (integrated GPU) or a dGPU (discrete GPU) and use [NGC's Holoscan SDK container](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/clara-holoscan/containers/holoscan) **`v2.1`** for the [Container build](#container-build-recommended). See [Advanced Container Build Options](/doc/developer.md#advanced-build-options-container) if you would like to use an older version of the SDK as a custom base image.
+***Note:*** The development container script ```dev_container``` will by default detect if the system is using an iGPU (integrated GPU) or a dGPU (discrete GPU) and use [NGC's Holoscan SDK container](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/clara-holoscan/containers/holoscan) **`v2.8`** for the [Container build](#container-build-recommended). See [Advanced Container Build Options](/doc/developer.md#advanced-build-options-container) if you would like to use an older version of the SDK as a custom base image.
 
 See the [Developer Reference document](/doc/developer.md) for additional options.
 


### PR DESCRIPTION
Update the holoscan Docker image version to 2.8.0 in the README, which is the version that will be installed in the Docker images.