### PR TITLE
Update packaging scripts to use consolidated platform options

### DIFF
--- a/applications/distributed/grpc/grpc_endoscopy_tool_tracking/cpp/package-app.sh
+++ b/applications/distributed/grpc/grpc_endoscopy_tool_tracking/cpp/package-app.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/applications/distributed/grpc/grpc_endoscopy_tool_tracking/cpp/package-app.sh
+++ b/applications/distributed/grpc/grpc_endoscopy_tool_tracking/cpp/package-app.sh
@@ -26,11 +26,7 @@ if [ ! -d $APP_PATH ]; then
     exit -1
 fi
 
-PLATFORM=x64-workstation
-GPU=$(get_host_gpu)
-if [ $(get_host_arch) == "aarch64" ]; then
-    PLATFORM=igx-orin-devkit
-fi
+PLATFORM=$(get_platform_example_for_cli)
 
 echo -e "Copying the required files to the application directory..."
 # cp -rf "$GIT_ROOT/install/lib/." "$APP_PATH"
@@ -41,13 +37,13 @@ echo -e "done\n"
 echo -e Install Holoscan CLI and then use the following commands to package and run the Endoscopy Tool Tracking application:
 echo -e "==========Package the application=========="
 echo -e "Cloud:"
-echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform [igx-orin-devkit | jetson-agx-orin-devkit | sbsa, x64-workstation] --platform-config [igpu | dgpu] -t holohub-grpc-endoscopy-tool-tracking-cloud $APP_PATH/grpc_endoscopy_tool_tracking_cloud --include onnx holoviz$ --add $GIT_ROOT/install/lib${NOCOLOR}"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform [jetson | igx-igpu | igx-dgpu | sbsa | x86_64] -t holohub-grpc-endoscopy-tool-tracking-cloud $APP_PATH/grpc_endoscopy_tool_tracking_cloud --include onnx holoviz$ --add $GIT_ROOT/install/lib${NOCOLOR}"
 echo -e "\nFor example:"
-echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform ${PLATFORM} --platform-config ${GPU} -t holohub-grpc-endoscopy-tool-tracking-cloud $APP_PATH/grpc_endoscopy_tool_tracking_cloud --include onnx holoviz --add $GIT_ROOT/install/lib${NOCOLOR}"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform ${PLATFORM} -t holohub-grpc-endoscopy-tool-tracking-cloud $APP_PATH/grpc_endoscopy_tool_tracking_cloud --include onnx holoviz --add $GIT_ROOT/install/lib${NOCOLOR}"
 echo -e "\nEdge:"
-echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform [igx-orin-devkit | jetson-agx-orin-devkit | sbsa, x64-workstation] --platform-config [igpu | dgpu] -t holohub-grpc-endoscopy-tool-tracking-edge $APP_PATH/grpc_endoscopy_tool_tracking_edge --include onnx holoviz --add $GIT_ROOT/install/lib${NOCOLOR}"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform [jetson | igx-igpu | igx-dgpu | sbsa | x86_64] --platform-config [igpu | dgpu] -t holohub-grpc-endoscopy-tool-tracking-edge $APP_PATH/grpc_endoscopy_tool_tracking_edge --include onnx holoviz --add $GIT_ROOT/install/lib${NOCOLOR}"
 echo -e "\nFor example:"
-echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform ${PLATFORM} --platform-config ${GPU} -t holohub-grpc-endoscopy-tool-tracking-edge $APP_PATH/grpc_endoscopy_tool_tracking_edge --include onnx holoviz --add $GIT_ROOT/install/lib${NOCOLOR}"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform ${PLATFORM} -t holohub-grpc-endoscopy-tool-tracking-edge $APP_PATH/grpc_endoscopy_tool_tracking_edge --include onnx holoviz --add $GIT_ROOT/install/lib${NOCOLOR}"
 echo -e "\n\n==========Run the application=========="
 echo -e "Cloud:"
 echo -e "${YELLOW}holoscan run -r \$(docker images | grep "holohub-grpc-endoscopy-tool-tracking-cloud" | awk '{print \$1\":\"\$2}') -i $GIT_ROOT/data/endoscopy${NOCOLOR}"

