### PR TITLE
GPUNet IO fixes

### DIFF
--- a/applications/adv_networking_bench/adv_networking_bench_gpunetio_tx_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_gpunetio_tx_rx.yaml
@@ -72,6 +72,7 @@ advanced_network:
               - "Data_RX_GPU"
           flows:
             - name: "ADC Samples"
+              id: 2
               action:
                 type: queue
                 id: 0

--- a/operators/advanced_network/managers/gpunetio/adv_network_doca_mgr.h
+++ b/operators/advanced_network/managers/gpunetio/adv_network_doca_mgr.h
@@ -60,7 +60,7 @@
 #define THRESHOLD_BUF_NUM 32768
 
 #define MPS_ENABLED 0
-#define RX_PERSISTENT_ENABLED 1
+#define RX_PERSISTENT_ENABLED 0
 
 struct adv_doca_rx_gpu_info {
   uint32_t num_pkts;


### PR DESCRIPTION
Tested by @eagonv post #707 to ensure GPUNet IO works.

- disable rx persistent kernel: see https://github.com/nvidia-holoscan/holohub/blob/main/operators/advanced_network/README.md#doca
- add missing `id` field to gpunetio config