### PR TITLE
Remove call to install CLI dependencies

### DIFF
--- a/tutorials/debugging/holoscan_container_vscode/.devcontainer/Dockerfile
+++ b/tutorials/debugging/holoscan_container_vscode/.devcontainer/Dockerfile
@@ -37,9 +37,6 @@ RUN groupadd --gid $USER_GID $USERNAME \
 # [Optional] Uncomment this section to install additional vcpkg ports.
 # RUN su vscode -c "${VCPKG_ROOT}/vcpkg install <your-port-name-here>"
 
-# Install Holoscan CLI dependencies
-RUN pip install $(sed -n '/done <<EOF/,/EOF/{/done <<EOF/b;/EOF/b;p}' /opt/nvidia/holoscan/bin/holoscan)
-
 # Install additional packages
 RUN apt-get update \
     && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
Since CLI is no longer bundled with HSDK (2.9 and onward), we can remove the call to parse and install CLI dependencies.