--- a/applications/ehr_query_llm/fhir/packageHAP.sh
+++ b/applications/ehr_query_llm/fhir/packageHAP.sh
@@ -37,9 +37,9 @@ fi
 
 echo -e "\nPlease use the Holoscan SDK CLI to package and run the $APP_NAME application container with the following set of commands:"
 echo -e "\nGeneral command and options to package an application:"
-echo -e "${YELLOW}holoscan package -c <App_Path>/<App_Config> --platform [igx-orin-devkit | jetson-agx-orin-devkit | sbsa, x64-workstation] --platform-config [igpu | dgpu] -t <Image Tag> ${NOCOLOR}"
+echo -e "${YELLOW}holoscan package -c <App_Path>/<App_Config> --platform [jetson | igx-igpu | igx-dgpu | sbsa | x86_64] -t <Image Tag> ${NOCOLOR}"
 echo -e "\nCommand to package this application:"
-echo -e "${YELLOW}holoscan package -c $APP_PATH/$APP_CONFIG --platform ${PLATFORM} --platform-config ${GPU} -t $IMAGE_TAG $APP_PATH ${NOCOLOR}"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/$APP_CONFIG --platform ${PLATFORM}  -t $IMAGE_TAG $APP_PATH ${NOCOLOR}"
 echo -e "\nList the newly built application container image (command result also shown):"
 echo -e "${YELLOW}docker images | grep "$IMAGE_TAG" | awk '{print \$1\":\"\$2}' ${NOCOLOR}"
 IMAGE_FULL_NAME=$(docker images | grep "$IMAGE_TAG" | awk '{print $1":"$2}')

--- a/applications/endoscopy_tool_tracking/cpp/package-app.sh
+++ b/applications/endoscopy_tool_tracking/cpp/package-app.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/applications/endoscopy_tool_tracking/cpp/package-app.sh
+++ b/applications/endoscopy_tool_tracking/cpp/package-app.sh
@@ -27,11 +27,7 @@ if [ ! -d $APP_PATH ]; then
     exit -1
 fi
 
-PLATFORM=x64-workstation
-GPU=$(get_host_gpu)
-if [ $(get_host_arch) == "aarch64" ]; then
-    PLATFORM=igx-orin-devkit
-fi
+PLATFORM=$(get_platform_example_for_cli)
 
 echo -e "Updating application configuration file..."
 sed -i 's|lib/gxf_extensions/||' "$APP_PATH/endoscopy_tool_tracking.yaml"
@@ -39,9 +35,9 @@ echo -e "done\n"
 
 echo -e Install Holoscan CLI and then use the following commands to package and run the Endoscopy Tool Tracking application:
 echo -e "Package the application:"
-echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform [igx-orin-devkit | jetson-agx-orin-devkit | sbsa, x64-workstation] --platform-config [igpu | dgpu] -t holohub-endoscopy-tool-tracking-cpp --include onnx holoviz --add $INSTALL_DIR/lib/ $APP_PATH/endoscopy_tool_tracking${NOCOLOR}"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform [jetson | igx-igpu | igx-dgpu | sbsa | x86_64] -t holohub-endoscopy-tool-tracking-cpp --include onnx holoviz --add $INSTALL_DIR/lib/ $APP_PATH/endoscopy_tool_tracking${NOCOLOR}"
 echo -e "\nFor example:"
-echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform ${PLATFORM} --platform-config ${GPU} -t holohub-endoscopy-tool-tracking-cpp --include onnx holoviz --add $INSTALL_DIR/lib/ $APP_PATH/endoscopy_tool_tracking${NOCOLOR}"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform ${PLATFORM}  -t holohub-endoscopy-tool-tracking-cpp --include onnx holoviz --add $INSTALL_DIR/lib/ $APP_PATH/endoscopy_tool_tracking${NOCOLOR}"
 echo -e "\nRun the application:"
 echo -e "${YELLOW}holoscan run -r \$(docker images | grep "holohub-endoscopy-tool-tracking-cpp" | awk '{print \$1\":\"\$2}') -i $GIT_ROOT/data/endoscopy${NOCOLOR}"
 echo -e "\n\nRefer to Packaging Holoscan Applications (https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_packager.html) in the User Guide for more information."

--- a/applications/endoscopy_tool_tracking/python/package-app.sh
+++ b/applications/endoscopy_tool_tracking/python/package-app.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/applications/endoscopy_tool_tracking/python/package-app.sh
+++ b/applications/endoscopy_tool_tracking/python/package-app.sh
@@ -27,11 +27,7 @@ if [ ! -d $APP_PATH ]; then
     exit -1
 fi
 
