### PR TITLE
Infra: Bump for Holoscan SDK v2.9.0 container release

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Check to verify that the image is created:
 $ docker images
 REPOSITORY      TAG               IMAGE ID       CREATED         SIZE
 ...
-holohub         ngc-v2.8.0-dgpu   17e3aa51f129   13 days ago     13.2GB
+holohub         ngc-v2.9.0-dgpu   17e3aa51f129   13 days ago     13.2GB
 ...
 ```
 

--- a/dev_container
+++ b/dev_container
@@ -460,11 +460,11 @@ get_host_gpu() {
 }
 
 get_default_base_img() {
-    echo -n "nvcr.io/nvidia/clara-holoscan/holoscan:v2.8.0-"$(get_host_gpu)
+    echo -n "nvcr.io/nvidia/clara-holoscan/holoscan:v2.9.0-"$(get_host_gpu)
 }
 
 get_default_img() {
-    echo -n "holohub:ngc-v2.8.0-"$(get_host_gpu)
+    echo -n "holohub:ngc-v2.9.0-"$(get_host_gpu)
 }
 
 # This function returns the compute capacity of the system's GPU (8.6, 8.9, etc.)

--- a/operators/advanced_network/Dockerfile
+++ b/operators/advanced_network/Dockerfile
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ARG GPU_TYPE=dgpu
-ARG BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v2.8.0-${GPU_TYPE}
+ARG BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v2.9.0-${GPU_TYPE}
 
 FROM ${BASE_IMAGE} AS base
 ARG UBUNTU_VERSION=22.04


### PR DESCRIPTION
Bump default HoloHub base container to [Holoscan SDK v2.9.0](https://github.com/nvidia-holoscan/holoscan-sdk/releases/tag/v2.9.0)