### PR TITLE
Fix Docker Build Failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN apt update \
     graphviz\
     ninja-build
 
-RUN pip install meson
+RUN pip install meson pygobject==3.50.0
 
 RUN if ! grep -q "VERSION_ID=\"22.04\"" /etc/os-release; then \
         pip install setuptools; \


### PR DESCRIPTION
A benchmarking dependency installation (`xdot`) caused the `./dev_container build` to fail.
It was due to a recent release of pygobject, which requires `libgirepository-2.0-dev`. This dependency cannot be satisfied in holoscan container, which is based on ubuntu 22.04.

This PR fixes the pygobject version to `3.50.0` to resolve the issue.