### PR TITLE
CMake add_custom_command when using OUTPUT

### DIFF
--- a/applications/colonoscopy_segmentation/CMakeLists.txt
+++ b/applications/colonoscopy_segmentation/CMakeLists.txt
@@ -52,7 +52,6 @@ if(BUILD_TESTING)
 
     # Patch the current example to enable recording the rendering window
     add_custom_command(OUTPUT colonoscopy_segmentation_test.py
-    PRE_LINK
     COMMAND patch -u -o colonoscopy_segmentation_test.py ${CMAKE_CURRENT_SOURCE_DIR}/colonoscopy_segmentation.py
         ${CMAKE_SOURCE_DIR}/applications/colonoscopy_segmentation/testing/colonoscopy_segmentation.patch
     COMMAND sed -i "s#RECORDING_DIR#${RECORDING_DIR}#g" colonoscopy_segmentation_test.py

--- a/applications/multiai_endoscopy/cpp/post-proc-cpu/CMakeLists.txt
+++ b/applications/multiai_endoscopy/cpp/post-proc-cpu/CMakeLists.txt
@@ -66,7 +66,6 @@ if(BUILD_TESTING)
 
     # Patch the current example to enable recording the rendering window
     add_custom_command(OUTPUT multiai_endoscopy_test.cpp
-    PRE_LINK
     COMMAND patch -u -o multiai_endoscopy_test.cpp ${CMAKE_CURRENT_SOURCE_DIR}/multi_ai.cpp
         ${CMAKE_SOURCE_DIR}/applications/multiai_endoscopy/testing/cpp_multiai_endoscopy.patch
     COMMAND sed -i "s#RECORDING_DIR#${RECORDING_DIR}#g" multiai_endoscopy_test.cpp

--- a/applications/multiai_endoscopy/python/CMakeLists.txt
+++ b/applications/multiai_endoscopy/python/CMakeLists.txt
@@ -40,7 +40,6 @@ if(BUILD_TESTING)
 
   # Patch the current example to enable recording the rendering window
   add_custom_command(OUTPUT multi_ai_test.py
-  PRE_LINK
   COMMAND patch -u -o multi_ai_test.py ${CMAKE_CURRENT_SOURCE_DIR}/multi_ai.py
       ${CMAKE_SOURCE_DIR}/applications/multiai_endoscopy/testing/python_multiai_endoscopy.patch
   COMMAND sed -i "s#RECORDING_DIR#${RECORDING_DIR}#g" multi_ai_test.py

--- a/applications/ultrasound_segmentation/cpp/CMakeLists.txt
+++ b/applications/ultrasound_segmentation/cpp/CMakeLists.txt
@@ -64,7 +64,6 @@ if(BUILD_TESTING)
 
     # Patch the current example to enable recording the rendering window
     add_custom_command(OUTPUT main_test.cpp
-    PRE_LINK
     COMMAND patch -u -o main_test.cpp ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
         ${CMAKE_SOURCE_DIR}/applications/ultrasound_segmentation/testing/cpp_ultrasound_segmentation.patch
     COMMAND sed -i "s#RECORDING_DIR#${RECORDING_DIR}#g" main_test.cpp

--- a/applications/ultrasound_segmentation/python/CMakeLists.txt
+++ b/applications/ultrasound_segmentation/python/CMakeLists.txt
@@ -33,7 +33,6 @@ if(BUILD_TESTING)
 
   # Patch the current example to enable recording the rendering window
   add_custom_command(OUTPUT ultrasound_segmentation_test.py
-  PRE_LINK
   COMMAND patch -u -o ultrasound_segmentation_test.py ${CMAKE_CURRENT_SOURCE_DIR}/ultrasound_segmentation.py
       ${CMAKE_SOURCE_DIR}/applications/ultrasound_segmentation/testing/python_ultrasound_segmentation.patch
   COMMAND sed -i "s#RECORDING_DIR#${RECORDING_DIR}#g" ultrasound_segmentation_test.py


### PR DESCRIPTION
CMake add_custom_command when using OUTPUT does not have PRE_LINK keyword (warning)