### PR TITLE
Build: Replace NGC ZIP archive HTTPS downloads with NGC CLI

### DIFF
--- a/applications/colonoscopy_segmentation/CMakeLists.txt
+++ b/applications/colonoscopy_segmentation/CMakeLists.txt
@@ -20,9 +20,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(colonoscopy_segmentation
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_colonoscopy_sample_data/versions/20230222/zip
+    URL nvidia/clara-holoscan/holoscan_colonoscopy_sample_data:20230222
     DOWNLOAD_NAME holoscan_colonoscopy_sample_data_20230222.zip
-    URL_MD5 46e42fb08602fa1acdd1c02f10bde5a5
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     GENERATE_GXF_ENTITIES
     GXF_ENTITIES_HEIGHT 576

--- a/applications/cvcuda_basic/CMakeLists.txt
+++ b/applications/cvcuda_basic/CMakeLists.txt
@@ -22,9 +22,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(endoscopy
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_endoscopy_sample_data/versions/20230222/zip
+    URL nvidia/clara-holoscan/holoscan_endoscopy_sample_data:20230222
     DOWNLOAD_NAME holoscan_endoscopy_sample_data_20230222.zip
-    URL_MD5 d54f84a562d29ed560a87d2607eba973
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     GENERATE_GXF_ENTITIES
     GXF_ENTITIES_HEIGHT 480

--- a/applications/distributed/grpc/grpc_endoscopy_tool_tracking/CMakeLists.txt
+++ b/applications/distributed/grpc/grpc_endoscopy_tool_tracking/CMakeLists.txt
@@ -20,9 +20,8 @@ project(grpc_endoscopy_tool_tracking LANGUAGES NONE)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(endoscopy
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_endoscopy_sample_data/versions/20230222/zip
+    URL nvidia/clara-holoscan/holoscan_endoscopy_sample_data:20230222
     DOWNLOAD_NAME holoscan_endoscopy_sample_data_20230222.zip
-    URL_MD5 d54f84a562d29ed560a87d2607eba973
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     GENERATE_GXF_ENTITIES
     GXF_ENTITIES_HEIGHT 480

--- a/applications/distributed/grpc/grpc_endoscopy_tool_tracking/cpp/CMakeLists.txt
+++ b/applications/distributed/grpc/grpc_endoscopy_tool_tracking/cpp/CMakeLists.txt
@@ -73,9 +73,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(endoscopy
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_endoscopy_sample_data/versions/20230222/zip
+    URL nvidia/clara-holoscan/holoscan_endoscopy_sample_data:20230222
     DOWNLOAD_NAME holoscan_endoscopy_sample_data_20230222.zip
-    URL_MD5 d54f84a562d29ed560a87d2607eba973
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
   )
   add_dependencies(grpc_endoscopy_tool_tracking_edge endoscopy_data)

--- a/applications/distributed/grpc/grpc_h264_endoscopy_tool_tracking/cpp/CMakeLists.txt
+++ b/applications/distributed/grpc/grpc_h264_endoscopy_tool_tracking/cpp/CMakeLists.txt
@@ -83,9 +83,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(endoscopy
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_endoscopy_sample_data/versions/20230222/zip
+    URL nvidia/clara-holoscan/holoscan_endoscopy_sample_data:20230222
     DOWNLOAD_NAME holoscan_endoscopy_sample_data_20230222.zip
-    URL_MD5 d54f84a562d29ed560a87d2607eba973
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
   )
   add_dependencies(grpc_h264_endoscopy_tool_tracking_edge endoscopy_data)

--- a/applications/distributed/ucx/ucx_endoscopy_tool_tracking/CMakeLists.txt
+++ b/applications/distributed/ucx/ucx_endoscopy_tool_tracking/CMakeLists.txt
@@ -23,9 +23,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(endoscopy
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_endoscopy_sample_data/versions/20230222/zip
+    URL nvidia/clara-holoscan/holoscan_endoscopy_sample_data:20230222
     DOWNLOAD_NAME holoscan_endoscopy_sample_data_20230222.zip
-    URL_MD5 d54f84a562d29ed560a87d2607eba973
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     GENERATE_GXF_ENTITIES
     GXF_ENTITIES_HEIGHT 480

--- a/applications/distributed/ucx/ucx_h264_endoscopy_tool_tracking/cpp/CMakeLists.txt
+++ b/applications/distributed/ucx/ucx_h264_endoscopy_tool_tracking/cpp/CMakeLists.txt
@@ -50,9 +50,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(endoscopy
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_endoscopy_sample_data/versions/20230222/zip
+    URL nvidia/clara-holoscan/holoscan_endoscopy_sample_data:20230222
     DOWNLOAD_NAME holoscan_endoscopy_sample_data_20230222.zip
-    URL_MD5 d54f84a562d29ed560a87d2607eba973
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
   )
   add_dependencies(ucx_h264_endoscopy_tool_tracking endoscopy_data)

--- a/applications/endoscopy_depth_estimation/CMakeLists.txt
+++ b/applications/endoscopy_depth_estimation/CMakeLists.txt
@@ -25,9 +25,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(endoscopy
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_endoscopy_sample_data/versions/20230222/zip
+    URL nvidia/clara-holoscan/holoscan_endoscopy_sample_data:20230222
     DOWNLOAD_NAME holoscan_endoscopy_sample_data_20230222.zip
-    URL_MD5 d54f84a562d29ed560a87d2607eba973
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     GENERATE_GXF_ENTITIES
     GXF_ENTITIES_HEIGHT 480
@@ -38,9 +37,8 @@ if(HOLOHUB_DOWNLOAD_DATASETS)
   )
   # Now download the model
   holoscan_download_data(endoscopy_depth
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_endoscopy_depth_estimation_sample_data/versions/20230727/zip
+    URL nvidia/clara-holoscan/holoscan_endoscopy_depth_estimation_sample_data:20230727
     DOWNLOAD_NAME holoscan_endoscopy_depth_model_20230727.zip
-    URL_MD5 b927cb2854eda9c7de44062c8019b87a
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     ALL
   )

--- a/applications/endoscopy_out_of_body_detection/CMakeLists.txt
+++ b/applications/endoscopy_out_of_body_detection/CMakeLists.txt
@@ -39,9 +39,8 @@ target_link_libraries(endoscopy_out_of_body_detection
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(endoscopy_out_of_body_detection
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/endoscopy_out_of_body_detection/versions/20230127/zip
+    URL nvidia/clara-holoscan/endoscopy_out_of_body_detection:20230127
     DOWNLOAD_NAME endoscopy_out_of_body_detection_20230127.zip
-    URL_MD5 378e9b19bdcb1293f8b3f44ebf07e160
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     GENERATE_GXF_ENTITIES
     GXF_ENTITIES_HEIGHT 256

--- a/applications/endoscopy_tool_tracking/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/CMakeLists.txt
@@ -23,9 +23,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(endoscopy
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_endoscopy_sample_data/versions/20230222/zip
+    URL nvidia/clara-holoscan/holoscan_endoscopy_sample_data:20230222
     DOWNLOAD_NAME holoscan_endoscopy_sample_data_20230222.zip
-    URL_MD5 d54f84a562d29ed560a87d2607eba973
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     GENERATE_GXF_ENTITIES
     GXF_ENTITIES_HEIGHT 480

--- a/applications/h264/h264_endoscopy_tool_tracking/cpp/CMakeLists.txt
+++ b/applications/h264/h264_endoscopy_tool_tracking/cpp/CMakeLists.txt
@@ -50,9 +50,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(endoscopy
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_endoscopy_sample_data/versions/20230222/zip
+    URL nvidia/clara-holoscan/holoscan_endoscopy_sample_data:20230222
     DOWNLOAD_NAME holoscan_endoscopy_sample_data_20230222.zip
-    URL_MD5 d54f84a562d29ed560a87d2607eba973
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
   )
   add_dependencies(h264_endoscopy_tool_tracking endoscopy_data)

--- a/applications/h264/h264_video_decode/cpp/CMakeLists.txt
+++ b/applications/h264/h264_video_decode/cpp/CMakeLists.txt
@@ -43,9 +43,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(endoscopy
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_endoscopy_sample_data/versions/20230222/zip
+    URL nvidia/clara-holoscan/holoscan_endoscopy_sample_data:20230222
     DOWNLOAD_NAME holoscan_endoscopy_sample_data_20230222.zip
-    URL_MD5 d54f84a562d29ed560a87d2607eba973
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
   )
   add_dependencies(h264_video_decode endoscopy_data)

--- a/applications/hyperspectral_segmentation/CMakeLists.txt
+++ b/applications/hyperspectral_segmentation/CMakeLists.txt
@@ -25,7 +25,7 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(hyperspectral
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/hyperspectral_segmentation/versions/20231109/zip
+    URL nvidia/clara-holoscan/hyperspectral_segmentation:20231109
     DOWNLOAD_NAME hyperspectral_segmentation_20231109.zip
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     ALL

--- a/applications/multiai_endoscopy/CMakeLists.txt
+++ b/applications/multiai_endoscopy/CMakeLists.txt
@@ -23,9 +23,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(endoscopy
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_endoscopy_sample_data/versions/20230222/zip
+    URL nvidia/clara-holoscan/holoscan_endoscopy_sample_data:20230222
     DOWNLOAD_NAME holoscan_endoscopy_sample_data_20230222.zip
-    URL_MD5 d54f84a562d29ed560a87d2607eba973
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     GENERATE_GXF_ENTITIES
     GXF_ENTITIES_HEIGHT 480
@@ -35,16 +34,14 @@ if(HOLOHUB_DOWNLOAD_DATASETS)
   )
 
   holoscan_download_data(ssd_model
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/ssd_surgical_tool_detection_model/versions/v0.1/zip
+    URL nvidia/clara-holoscan/ssd_surgical_tool_detection_model:v0.1
     DOWNLOAD_NAME ssd_surgical_tool_detection_model_v0.1.zip
-    URL_MD5 daf3663b4bc56de1cb324b0e58aed450
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
   )
 
   holoscan_download_data(monai_tool_seg_model
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/monai_endoscopic_tool_segmentation_model/versions/v0.1/zip
+    URL nvidia/clara-holoscan/monai_endoscopic_tool_segmentation_model:v0.1
     DOWNLOAD_NAME monai_endoscopic_tool_segmentation_model_v0.1.zip
-    URL_MD5 222d924c5b2b0f196a4ef605c9977764
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
   )
 endif()

--- a/applications/multiai_ultrasound/CMakeLists.txt
+++ b/applications/multiai_ultrasound/CMakeLists.txt
@@ -23,9 +23,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(multiai_ultrasound
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_multi_ai_ultrasound_sample_data/versions/20230222/zip
+    URL nvidia/clara-holoscan/holoscan_multi_ai_ultrasound_sample_data:20230222
     DOWNLOAD_NAME holoscan_multi_ai_ultrasound_sample_data_20230222.zip
-    URL_MD5 59e7b9043fa867a5d45077a91d0ef835
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     GENERATE_GXF_ENTITIES
     GXF_ENTITIES_HEIGHT 320

--- a/applications/nvidia_nim/nvidia_nim_imaging/CMakeLists.txt
+++ b/applications/nvidia_nim/nvidia_nim_imaging/CMakeLists.txt
@@ -29,9 +29,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(nvidia_nim_imaging
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_volume_rendering_sample_data/versions/20230628/zip
+    URL nvidia/clara-holoscan/holoscan_volume_rendering_sample_data:20230628
     DOWNLOAD_NAME holoscan_volume_rendering_sample_data_20230628.zip
-    URL_MD5 129a15d848b83c8f54988d1ee985edca
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     ALL
   )

--- a/applications/object_detection_torch/CMakeLists.txt
+++ b/applications/object_detection_torch/CMakeLists.txt
@@ -40,9 +40,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(object_detection_torch
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_cars_video/versions/20230725/zip
+    URL nvidia/clara-holoscan/holoscan_cars_video:20230725
     DOWNLOAD_NAME holoscan_cars_video_20230725.zip
-    URL_MD5 a0a510bc01cee0580a280d792da9ac5f
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     GENERATE_GXF_ENTITIES
     GXF_ENTITIES_HEIGHT 1080

--- a/applications/openigtlink_3dslicer/cpp/CMakeLists.txt
+++ b/applications/openigtlink_3dslicer/cpp/CMakeLists.txt
@@ -48,9 +48,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(ultrasound_segmentation
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_ultrasound_sample_data/versions/20240801/zip
+    URL nvidia/clara-holoscan/holoscan_ultrasound_sample_data:20240801
     DOWNLOAD_NAME holoscan_ultrasound_sample_data_20240801.zip
-    URL_MD5 9ac3ba657cfbf104ae515a31f3b5af61
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     GENERATE_GXF_ENTITIES
     GXF_ENTITIES_HEIGHT 256

--- a/applications/openigtlink_3dslicer/python/CMakeLists.txt
+++ b/applications/openigtlink_3dslicer/python/CMakeLists.txt
@@ -20,9 +20,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
     holoscan_download_data(colonoscopy_segmentation
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_colonoscopy_sample_data/versions/20230222/zip
+    URL nvidia/clara-holoscan/holoscan_colonoscopy_sample_data:20230222
     DOWNLOAD_NAME holoscan_colonoscopy_sample_data_20230222.zip
-    URL_MD5 46e42fb08602fa1acdd1c02f10bde5a5
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     GENERATE_GXF_ENTITIES
     GXF_ENTITIES_HEIGHT 576

--- a/applications/orsi/CMakeLists.txt
+++ b/applications/orsi/CMakeLists.txt
@@ -43,9 +43,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(orsi
-    URL  https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_orsi_academy_sample_data/versions/20240206/zip
+    URL  nvidia/clara-holoscan/holoscan_orsi_academy_sample_data:20240206
     DOWNLOAD_NAME orsi.zip
-    URL_MD5 5cf78e64bd9696f9e04796cb1e04d2ad
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     GENERATE_GXF_ENTITIES
     GXF_ENTITIES_HEIGHT 1080

--- a/applications/prohawk_video_replayer/cpp/CMakeLists.txt
+++ b/applications/prohawk_video_replayer/cpp/CMakeLists.txt
@@ -49,9 +49,8 @@ add_dependencies(prohawk_video_replayer prohawk_video_replayer_PAFSFilter)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(endoscopy
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_endoscopy_sample_data/versions/20230222/zip
+    URL nvidia/clara-holoscan/holoscan_endoscopy_sample_data:20230222
     DOWNLOAD_NAME holoscan_endoscopy_sample_data_20230222.zip
-    URL_MD5 d54f84a562d29ed560a87d2607eba973
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     GENERATE_GXF_ENTITIES
     GXF_ENTITIES_HEIGHT 480

--- a/applications/qt_video_replayer/CMakeLists.txt
+++ b/applications/qt_video_replayer/CMakeLists.txt
@@ -59,9 +59,8 @@ qt_add_qml_module(qt_video_replayer
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(racerx
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_racerx_video/versions/20231009/zip
+    URL nvidia/clara-holoscan/holoscan_racerx_video:20231009
     DOWNLOAD_NAME holoscan_racerx_video_20231009.zip
-    URL_MD5 86cd7e5477bb9eaa0cfc0547912d77b2
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     ALL
   )

--- a/applications/ultrasound_segmentation/CMakeLists.txt
+++ b/applications/ultrasound_segmentation/CMakeLists.txt
@@ -23,9 +23,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(ultrasound_segmentation
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_ultrasound_sample_data/versions/20240801/zip
+    URL nvidia/clara-holoscan/holoscan_ultrasound_sample_data:20240801
     DOWNLOAD_NAME holoscan_ultrasound_sample_data_20240801.zip
-    URL_MD5 9ac3ba657cfbf104ae515a31f3b5af61
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     GENERATE_GXF_ENTITIES
     GXF_ENTITIES_HEIGHT 256

--- a/applications/volume_rendering/cpp/CMakeLists.txt
+++ b/applications/volume_rendering/cpp/CMakeLists.txt
@@ -34,9 +34,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(volume_rendering
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_volume_rendering_sample_data/versions/20230628/zip
+    URL nvidia/clara-holoscan/holoscan_volume_rendering_sample_data:20230628
     DOWNLOAD_NAME holoscan_volume_rendering_sample_data_20230628.zip
-    URL_MD5 129a15d848b83c8f54988d1ee985edca
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
   )
   add_dependencies(volume_rendering volume_rendering_data)

--- a/applications/volume_rendering/python/CMakeLists.txt
+++ b/applications/volume_rendering/python/CMakeLists.txt
@@ -28,9 +28,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(volume_rendering
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_volume_rendering_sample_data/versions/20230628/zip
+    URL nvidia/clara-holoscan/holoscan_volume_rendering_sample_data:20230628
     DOWNLOAD_NAME holoscan_volume_rendering_python_sample_data_20230628.zip
-    URL_MD5 129a15d848b83c8f54988d1ee985edca
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     ALL
   )

--- a/applications/volume_rendering_xr/CMakeLists.txt
+++ b/applications/volume_rendering_xr/CMakeLists.txt
@@ -78,9 +78,8 @@ option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(volume_rendering_xr
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_volume_rendering_sample_data/versions/20230816/zip
+    URL nvidia/clara-holoscan/holoscan_volume_rendering_sample_data:20230816
     DOWNLOAD_NAME holoscan_volume_rendering_sample_data_20230816.zip
-    URL_MD5 cf5602f1dba90f2e50b1d4eefbf8081e
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
   )
   add_dependencies(volume_rendering_xr volume_rendering_xr_data)

--- a/applications/webrtc_video_server/CMakeLists.txt
+++ b/applications/webrtc_video_server/CMakeLists.txt
@@ -17,9 +17,8 @@
 if(HOLOHUB_DOWNLOAD_DATASETS)
   include(holoscan_download_data)
   holoscan_download_data(racerx
-    URL https://api.ngc.nvidia.com/v2/resources/nvidia/clara-holoscan/holoscan_racerx_video/versions/20231009/zip
+    URL nvidia/clara-holoscan/holoscan_racerx_video:20231009
     DOWNLOAD_NAME holoscan_racerx_video_20231009.zip
-    URL_MD5 86cd7e5477bb9eaa0cfc0547912d77b2
     DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
     ALL
   )


### PR DESCRIPTION
Update NGC data retrieval to address NGC ZIP HTTPS download support deprecation.

As of 2025-01-15 NVIDIA NGC has fully deprecated support for retrieving resources as a ZIP archive via HTTPS tools (curl, wget). This commit updates project CMake calls to `holoscan_download_data` to remove the `https` prefix and prompt the Holoscan SDK `download_ngc_data` script to use the NGC CLI rather than curl or wget to retrieve sample data. MD5 hashsum checks are not supported for NGC CLI downloads with the `download_ngc_data` script as of Holoscan SDK v2.8.0.

Developers not developing in the HoloHub container should run `./run setup` on their system to install HoloHub prerequisites including the NGC CLI tool.

The Holoscan SDK NGC download script is located at: https://raw.githubusercontent.com/nvidia-holoscan/holoscan-sdk/refs/tags/v2.8.0/scripts/download_ngc_data

Affected URLs were identified and replaced with VS Code regex matching:
- Find: https://api.ngc.nvidia.com/v2/resources/([a-zA-Z0-9/_-]+)/versions/([0-9a-zA-Z.]+)/zip
- Replace: $1:$2

https://github.com/nvidia-holoscan/holoscan-sdk/issues/42