-PLATFORM=x64-workstation
-GPU=$(get_host_gpu)
-if [ $(get_host_arch) == "aarch64" ]; then
-    PLATFORM=igx-orin-devkit
-fi
+PLATFORM=$(get_platform_example_for_cli)
 
 echo -e "Updating application configuration file..."
 sed -i 's|lib/gxf_extensions/||' "$APP_PATH/endoscopy_tool_tracking.yaml"
@@ -39,9 +35,9 @@ echo -e "done\n"
 
 echo -e Install Holoscan CLI and then use the following commands to package and run the Endoscopy Tool Tracking application:
 echo -e "Package the application:"
-echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform [igx-orin-devkit | jetson-agx-orin-devkit | sbsa, x64-workstation] --platform-config [igpu | dgpu] -t holohub-endoscopy-tool-tracking-python --include onnx holoviz --add $INSTALL_DIR/lib/ --add $INSTALL_DIR/python/lib/ $APP_PATH/endoscopy_tool_tracking.py${NOCOLOR}"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform [jetson | igx-igpu | igx-dgpu | sbsa | x86_64] -t holohub-endoscopy-tool-tracking-python --include onnx holoviz --add $INSTALL_DIR/lib/ --add $INSTALL_DIR/python/lib/ $APP_PATH/endoscopy_tool_tracking.py${NOCOLOR}"
 echo -e "\nFor example:"
-echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform ${PLATFORM} --platform-config ${GPU} -t holohub-endoscopy-tool-tracking-python --include onnx holoviz --add $INSTALL_DIR/lib/ --add $INSTALL_DIR/python/lib/ $APP_PATH/endoscopy_tool_tracking.py${NOCOLOR}"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/endoscopy_tool_tracking.yaml --platform ${PLATFORM}  -t holohub-endoscopy-tool-tracking-python --include onnx holoviz --add $INSTALL_DIR/lib/ --add $INSTALL_DIR/python/lib/ $APP_PATH/endoscopy_tool_tracking.py${NOCOLOR}"
 echo -e "\nRun the application:"
 echo -e "${YELLOW}holoscan run -r \$(docker images | grep "holohub-endoscopy-tool-tracking-python" | awk '{print \$1\":\"\$2}') -i $GIT_ROOT/data/endoscopy${NOCOLOR}"
 echo -e "\n\nRefer to Packaging Holoscan Applications (https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_packager.html) in the User Guide for more information."

--- a/applications/imaging_ai_segmentator/packageHAP.sh
+++ b/applications/imaging_ai_segmentator/packageHAP.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/applications/imaging_ai_segmentator/packageHAP.sh
+++ b/applications/imaging_ai_segmentator/packageHAP.sh
@@ -26,17 +26,13 @@ if [ ! -d $APP_PATH ]; then
     exit -1
 fi
 
-PLATFORM=x64-workstation
-GPU=$(get_host_gpu)
-if [ $(get_host_arch) == "aarch64" ]; then
-    PLATFORM=igx-orin-devkit
-fi
+PLATFORM=$(get_platform_example_for_cli)
 
 echo -e "\nPlease use the Holoscan SDK CLI to package and run the Imaging AI Segmentator application with the following set of commands:"
 echo -e "\nGeneral command and options to package an application:"
-echo -e "${YELLOW}holoscan package -c $APP_PATH/app.yaml --platform [igx-orin-devkit | jetson-agx-orin-devkit | sbsa, x64-workstation] --platform-config [igpu | dgpu] -t holohub-imaging_ai_segmentator -m $GIT_ROOT/data/imaging_ai_segmentator/models $APP_PATH/ ${NOCOLOR}"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/app.yaml --platform [jetson | igx-igpu | igx-dgpu | sbsa | x86_64] -t holohub-imaging_ai_segmentator -m $GIT_ROOT/data/imaging_ai_segmentator/models $APP_PATH/ ${NOCOLOR}"
 echo -e "\nCommand to package this application:"
