### PR TITLE
Support TGZ packaging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,3 +49,8 @@ tmp/
 .wget-hsts
 .viminfo
 .lesshst
+
+# Version control
+.git/
+.gitignore
+.github/

--- a/cmake/modules/holohub_configure_deb.cmake
+++ b/cmake/modules/holohub_configure_deb.cmake
@@ -50,19 +50,25 @@ function(holohub_configure_deb)
 
   if(ARG_COMPONENTS)
     # only packages installed components, in a single package
-    set(CPACK_COMPONENTS_ALL "${ARG_COMPONENTS}") # TODO: check if valid?
     set(CPACK_DEB_COMPONENT_INSTALL 1)
+    set(CPACK_ARCHIVE_COMPONENT_INSTALL 1)
+    set(CPACK_COMPONENTS_ALL "${ARG_COMPONENTS}") # TODO: check if components are valid?
     set(CPACK_COMPONENTS_GROUPING ALL_COMPONENTS_IN_ONE)
   else()
     # package all installed targets
     set(CPACK_DEB_COMPONENT_INSTALL 0)
+    set(CPACK_ARCHIVE_COMPONENT_INSTALL 0)
   endif()
 
   # standard configurations
   set(CPACK_PACKAGING_INSTALL_PREFIX "/opt/nvidia/holoscan")
   set(CPACK_STRIP_FILES TRUE)
-  set(CPACK_GENERATOR DEB)
+  set(CPACK_GENERATOR DEB) # default, can be overridden with cpack -G <generator>
   set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+  set(CPACK_ARCHIVE_FILE_NAME "${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}_${CMAKE_SYSTEM_PROCESSOR}")
+  # Note: CPACK_ARCHIVE_FILE_NAME above does not work if there is no components:
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/20419
+  # Fixed in CMake 4.0: https://gitlab.kitware.com/cmake/cmake/-/blob/master/Help/release/4.0.rst
 
   # generate package specific CPack configs to allow for multi packages
   set(CPACK_OUTPUT_CONFIG_FILE "${CMAKE_BINARY_DIR}/pkg/CPackConfig-${ARG_NAME}.cmake")

--- a/run
+++ b/run
@@ -702,6 +702,7 @@ build() {
   local benchmark=false
   local install=false
   local parallel_jobs=""
+  local pkg_generator="DEB"
 
   for i in "${!ARGS[@]}"; do
       arg="${ARGS[i]}"
@@ -736,6 +737,9 @@ build() {
       elif [ "$arg" = "--parallel" ]; then
          parallel_jobs="${ARGS[i+1]}"
          echo "Setting the number of parallel build jobs: ${ARGS[i+1]}"
+         skipnext=1
+      elif [ "$arg" = "--pkg" ]; then
+         pkg_generator="${ARGS[i+1]}"
          skipnext=1
       elif [[ $arg = -* ]]; then
         print_error "Unknown option $arg"
@@ -815,7 +819,7 @@ build() {
 
   if [ $is_pkg == true ]; then
     for cpack_config in $(find ${build_path}/pkg -name "CPackConfig-*.cmake"); do
-      run_command cpack --config "$cpack_config"
+      run_command cpack --config "$cpack_config" -G "${pkg_generator}"
     done
   fi
 


### PR DESCRIPTION
## Context

Would like to build TGZ for internal formal release process of holohub packages

## Changes

- Support [ARCHIVE](https://cmake.org/cmake/help/latest/cpack_gen/archive.html) generators in `holohub_configure_deb`
- Support passing the generator explicitly to the `run build` script utility with the `--pkg` flag
- Update .gitignore and .dockerignore to ignore CPack outputs

## Results
```bash
./run build holoscan-networking --pkg TGZ
...
[command] cpack --config build/holoscan-networking/pkg/CPackConfig-holoscan-networking.cmake -G TGZ
CPack: Create package using TGZ
CPack: Install projects
CPack: - Run preinstall target for: Holohub
CPack: - Install project: Holohub []
CPack: -   Install component: basic_network-cpp
CPack: -   Install component: basic_networking_ping-cpp
CPack: -   Install component: basic_networking_ping-configs
CPack: -   Install component: advanced_network-cpp
CPack: -   Install component: adv_networking_bench-cpp
CPack: -   Install component: adv_networking_bench-configs
CPack: -   Install component: advanced_network-utils
CPack: Create package
CPack: - package: /workspace/holohub/holoscan-networking_0.1.0_aarch64.tar.gz generated.
Build done.
```


