### PR TITLE
Fix ano yaml

### DIFF
--- a/applications/adv_networking_bench/adv_networking_bench_default_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_rx.yaml
@@ -48,8 +48,8 @@ advanced_network:
     interfaces:
     - name: data2
       address: 0005:03:00.0
-      flow_isolation: true
       rx:
+        flow_isolation: true
         queues:
         - name: "Data"
           id: 0

--- a/applications/adv_networking_bench/adv_networking_bench_default_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_rx.yaml
@@ -37,15 +37,11 @@ advanced_network:
     - name: "Data_RX_CPU"
       kind: "huge"
       affinity: 0
-      access:
-        - local
       num_bufs: 30720
       buf_size: 64
     - name: "Data_RX_GPU"
       kind: "device"
       affinity: 0
-      access:
-        - local
       num_bufs: 30720
       buf_size: 1064
 

--- a/applications/adv_networking_bench/adv_networking_bench_default_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_rx.yaml
@@ -50,23 +50,23 @@ advanced_network:
       address: 0005:03:00.0
       flow_isolation: true
       rx:
-        - queues:
-          - name: "Data"
-            id: 0
-            cpu_core: 8
-            batch_size: 10240
-            output_port: "bench_rx_out"
-            memory_regions:
-              - "Data_RX_CPU"
-              - "Data_RX_GPU"
-          flows:
-            - name: "ADC Samples"
-              action:
-                type: queue
-                id: 0
-              match:
-                udp_src: 4096 #12288
-                udp_dst: 4096 #12288
+        queues:
+        - name: "Data"
+          id: 0
+          cpu_core: 8
+          batch_size: 10240
+          output_port: "bench_rx_out"
+          memory_regions:
+            - "Data_RX_CPU"
+            - "Data_RX_GPU"
+        flows:
+          - name: "ADC Samples"
+            action:
+              type: queue
+              id: 0
+            match:
+              udp_src: 4096 #12288
+              udp_dst: 4096 #12288
 
 bench_rx:
   gpu_direct: true        # Set to true if using a GPU region for the Rx queues.

--- a/applications/adv_networking_bench/adv_networking_bench_default_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_rx.yaml
@@ -60,8 +60,8 @@ advanced_network:
               type: queue
               id: 0
             match:
-              udp_src: 4096 #12288
-              udp_dst: 4096 #12288
+              udp_src: 4096
+              udp_dst: 4096
 
 bench_rx:
   gpu_direct: true        # Set to true if using a GPU region for the Rx queues.

--- a/applications/adv_networking_bench/adv_networking_bench_default_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_rx.yaml
@@ -14,11 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-multithreaded: true
-num_delay_ops: 32
-delay: 0.1
-delay_step: 0.01
-
 scheduler:
   check_recession_period_ms: 0
   worker_thread_number: 5

--- a/applications/adv_networking_bench/adv_networking_bench_default_rx_multi_q.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_rx_multi_q.yaml
@@ -14,11 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-multithreaded: true
-num_delay_ops: 32
-delay: 0.1
-delay_step: 0.01
-
 scheduler:
   check_recession_period_ms: 0
   worker_thread_number: 5
@@ -44,7 +39,7 @@ advanced_network:
       kind: "device"
       affinity: 0
       num_bufs: 51200
-      buf_size: 9000      
+      buf_size: 9000
 
     interfaces:
     - name: data2

--- a/applications/adv_networking_bench/adv_networking_bench_default_rx_multi_q.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_rx_multi_q.yaml
@@ -51,38 +51,38 @@ advanced_network:
       address: <0000:00:00.0>       # The BUS address of the interface doing Rx
       flow_isolation: true
       rx:
-        - queues:
-          - name: "Data"
+        queues:
+        - name: "Data"
+          id: 0
+          cpu_core: 9
+          batch_size: 10240
+          output_port: "bench_rx_out"
+          memory_regions:
+            - "Data_RX_GPU"
+        - name: "Data"
+          id: 1
+          cpu_core: 9
+          batch_size: 10240
+          output_port: "bench_rx_out"
+          memory_regions:
+            - "Data_RX_GPU2"
+        flows:
+        - name: "ADC Samples"
+          id: 0
+          action:
+            type: queue
             id: 0