-echo -e "${YELLOW}holoscan package -c $APP_PATH/app.yaml --platform ${PLATFORM} --platform-config ${GPU} -t holohub-imaging_ai_segmentator -m $GIT_ROOT/data/imaging_ai_segmentator/models $APP_PATH/ ${NOCOLOR}"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/app.yaml --platform ${PLATFORM}  -t holohub-imaging_ai_segmentator -m $GIT_ROOT/data/imaging_ai_segmentator/models $APP_PATH/ ${NOCOLOR}"
 echo -e "\nList the newly built application container:"
 echo -e "${YELLOW}docker images | grep "holohub-imaging_ai_segmentator" | awk '{print \$1\":\"\$2}' ${NOCOLOR}"
 echo -e "\nRun the application container, after creating and cleaning output folder:"

--- a/applications/object_detection_torch/package-app.sh
+++ b/applications/object_detection_torch/package-app.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/applications/object_detection_torch/package-app.sh
+++ b/applications/object_detection_torch/package-app.sh
@@ -26,17 +26,13 @@ if [ ! -d $APP_PATH ]; then
     exit -1
 fi
 
-PLATFORM=x64-workstation
-GPU=$(get_host_gpu)
-if [ $(get_host_arch) == "aarch64" ]; then
-    PLATFORM=igx-orin-devkit
-fi
+PLATFORM=$(get_platform_example_for_cli)
 
 echo -e Install Holoscan CLI and then use the following commands to package and run the Object Detection Torch application:
 echo -e "Package the application:"
-echo -e "${YELLOW}holoscan package -c $APP_PATH/object_detection_torch.yaml --platform [igx-orin-devkit | jetson-agx-orin-devkit | sbsa, x64-workstation] --platform-config [igpu | dgpu] -t holohub-object-detection-torch $APP_PATH/object_detection_torch --include onnx holoviz torch${NOCOLOR}"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/object_detection_torch.yaml --platform [jetson | igx-igpu | igx-dgpu | sbsa | x86_64] -t holohub-object-detection-torch $APP_PATH/object_detection_torch --include onnx holoviz torch${NOCOLOR}"
 echo -e "\nFor example:"
-echo -e "${YELLOW}holoscan package -c $APP_PATH/object_detection_torch.yaml --platform ${PLATFORM} --platform-config ${GPU} -t holohub-object-detection-torch $APP_PATH/object_detection_torch --include onnx holoviz torch${NOCOLOR}"
+echo -e "${YELLOW}holoscan package -c $APP_PATH/object_detection_torch.yaml --platform ${PLATFORM}  -t holohub-object-detection-torch $APP_PATH/object_detection_torch --include onnx holoviz torch${NOCOLOR}"
 echo -e "\nRun the application:"
 echo -e "${YELLOW}holoscan run -r \$(docker images | grep "holohub-object-detection-torch" | awk '{print \$1\":\"\$2}') -i $GIT_ROOT/data/object_detection_torch${NOCOLOR}"
 echo -e "\n\nRefer to Packaging Holoscan Applications (https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_packager.html) in the User Guide for more information."

--- a/utilities/bash_utils.sh
+++ b/utilities/bash_utils.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/utilities/bash_utils.sh
+++ b/utilities/bash_utils.sh
@@ -39,3 +39,16 @@ get_host_gpu() {
 get_host_arch() {
     echo -n "$(uname -m)"
 }
+
+get_platform_example_for_cli() {
+    if [ $(get_host_arch) == "aarch64" ]; then
+        if [ $(get_host_gpu) == "igpu" ]; then
+            PLATFORM=igx-igpu
+        else
+            PLATFORM=igx-dgpu
+        fi
+    else
+        PLATFORM=x86_64
+    fi
+    echo -n $PLATFORM
+}

--- a/utilities/bash_utils.sh
+++ b/utilities/bash_utils.sh
@@ -40,6 +40,8 @@ get_host_arch() {
     echo -n "$(uname -m)"
 }
 
+# Get an example value for the running PLATFORM.
+# Since we cannot detect the actual hardware, IGX vs Jetson, we use IGX as an example.
 get_platform_example_for_cli() {
     if [ $(get_host_arch) == "aarch64" ]; then
         if [ $(get_host_gpu) == "igpu" ]; then


### PR DESCRIPTION
This PR updates the packaging scripts to use the new consolidated `--platform` options introduced in CLI 3.0 https://github.com/nvidia-holoscan/holoscan-cli/pull/26