### PR TITLE
Remove deprecated rx config target from the CMakeLists.txt.install

### DIFF
--- a/applications/adv_networking_bench/cpp/CMakeLists.txt.install
+++ b/applications/adv_networking_bench/cpp/CMakeLists.txt.install
@@ -76,12 +76,6 @@ add_custom_target(adv_networking_bench_default_tx_rx_hds_yaml
 )
 add_dependencies(adv_networking_bench adv_networking_bench_default_tx_rx_hds_yaml)
 
-add_custom_target(adv_networking_bench_default_rx_yaml
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/adv_networking_bench_default_rx.yaml" ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/adv_networking_bench_default_rx.yaml"
-)
-add_dependencies(adv_networking_bench adv_networking_bench_default_rx_yaml)
-
 add_custom_target(adv_networking_bench_gpunetio_tx_rx_yaml
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/adv_networking_bench_gpunetio_tx_rx.yaml" ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/adv_networking_bench_gpunetio_tx_rx.yaml"


### PR DESCRIPTION
Should have been removed in 37e6047c8d8926b72ae28aaab400dce8eaa36832