-            cpu_core: 9
-            batch_size: 10240
-            output_port: "bench_rx_out"
-            memory_regions:
-              - "Data_RX_GPU"
-          - name: "Data"
+          match:
+            udp_src: 4096 #12288
+            udp_dst: 4096 #12288
+        - name: "ADC Samples"
+          id: 1
+          action:
+            type: queue
             id: 1
-            cpu_core: 9
-            batch_size: 10240
-            output_port: "bench_rx_out"
-            memory_regions:
-              - "Data_RX_GPU2"              
-          flows:
-          - name: "ADC Samples"
-            id: 0
-            action:
-              type: queue
-              id: 0
-            match:
-              udp_src: 4096 #12288
-              udp_dst: 4096 #12288
-          - name: "ADC Samples"
-            id: 1
-            action:
-              type: queue
-              id: 1
-            match:
-              udp_src: 4095 #12288
-              udp_dst: 4095 #12288           
+          match:
+            udp_src: 4095 #12288
+            udp_dst: 4095 #12288
 
 bench_rx:
   gpu_direct: true        # Set to true if using a GPU region for the Rx queues.

--- a/applications/adv_networking_bench/adv_networking_bench_default_rx_multi_q.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_rx_multi_q.yaml
@@ -68,16 +68,16 @@ advanced_network:
             type: queue
             id: 0
           match:
-            udp_src: 4096 #12288
-            udp_dst: 4096 #12288
+            udp_src: 4096
+            udp_dst: 4096
         - name: "ADC Samples"
           id: 1
           action:
             type: queue
             id: 1
           match:
-            udp_src: 4095 #12288
-            udp_dst: 4095 #12288
+            udp_src: 4095
+            udp_dst: 4095
 
 bench_rx:
   gpu_direct: true        # Set to true if using a GPU region for the Rx queues.

--- a/applications/adv_networking_bench/adv_networking_bench_default_rx_multi_q.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_rx_multi_q.yaml
@@ -38,15 +38,11 @@ advanced_network:
     - name: "Data_RX_GPU"
       kind: "device"
       affinity: 0
-      access:
-        - local
       num_bufs: 51200
       buf_size: 9000
     - name: "Data_RX_GPU2"
       kind: "device"
       affinity: 0
-      access:
-        - local
       num_bufs: 51200
       buf_size: 9000      
 

--- a/applications/adv_networking_bench/adv_networking_bench_default_rx_multi_q.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_rx_multi_q.yaml
@@ -49,8 +49,8 @@ advanced_network:
     interfaces:
     - name: data2
       address: <0000:00:00.0>       # The BUS address of the interface doing Rx
-      flow_isolation: true
       rx:
+        flow_isolation: true
         queues:
         - name: "Data"
           id: 0

--- a/applications/adv_networking_bench/adv_networking_bench_default_tx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx.yaml
@@ -37,8 +37,6 @@ advanced_network:
     - name: "Data_TX_CPU"
       kind: "huge"
       affinity: 0
-      access:
-        - local
       num_bufs: 51200
       buf_size: 1064
 

--- a/applications/adv_networking_bench/adv_networking_bench_default_tx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx.yaml
@@ -14,11 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-multithreaded: true
-num_delay_ops: 32
-delay: 0.1
-delay_step: 0.01
-
 scheduler:
   check_recession_period_ms: 0
   worker_thread_number: 5

--- a/applications/adv_networking_bench/adv_networking_bench_default_tx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx.yaml
@@ -44,15 +44,15 @@ advanced_network:
     - name: data1
       address: 0005:03:00.0
       tx:
-        - queues:
-          - name: "ADC Samples"
-            id: 0
-            batch_size: 10240
-            cpu_core: 4
-            memory_regions:
-              - "Data_TX_CPU"
-            offloads:
-              - "tx_eth_src"
+        queues:
+        - name: "ADC Samples"
+          id: 0
+          batch_size: 10240
+          cpu_core: 4
+          memory_regions:
+            - "Data_TX_CPU"
+          offloads:
+            - "tx_eth_src"
 
 bench_tx:
   gpu_direct: false       # Set to true if using a GPU region for the Tx queues.

--- a/applications/adv_networking_bench/adv_networking_bench_default_tx_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx_rx.yaml
@@ -50,37 +50,37 @@ advanced_network:
     - name: data1
       address: <0000:00:00.0>       # The BUS address of the interface doing Tx
       tx:
