### PR TITLE
Fix port IDs when different from order in the config file

### DIFF
--- a/applications/adv_networking_bench/cpp/doca_bench_op_tx.h
+++ b/applications/adv_networking_bench/cpp/doca_bench_op_tx.h
@@ -230,7 +230,7 @@ class AdvNetworkingBenchDocaTxOp : public Operator {
   UDPIPV4Pkt pkt;
   void* pkt_header_;
   int cur_idx = 0;
-  uint16_t port_id_ = 0;
+  uint16_t port_id_;
   Parameter<uint32_t> batch_size_;
   Parameter<uint16_t> header_size_;  // Header size of packet
   Parameter<uint16_t> payload_size_;

--- a/operators/advanced_network/advanced_network/common.h
+++ b/operators/advanced_network/advanced_network/common.h
@@ -537,7 +537,6 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
 
       try {
         const auto& intfs = node["interfaces"];
-        uint16_t port = 0;
         for (const auto& intf : intfs) {
           holoscan::ops::AdvNetConfigInterface ifcfg;
 
@@ -546,8 +545,6 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
           try {
             ifcfg.flow_isolation_ = intf["flow_isolation"].as<bool>();
           } catch (const std::exception& e) { ifcfg.flow_isolation_ = false; }
-
-          ifcfg.port_id_ = port++;
 
           const auto& rx = intf["rx"];
           for (const auto& rx_item : rx) {


### PR DESCRIPTION
Currently the TX example expected the port ID to be 0, and it was hard-coded that way. If a user tried to change it to 1 it would not work due to some problems in the initialization order in DPDK vs the ANO order. This PR fixes these to be consistent.

Fix was tested with original configuration and the new one with the ports swapped.