### PR TITLE
Only build python applications when HOLOHUB_BUILD_PYTHON is ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ include(CTest)
 
 # Options
 option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
-option(HOLOHUB_BUILD_PYTHON "Build Holoscan SDK Python Bindings" ON)
+option(HOLOHUB_BUILD_PYTHON "Build support for Python" ON)
 
 # Enable flow benchmarking
 option(FLOW_BENCHMARKING "Enable Flow Benchmarking" OFF)

--- a/applications/endoscopy_tool_tracking/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/CMakeLists.txt
@@ -36,4 +36,7 @@ if(HOLOHUB_DOWNLOAD_DATASETS)
 endif()
 
 add_subdirectory(cpp)
-add_subdirectory(python)
+
+if(HOLOHUB_BUILD_PYTHON)
+  add_subdirectory(python)
+endif()

--- a/applications/multiai_endoscopy/CMakeLists.txt
+++ b/applications/multiai_endoscopy/CMakeLists.txt
@@ -47,4 +47,7 @@ if(HOLOHUB_DOWNLOAD_DATASETS)
 endif()
 
 add_subdirectory(cpp)
-add_subdirectory(python)
+
+if(HOLOHUB_BUILD_PYTHON)
+  add_subdirectory(python)
+endif()

--- a/applications/ultrasound_segmentation/CMakeLists.txt
+++ b/applications/ultrasound_segmentation/CMakeLists.txt
@@ -36,4 +36,7 @@ if(HOLOHUB_DOWNLOAD_DATASETS)
 endif()
 
 add_subdirectory(cpp)
-add_subdirectory(python)
+
+if(HOLOHUB_BUILD_PYTHON)
+  add_subdirectory(python)
+endif()


### PR DESCRIPTION
Some applications cannot be tested with Debian packages since Python is removed.
Adding conditional to only build when HOLOHUB_BUILD_PYTHON is ON (default)