### PR TITLE
Update `aja_video_capture` README and compatibility

### DIFF
--- a/applications/aja_video_capture/README.md
+++ b/applications/aja_video_capture/README.md
@@ -4,49 +4,12 @@ Minimal example to demonstrate the use of the aja source operator to capture dev
 
 *Visit the [SDK User Guide](https://docs.nvidia.com/holoscan/sdk-user-guide/aja_setup.html) to setup the AJA Card.*
 
-## C++ Run instructions
+## Quick Start
 
-* **using deb package install or NGC container**:
-  ```bash
-  /opt/nvidia/holoscan/examples/aja_capture/cpp/aja_capture
-  ```
-* **source (dev container)**:
-  ```bash
-  ./run launch # optional: append `install` for install tree
-  ./examples/aja_capture/cpp/aja_capture
-  
-* **source (local env)**:
-  ```bash
-  ${BUILD_OR_INSTALL_DIR}/examples/aja_capture/cpp/aja_capture
-  ```
+```bash
+dev_container build_and_run aja_video_capture --language <cpp/python>
+```
 
-## Python Run instructions
-
-* **using python wheel**:
-  ```bash
-  # [Prerequisite] Download example .py file below to `APP_DIR`
-  # [Optional] Start the virtualenv where holoscan is installed
-  python3 <APP_DIR>/aja_capture.py
-  ```
-* **using deb package install**:
-  ```bash
-  export PYTHONPATH=/opt/nvidia/holoscan/python/lib
-  python3 /opt/nvidia/holoscan/examples/aja_capture/python/aja_capture.py
-  ```
-* **from NGC container**:
-  ```bash
-  python3 /opt/nvidia/holoscan/examples/aja_capture/python/aja_capture.py
-  ```
-* **source (dev container)**:
-  ```bash
-  ./run launch # optional: append `install` for install tree
-  python3 ./examples/aja_capture/python/aja_capture.py
-  ```
-* **source (local env)**:
-  ```bash
-  export PYTHONPATH=${BUILD_OR_INSTALL_DIR}/python/lib
-  python3 ${BUILD_OR_INSTALL_DIR}/examples/aja_capture/python/aja_capture.py
-  ```
 ## Settings
 
  To evaluate the AJA example using alternative resolutions, you may modify the aja_capture.yaml configuration file as needed. For instance, to test a resolution format of 1280 x 720 at 60 Hz, you can specify the following parameters in the aja section of the configuration :
@@ -57,3 +20,12 @@ Minimal example to demonstrate the use of the aja source operator to capture dev
         height: 720
         framerate: 60
     ```
+
+## Migration Notes
+
+Holoscan SDK AJA support is migrated from the core Holoscan SDK library to the HoloHub community repository in Holoscan SDK v3.0.0.
+Projects depending on AJA support should accordingly update include and linking paths to reference HoloHub.
+
+C++/CMake projects should update `holoscan::ops::aja` to `holoscan::aja`
+
+Python projects should update `import holoscan.operators.AJASourceOp` to `import holohub.aja_source.AJASourceOp`

--- a/applications/aja_video_capture/cpp/CMakeLists.txt
+++ b/applications/aja_video_capture/cpp/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(holoscan 3.0 REQUIRED)
+find_package(holoscan 1.0 REQUIRED)
 
 # Create example
 add_executable(aja_capture

--- a/operators/aja_source/CMakeLists.txt
+++ b/operators/aja_source/CMakeLists.txt
@@ -34,6 +34,7 @@ set(AJANTV2_DISABLE_TESTS ON)
 set(AJANTV2_DISABLE_TOOLS ON)
 set(AJA_INSTALL_HEADERS OFF)
 set(AJA_INSTALL_SOURCES OFF)
+message(STATUS "Fetching AJA sources")
 FetchContent_MakeAvailable(ajantv2)
 # Disable all the warnings for AJA
 target_compile_options(ajantv2 PRIVATE -w)


### PR DESCRIPTION
Changes:
- Update AJA Video Capture README instructions following HoloHub migration
- Downgrade Holoscan SDK build requirement to reflect `metadata.json` versions
- Log a message when beginning to fetch AJA sources