### PR TITLE
App: Fix `object_detection_torch` data download

### DIFF
--- a/applications/object_detection_torch/CMakeLists.txt
+++ b/applications/object_detection_torch/CMakeLists.txt
@@ -54,6 +54,7 @@ if(HOLOHUB_DOWNLOAD_DATASETS)
   # Download the model
   add_custom_target(download_model
     COMMAND python3 "${CMAKE_CURRENT_SOURCE_DIR}/generate_resnet_model.py"  "${HOLOHUB_DATA_DIR}/object_detection_torch/frcnn_resnet50_t.pt"
+    DEPENDS object_detection_torch_data
     BYPRODUCTS "${HOLOHUB_DATA_DIR}/object_detection_torch/frcnn_resnet50_t.pt"
   )
   add_dependencies(object_detection_torch download_model)
@@ -69,7 +70,9 @@ add_custom_target(object_detection_torch_yaml
                                                   "${HOLOHUB_DATA_DIR}/object_detection_torch/frcnn_resnet50_t.yaml"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/labels.txt"
                                                   "${HOLOHUB_DATA_DIR}/object_detection_torch/labels.txt"
-    DEPENDS "object_detection_torch.yaml" "postprocessing.yaml" "frcnn_resnet50_t.yaml" "labels.txt"
+    DEPENDS
+      "object_detection_torch.yaml" "postprocessing.yaml" "frcnn_resnet50_t.yaml" "labels.txt"
+      object_detection_torch_data  # download after NGC data is downloaded to avoid directory overwrite
     BYPRODUCTS "object_detection_torch.yaml" "postprocessing.yaml" "frcnn_resnet50_t.yaml" "labels.txt"
 )
 add_dependencies(object_detection_torch object_detection_torch_yaml)


### PR DESCRIPTION
Update the `object_detection_torch` CMake build to avoid overwriting local YAML data with NGC downloaded data. Addresses an issue where the `object_detection_torch` app would sometimes fail to run after build.

Followup to 4e1da8a0 which updated HoloHub NGC data downloads to use the NGC CLI tool rather than HTTPS following NGC deprecation. The Holoscan SDK `download_ngc_data` script assumes the target directory is empty and forcibly clears the local directory when downloading with NGC CLI. If the app build target to populate local files in the data directory completed before NGC CLI download/unzip completed, the local data files would be overwritten and unavailable at runtime.

This fix forces other data targets to depend on the NGC download operation to prevent overwriting data.

Holoscan SDK script reference: https://github.com/nvidia-holoscan/holoscan-sdk/blob/main/scripts/download_ngc_data#L402

Previous failure:
```
[error] [main.cpp:101] Config path not found. Please make sure the path exists /workspace/holohub/data-object_detection_torch-object_detection_torch_main/object_detection_torch/postprocessing.yaml
[error] [main.cpp:103] Did you forget to download the datasets manually?
```

Failure is no longer reproducible after the fix.