### PR TITLE
minor fixes build args when nvidia-smi not available

### DIFF
--- a/dev_container
+++ b/dev_container
@@ -449,7 +449,7 @@ check_nvidia_ctk() {
 
 get_host_gpu() {
     if ! command -v nvidia-smi >/dev/null; then
-        echo "Could not find any GPU drivers on host. Defaulting build to target dGPU/CPU stack."
+        echo "Could not find any GPU drivers on host. Defaulting build to target dGPU/CPU stack." >&2
         echo -n "dgpu";
     elif [[ ! $(nvidia-smi --query-gpu=name --format=csv,noheader) ]] || \
          [[ $(nvidia-smi --query-gpu=name --format=csv,noheader -i 0) =~ "Orin (nvgpu)" ]]; then
@@ -470,7 +470,11 @@ get_default_img() {
 # This function returns the compute capacity of the system's GPU (8.6, 8.9, etc.)
 # Compute capacity is a version number that represents the GPU's features & specs
 get_compute_capacity() {
-    echo -n $(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -n 1)
+    if ! command -v nvidia-smi >/dev/null; then
+        echo -n "0.0"  # Default value when nvidia-smi is not available
+    else
+        echo -n $(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -n 1)
+    fi
 }
 
 build_desc() { c_echo 'Build dev image


### PR DESCRIPTION
when `nvidia-smi` is not available, the `get_host_gpu()` will return `dgpu` along with the warning message, as a result the build command would become:

```
--build-arg GPU_TYPE=Could not find any GPU drivers on host. Defaulting build to target dGPU/CPU stack. dgpu
--build-arg COMPUTE_CAPACITY=
```