-        - queues:
-          - name: "ADC Samples"
-            id: 0
-            batch_size: 10240
-            cpu_core: 11
-            memory_regions:
-              - "Data_TX_GPU"
-            offloads:
-              - "tx_eth_src"
+        queues:
+        - name: "ADC Samples"
+          id: 0
+          batch_size: 10240
+          cpu_core: 11
+          memory_regions:
+            - "Data_TX_GPU"
+          offloads:
+            - "tx_eth_src"
     - name: data2
       address: <0000:00:00.0>       # The BUS address of the interface doing Rx
       flow_isolation: true
       rx:
-        - queues:
-          - name: "Data"
+        queues:
+        - name: "Data"
+          id: 0
+          cpu_core: 9
+          batch_size: 10240
+          output_port: "bench_rx_out"
+          memory_regions:
+            - "Data_RX_GPU"
+        flows:
+        - name: "ADC Samples"
+          id: 2
+          action:
+            type: queue
             id: 0
-            cpu_core: 9
-            batch_size: 10240
-            output_port: "bench_rx_out"
-            memory_regions:
-              - "Data_RX_GPU"
-          flows:
-          - name: "ADC Samples"
-            id: 2
-            action:
-              type: queue
-              id: 0
-            match:
-              udp_src: 4096 #12288
-              udp_dst: 4096 #12288
-              ipv4_len: 1050
+          match:
+            udp_src: 4096 #12288
+            udp_dst: 4096 #12288
+            ipv4_len: 1050
 
 bench_rx:
   gpu_direct: true        # Set to true if using a GPU region for the Rx queues.

--- a/applications/adv_networking_bench/adv_networking_bench_default_tx_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx_rx.yaml
@@ -38,15 +38,11 @@ advanced_network:
     - name: "Data_TX_GPU"
       kind: "device"
       affinity: 0
-      access:
-        - local
       num_bufs: 51200
       buf_size: 9000
     - name: "Data_RX_GPU"
       kind: "device"
       affinity: 0
-      access:
-        - local
       num_bufs: 51200
       buf_size: 9000
 

--- a/applications/adv_networking_bench/adv_networking_bench_default_tx_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx_rx.yaml
@@ -61,8 +61,8 @@ advanced_network:
             - "tx_eth_src"
     - name: data2
       address: <0000:00:00.0>       # The BUS address of the interface doing Rx
-      flow_isolation: true
       rx:
+        flow_isolation: true
         queues:
         - name: "Data"
           id: 0

--- a/applications/adv_networking_bench/adv_networking_bench_default_tx_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx_rx.yaml
@@ -73,8 +73,8 @@ advanced_network:
             type: queue
             id: 0
           match:
-            udp_src: 4096 #12288
-            udp_dst: 4096 #12288
+            udp_src: 4096
+            udp_dst: 4096
             ipv4_len: 1050
 
 bench_rx:

--- a/applications/adv_networking_bench/adv_networking_bench_default_tx_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx_rx.yaml
@@ -14,11 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-multithreaded: true
-num_delay_ops: 32
-delay: 0.1
-delay_step: 0.01
-
 scheduler:
   check_recession_period_ms: 0
   worker_thread_number: 5

--- a/applications/adv_networking_bench/adv_networking_bench_gpunetio_tx_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_gpunetio_tx_rx.yaml
@@ -46,7 +46,6 @@ advanced_network:
     interfaces:
     - name: data1
       address: 0000:ca:00.0
-      flow_isolation: true
       tx:
         queues:
         - name: "ADC Samples"
@@ -58,6 +57,7 @@ advanced_network:
           offloads:
             - "tx_eth_src"
       rx:
+        flow_isolation: true
         queues:
         - name: "Data"
           id: 0

--- a/applications/adv_networking_bench/adv_networking_bench_gpunetio_tx_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_gpunetio_tx_rx.yaml
@@ -14,11 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-multithreaded: true
-num_delay_ops: 32
-delay: 0.1
-delay_step: 0.01
-
 scheduler:
   check_recession_period_ms: 0
   worker_thread_number: 5

--- a/applications/adv_networking_bench/adv_networking_bench_gpunetio_tx_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_gpunetio_tx_rx.yaml
@@ -48,33 +48,33 @@ advanced_network:
       address: 0000:ca:00.0
       flow_isolation: true
       tx:
-        - queues:
-          - name: "ADC Samples"
-            id: 0
-            batch_size: 10240
-            cpu_core: 8
-            memory_regions:
-              - "Data_TX_GPU"
-            offloads:
-              - "tx_eth_src"
+        queues:
+        - name: "ADC Samples"
+          id: 0
+          batch_size: 10240
+          cpu_core: 8
+          memory_regions:
+            - "Data_TX_GPU"
+          offloads:
+            - "tx_eth_src"
       rx:
-        - queues:
-          - name: "Data"
-            id: 0
-            cpu_core: 10
-            batch_size: 10240
-            output_port: "bench_rx_out"
-            memory_regions:
-              - "Data_RX_GPU"
-          flows:
-            - name: "ADC Samples"
-              id: 2
-              action:
-                type: queue
-                id: 0
-              match:
-                udp_src: 4096 #12288
-                udp_dst: 4096 #12288
+        queues:
+        - name: "Data"
+          id: 0
+          cpu_core: 10
+          batch_size: 10240
+          output_port: "bench_rx_out"
+          memory_regions:
+            - "Data_RX_GPU"
+        flows:
+          - name: "ADC Samples"
+            id: 2
+            action:
+              type: queue
+              id: 0
+            match:
+              udp_src: 4096 #12288
+              udp_dst: 4096 #12288
 
 bench_rx:
   batch_size: 10240

--- a/applications/adv_networking_bench/adv_networking_bench_gpunetio_tx_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_gpunetio_tx_rx.yaml
@@ -68,8 +68,8 @@ advanced_network:
               type: queue
               id: 0
             match:
-              udp_src: 4096 #12288
-              udp_dst: 4096 #12288
+              udp_src: 4096
+              udp_dst: 4096
 
 bench_rx:
   batch_size: 10240

--- a/applications/adv_networking_bench/adv_networking_bench_gpunetio_tx_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_gpunetio_tx_rx.yaml
@@ -35,15 +35,11 @@ advanced_network:
     - name: "Data_TX_GPU"
       kind: "device"
       affinity: 0
-      access:
-        - local
       num_bufs: 51200
       buf_size: 9000
     - name: "Data_RX_GPU"
       kind: "device"
       affinity: 0
-      access:
-        - local
       num_bufs: 51200
       buf_size: 9000
 

--- a/applications/adv_networking_bench/adv_networking_bench_rmax_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_rmax_rx.yaml
@@ -36,15 +36,11 @@ advanced_network:
     - name: "Data_RX_CPU"
       kind: "huge"
       affinity: 0
-      access:
-        - local
       num_bufs: 43200
       buf_size: 20
     - name: "Data_RX_GPU"
       kind: "device"
       affinity: 0
-      access:
-        - local
       num_bufs: 43200
       buf_size: 1200
     interfaces:

--- a/applications/adv_networking_bench/adv_networking_bench_rmax_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_rmax_rx.yaml
@@ -14,11 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-multithreaded: true
-num_delay_ops: 32
-delay: 0.1
-delay_step: 0.01
-
 scheduler:
   check_recession_period_ms: 0
   worker_thread_number: 5

--- a/applications/adv_networking_bench/adv_networking_bench_rmax_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_rmax_rx.yaml
@@ -47,36 +47,36 @@ advanced_network:
     - name: data1
       address:  cc:00.1
       rx:
-        - queues:
-          - name: "Data"
-            id: 1
-            cpu_core:  "11,12,13"
-            batch_size: 4320
-            output_port: "bench_rx_out_1"
-            memory_regions:
-            - "Data_RX_CPU"
-            - "Data_RX_GPU"
-            rmax_rx_settings:
-              memory_registration: true
-              #allocator_type: "huge_page_2mb"
-              verbose: true
-              max_path_diff_us: 100
-              ext_seq_num: true
-              sleep_between_operations_us: 100
-              local_ip_addresses:
-                - 2.1.0.12
-                - 2.1.0.12
-              source_ip_addresses:
-                - 2.1.0.2
-                - 2.1.0.2
-              destination_ip_addresses:
-                - 224.1.1.1
-                - 224.1.1.2
-              destination_ports:
-                - 50001
-                - 50001
-              rx_stats_period_report_ms: 3000
-              send_packet_ext_info: true
+        queues:
+        - name: "Data"
+          id: 1
+          cpu_core:  "11,12,13"
+          batch_size: 4320
+          output_port: "bench_rx_out_1"
+          memory_regions:
+          - "Data_RX_CPU"
+          - "Data_RX_GPU"
+          rmax_rx_settings:
+            memory_registration: true
+            #allocator_type: "huge_page_2mb"
+            verbose: true
+            max_path_diff_us: 100
+            ext_seq_num: true
+            sleep_between_operations_us: 100
+            local_ip_addresses:
+              - 2.1.0.12
+              - 2.1.0.12
+            source_ip_addresses:
+              - 2.1.0.2
+              - 2.1.0.2
+            destination_ip_addresses:
+              - 224.1.1.1
+              - 224.1.1.2
+            destination_ports:
+              - 50001
+              - 50001
+            rx_stats_period_report_ms: 3000
+            send_packet_ext_info: true
 bench_rx:
   gpu_direct: true        # Set to true if using a GPU region for the Rx queues.
   split_boundary: true    # Whether header and data is split (Header to CPU)

--- a/operators/advanced_network/advanced_network/common.cpp
+++ b/operators/advanced_network/advanced_network/common.cpp
@@ -288,12 +288,14 @@ std::unordered_set<std::string> adv_net_get_port_names(const Config& conf, const
     for (const YAML::Node& node : yaml_nodes) {
       const auto& intfs = node["advanced_network"]["cfg"]["interfaces"];
       for (const auto& intf : intfs) {
-        const auto& intf_dir = intf[dir];
-        for (const auto& dir_item : intf_dir) {
-          for (const auto& q_item : dir_item["queues"]) {
+        try {
+          const auto& intf_dir = intf[dir];
+          for (const auto& q_item : intf_dir["queues"]) {
             auto out_port_name = q_item["output_port"].as<std::string>(default_output_name);
             output_ports.insert(out_port_name);
           }
+        } catch (const std::exception& e) {
+          continue;  // No queues defined for this direction
         }
       }
     }

--- a/operators/advanced_network/advanced_network/common.cpp
+++ b/operators/advanced_network/advanced_network/common.cpp
@@ -353,7 +353,11 @@ bool YAML::convert<holoscan::ops::AdvNetConfigYaml>::parse_memory_region_config(
     tmr.buf_size_ = mr["buf_size"].as<size_t>();
     tmr.num_bufs_ = mr["num_bufs"].as<size_t>();
     tmr.affinity_ = mr["affinity"].as<uint32_t>();
-    tmr.access_ = holoscan::ops::GetMemoryAccessPropertiesFromList(mr["access"]);
+    try {
+      tmr.access_ = holoscan::ops::GetMemoryAccessPropertiesFromList(mr["access"]);
+    } catch (const std::exception& e) {
+      tmr.access_ = holoscan::ops::MEM_ACCESS_LOCAL;
+    }
     tmr.owned_ = mr["owned"].template as<bool>(true);
   } catch (const std::exception& e) {
     HOLOSCAN_LOG_ERROR("Error parsing MemoryRegion: {}", e.what());

--- a/operators/advanced_network/advanced_network/common.h
+++ b/operators/advanced_network/advanced_network/common.h
@@ -546,11 +546,11 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
             ifcfg.flow_isolation_ = intf["flow_isolation"].as<bool>();
           } catch (const std::exception& e) { ifcfg.flow_isolation_ = false; }
 
-          const auto& rx = intf["rx"];
-          for (const auto& rx_item : rx) {
+          try {
+            const auto& rx = intf["rx"];
             holoscan::ops::AdvNetRxConfig rx_cfg;
 
-            for (const auto& q_item : rx_item["queues"]) {
+            for (const auto& q_item : rx["queues"]) {
               holoscan::ops::RxQueueConfig q;
               if (!parse_rx_queue_config(q_item, input_spec.common_.manager_type, q)) {
                 HOLOSCAN_LOG_ERROR("Failed to parse RxQueueConfig");
@@ -564,7 +564,7 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
               rx_cfg.queues_.emplace_back(std::move(q));
             }
 
-            for (const auto& flow_item : rx_item["flows"]) {
+            for (const auto& flow_item : rx["flows"]) {
               holoscan::ops::FlowConfig flow;
               if (!parse_flow_config(flow_item, flow)) {
                 HOLOSCAN_LOG_ERROR("Failed to parse FlowConfig");
@@ -574,17 +574,17 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
             }
 
             ifcfg.rx_ = rx_cfg;
-          }
+          } catch (const std::exception& e) {}  // No RX queues defined for this interface.
 
-          const auto& tx = intf["tx"];
-          for (const auto& tx_item : tx) {
+          try {
+            const auto& tx = intf["tx"];
             holoscan::ops::AdvNetTxConfig tx_cfg;
 
             try {
-              tx_cfg.accurate_send_ = tx_item["accurate_send"].as<bool>();
+              tx_cfg.accurate_send_ = tx["accurate_send"].as<bool>();
             } catch (const std::exception& e) { tx_cfg.accurate_send_ = false; }
 
-            for (const auto& q_item : tx_item["queues"]) {
+            for (const auto& q_item : tx["queues"]) {
               holoscan::ops::TxQueueConfig q;
               if (!parse_tx_queue_config(q_item, input_spec.common_.manager_type, q)) {
                 HOLOSCAN_LOG_ERROR("Failed to parse TxQueueConfig");
@@ -594,7 +594,7 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
             }
 
             ifcfg.tx_ = tx_cfg;
-          }
+          } catch (const std::exception& e) {}  // No TX queues defined for this interface.
 
           input_spec.ifs_.push_back(ifcfg);
         }

--- a/operators/advanced_network/advanced_network/common.h
+++ b/operators/advanced_network/advanced_network/common.h
@@ -542,13 +542,14 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
 
           ifcfg.name_ = intf["name"].as<std::string>();
           ifcfg.address_ = intf["address"].as<std::string>();
-          try {
-            ifcfg.flow_isolation_ = intf["flow_isolation"].as<bool>();
-          } catch (const std::exception& e) { ifcfg.flow_isolation_ = false; }
 
           try {
             const auto& rx = intf["rx"];
             holoscan::ops::AdvNetRxConfig rx_cfg;
+
+            try {
+              rx_cfg.flow_isolation_ = rx["flow_isolation"].as<bool>();
+            } catch (const std::exception& e) { rx_cfg.flow_isolation_ = false; }
 
             for (const auto& q_item : rx["queues"]) {
               holoscan::ops::RxQueueConfig q;

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
@@ -705,7 +705,7 @@ void DpdkMgr::initialize() {
 
     rte_eth_macaddr_get(intf.port_id_, &conf_ports_eth_addr[intf.port_id_]);
 
-    if (intf.flow_isolation_) {
+    if (intf.rx_.flow_isolation_) {
       struct rte_flow_error error;
       ret = rte_flow_isolate(intf.port_id_, 1, &error);
       if (ret < 0) {
@@ -770,7 +770,7 @@ void DpdkMgr::initialize() {
       }
     }
 
-    if (!intf.flow_isolation_) {
+    if (!intf.rx_.flow_isolation_) {
       HOLOSCAN_LOG_INFO("Enabling promiscuous mode for port {}", intf.port_id_);
       rte_eth_promiscuous_enable(intf.port_id_);
     } else {

--- a/operators/advanced_network/advanced_network/types.h
+++ b/operators/advanced_network/advanced_network/types.h
@@ -377,6 +377,7 @@ struct CommonConfig {
 };
 
 struct AdvNetRxConfig {
+  bool flow_isolation_;
   std::vector<RxQueueConfig> queues_;
   std::vector<FlowConfig> flows_;
 };
@@ -391,7 +392,6 @@ struct AdvNetConfigInterface {
   std::string name_;
   std::string address_;
   uint16_t port_id_;
-  bool flow_isolation_;
   AdvNetRxConfig rx_;
   AdvNetTxConfig tx_;
 };


### PR DESCRIPTION
## Issues

- ano yaml configs have some invalid formats:
  - `queues` itself is a list item under `tx` or `rx` instead of a property
  - `flows` should be under `tx` or `rx` not `queues`
- `flow_isolation` is under the `interfaces` items, but for better UX, it would be preferred under `rx` which is the only one affected by it.
- there is some extra unused properties at the top of the configs
- `access: local` is unlikely to be ever changed

## Changes

- [x] make `access` default to `local` and remove from configs
- [x] fix yaml formatting for `queues` and `flows`
- [x] move `flow_isolation` under `rx`
- [x] remove extraneous fields and comments

## Results

WIP
