### PR TITLE
ANO namespace and type renaming

### DIFF
--- a/applications/adv_networking_bench/cpp/default_bench_op_rx.h
+++ b/applications/adv_networking_bench/cpp/default_bench_op_rx.h
@@ -28,6 +28,8 @@
 
 #define BURST_ACCESS_METHOD BURST_ACCESS_METHOD_RAW_PTR
 
+using namespace holoscan::advanced_network;
+
 namespace holoscan::ops {
 
 #define CUDA_TRY(stmt)                                                                          \

--- a/applications/adv_networking_bench/cpp/default_bench_op_tx.h
+++ b/applications/adv_networking_bench/cpp/default_bench_op_tx.h
@@ -24,6 +24,8 @@
 #include <assert.h>
 #include <sys/time.h>
 
+using namespace holoscan::advanced_network;
+
 namespace holoscan::ops {
 
 /*

--- a/applications/adv_networking_bench/cpp/doca_bench_op_rx.h
+++ b/applications/adv_networking_bench/cpp/doca_bench_op_rx.h
@@ -23,6 +23,8 @@
 #include <assert.h>
 #include <sys/time.h>
 
+using namespace holoscan::advanced_network;
+
 namespace holoscan::ops {
 
 class AdvNetworkingBenchDocaRxOp : public Operator {

--- a/applications/adv_networking_bench/cpp/doca_bench_op_rx.h
+++ b/applications/adv_networking_bench/cpp/doca_bench_op_rx.h
@@ -66,7 +66,7 @@ class AdvNetworkingBenchDocaRxOp : public Operator {
   }
 
   void setup(OperatorSpec& spec) override {
-    spec.input<std::shared_ptr<AdvNetBurstParams>>("burst_in");
+    spec.input<std::shared_ptr<BurstParams>>("burst_in");
     spec.param<uint32_t>(batch_size_,
                          "batch_size",
                          "Batch size",
@@ -110,7 +110,7 @@ class AdvNetworkingBenchDocaRxOp : public Operator {
     free_batch_queue();
 
     // Get new input burst (ANO batch of packets)
-    auto burst_opt = op_input.receive<AdvNetBurstParams*>("burst_in");
+    auto burst_opt = op_input.receive<BurstParams*>("burst_in");
     if (!burst_opt) {
       HOLOSCAN_LOG_ERROR("No burst input");
       return;
@@ -118,10 +118,10 @@ class AdvNetworkingBenchDocaRxOp : public Operator {
     auto burst = burst_opt.value();
 
     // Count packets received
-    ttl_pkts_recv_ += adv_net_get_num_pkts(burst);
+    ttl_pkts_recv_ += get_num_packets(burst);
 
     // Iterate over packets on GPU
-    for (int pkt_idx = 0; pkt_idx < adv_net_get_num_pkts(burst); pkt_idx++) {
+    for (int pkt_idx = 0; pkt_idx < get_num_packets(burst); pkt_idx++) {
       /* For each ANO batch (named burst), we might not want to right away send the packets to the
       * next operator, but maybe wait for more packets to come in, to make up what we call an
       * "App batch". While that increases the latency by needing more data to come in to continue,
@@ -193,11 +193,11 @@ class AdvNetworkingBenchDocaRxOp : public Operator {
       // NOTE: currently ordering pointers in the order packets come in. If headers had segment
       //       ID, the index in h_dev_ptrs_ should use that (instead of aggr_pkts_recv_ + p).
       h_dev_ptrs_[cur_batch_idx_][aggr_pkts_recv_++] =
-          reinterpret_cast<uint8_t*>(adv_net_get_pkt_ptr(burst, pkt_idx)) + header_size_.get();
+          reinterpret_cast<uint8_t*>(get_packet_ptr(burst, pkt_idx)) + header_size_.get();
     }
 
     // Count bytes received
-    ttl_bytes_recv_ += adv_net_get_burst_tot_byte(burst);
+    ttl_bytes_recv_ += get_burst_tot_byte(burst);
   }
 
  private:
@@ -208,7 +208,7 @@ class AdvNetworkingBenchDocaRxOp : public Operator {
 
   // Holds burst buffers that cannot be freed yet and CUDA event indicating when they can be freed
   struct BatchAggregationParams {
-    std::array<std::shared_ptr<AdvNetBurstParams>, MAX_ANO_BURSTS> bursts;
+    std::array<std::shared_ptr<BurstParams>, MAX_ANO_BURSTS> bursts;
     int num_bursts;
     cudaEvent_t evt;
   };

--- a/applications/adv_networking_bench/cpp/doca_bench_op_tx.h
+++ b/applications/adv_networking_bench/cpp/doca_bench_op_tx.h
@@ -53,7 +53,7 @@ class AdvNetworkingBenchDocaTxOp : public Operator {
   ~AdvNetworkingBenchDocaTxOp() { HOLOSCAN_LOG_INFO("ANO benchmark TX op shutting down"); }
 
   void populate_dummy_headers(UDPIPV4Pkt& pkt) {
-    // adv_net_get_mac(port_id_, reinterpret_cast<char*>(&pkt.eth.h_source[0]));
+    // get_mac_addr(port_id_, reinterpret_cast<char*>(&pkt.eth.h_source[0]));
     memcpy(pkt.eth.h_dest, eth_dst_, sizeof(pkt.eth.h_dest));
     pkt.eth.h_proto = htons(0x0800);
 
@@ -82,7 +82,7 @@ class AdvNetworkingBenchDocaTxOp : public Operator {
 
     size_t buf_size = batch_size_.get() * payload_size_.get();
 
-    adv_net_format_eth_addr(eth_dst_, eth_dst_addr_.get());
+    format_eth_addr(eth_dst_, eth_dst_addr_.get());
     inet_pton(AF_INET, ip_src_addr_.get().c_str(), &ip_src_);
     inet_pton(AF_INET, ip_dst_addr_.get().c_str(), &ip_dst_);
 
@@ -116,7 +116,7 @@ class AdvNetworkingBenchDocaTxOp : public Operator {
   }
 
   void setup(OperatorSpec& spec) override {
-    spec.output<std::shared_ptr<AdvNetBurstParams>>("burst_out");
+    spec.output<std::shared_ptr<BurstParams>>("burst_out");
 
     spec.param<uint32_t>(
         batch_size_, "batch_size", "Batch size", "Batch size for each processing epoch", 1000);
@@ -144,7 +144,7 @@ class AdvNetworkingBenchDocaTxOp : public Operator {
   }
 
   void compute(InputContext&, OutputContext& op_output, ExecutionContext&) override {
-    AdvNetStatus ret;
+    Status ret;
     int gpu_len;
     int cpu_len = 0;
     cudaError_t ret_cuda;
@@ -165,21 +165,21 @@ class AdvNetworkingBenchDocaTxOp : public Operator {
       }
     }
 
-    auto msg = adv_net_create_burst_params();
-    adv_net_set_hdr(msg, port_id_, queue_id, batch_size_.get(), num_segments);
+    auto msg = create_burst_params();
+    set_header(msg, port_id_, queue_id, batch_size_.get(), num_segments);
 
     // HOLOSCAN_LOG_INFO("Start main thread");
 
-    while ((ret = adv_net_get_tx_pkt_burst(msg)) != AdvNetStatus::SUCCESS) {}
+    while ((ret = get_tx_packet_burst(msg)) != Status::SUCCESS) {}
 
     // For HDS mode or CPU mode populate the packet headers
-    for (int num_pkt = 0; num_pkt < adv_net_get_num_pkts(msg); num_pkt++) {
+    for (int num_pkt = 0; num_pkt < get_num_packets(msg); num_pkt++) {
       gpu_len = payload_size_.get() + header_size_.get();  // sizeof UDP header
-      gpu_bufs[cur_idx][num_pkt] = reinterpret_cast<uint8_t*>(adv_net_get_pkt_ptr(msg, num_pkt));
+      gpu_bufs[cur_idx][num_pkt] = reinterpret_cast<uint8_t*>(get_packet_ptr(msg, num_pkt));
 
-      if ((ret = adv_net_set_pkt_lens(msg, num_pkt, {gpu_len})) != AdvNetStatus::SUCCESS) {
+      if ((ret = set_packet_lengths(msg, num_pkt, {gpu_len})) != Status::SUCCESS) {
         HOLOSCAN_LOG_ERROR("Failed to set lengths for packet {}", num_pkt);
-        adv_net_free_all_pkts_and_burst_tx(msg);
+        free_all_packets_and_burst_tx(msg);
         return;
       }
     }
@@ -188,13 +188,13 @@ class AdvNetworkingBenchDocaTxOp : public Operator {
     copy_headers(gpu_bufs[cur_idx],
                  pkt_header_,
                  header_size_.get(),
-                 adv_net_get_num_pkts(msg),
+                 get_num_packets(msg),
                  streams_[cur_idx]);
 
     // Populate packets with 16-bit numbers of {0,0}, {1,1}, ...
     populate_packets(gpu_bufs[cur_idx],
                      payload_size_.get(),
-                     adv_net_get_num_pkts(msg),
+                     get_num_packets(msg),
                      header_size_.get(),
                      streams_[cur_idx]);
     cudaEventRecord(events_[cur_idx], streams_[cur_idx]);
@@ -213,7 +213,7 @@ class AdvNetworkingBenchDocaTxOp : public Operator {
 
  private:
   struct TxMsg {
-    AdvNetBurstParams* msg;
+    BurstParams* msg;
     cudaEvent_t evt;
   };
 

--- a/applications/adv_networking_bench/cpp/doca_bench_op_tx.h
+++ b/applications/adv_networking_bench/cpp/doca_bench_op_tx.h
@@ -24,6 +24,9 @@
 #include <assert.h>
 #include <sys/time.h>
 #include <unistd.h>
+
+using namespace holoscan::advanced_network;
+
 namespace holoscan::ops {
 
 /*

--- a/applications/adv_networking_bench/cpp/main.cpp
+++ b/applications/adv_networking_bench/cpp/main.cpp
@@ -33,14 +33,14 @@ class App : public holoscan::Application {
     using namespace holoscan;
 
     HOLOSCAN_LOG_INFO("Initializing advanced network operator");
-    const auto [rx_en, tx_en] = holoscan::ops::adv_net_get_rx_tx_cfg_en(config());
-    const auto mgr_type = holoscan::ops::adv_net_get_manager_type(config());
-    auto output_rx_ports = holoscan::ops::adv_net_get_port_names(config(), "rx");
+    const auto [rx_en, tx_en] = holoscan::advanced_network::adv_net_get_rx_tx_cfg_en(config());
+    const auto mgr_type = holoscan::advanced_network::adv_net_get_manager_type(config());
+    auto output_rx_ports = holoscan::advanced_network::adv_net_get_port_names(config(), "rx");
 
-    HOLOSCAN_LOG_INFO("Using ANO manager {}", holoscan::ops::manager_type_to_string(mgr_type));
+    HOLOSCAN_LOG_INFO("Using ANO manager {}", holoscan::advanced_network::manager_type_to_string(mgr_type));
 
     // DPDK is the default manager backend
-    if (mgr_type == holoscan::ops::AnoMgrType::DPDK) {
+    if (mgr_type == holoscan::advanced_network::AnoMgrType::DPDK) {
 #if ANO_MGR_DPDK
       if (rx_en) {
         auto adv_net_rx =
@@ -65,7 +65,7 @@ class App : public holoscan::Application {
       exit(1);
 #endif
 
-    } else if (mgr_type == holoscan::ops::AnoMgrType::DOCA) {
+    } else if (mgr_type == holoscan::advanced_network::AnoMgrType::DOCA) {
 #if ANO_MGR_GPUNETIO
       if (rx_en) {
         auto bench_rx =
@@ -89,10 +89,10 @@ class App : public holoscan::Application {
       HOLOSCAN_LOG_ERROR("DOCA ANO manager/backend is disabled");
       exit(1);
 #endif
-    } else if (mgr_type == holoscan::ops::AnoMgrType::RIVERMAX) {
+    } else if (mgr_type == holoscan::advanced_network::AnoMgrType::RIVERMAX) {
 #if ANO_MGR_RIVERMAX
       if (rx_en) {
-        auto adv_net_rx = make_operator<holoscan::ops::AdvNetworkOpRx>(
+        auto adv_net_rx = make_operator<ops::AdvNetworkOpRx>(
             "adv_network_rx",
             output_rx_ports,
             from_config("advanced_network"),
@@ -136,6 +136,6 @@ int main(int argc, char** argv) {
       "multithread-scheduler", app->from_config("scheduler")));
   app->run();
 
-  holoscan::ops::adv_net_shutdown();
+  holoscan::advanced_network::adv_net_shutdown();
   return 0;
 }

--- a/applications/adv_networking_bench/cpp/main.cpp
+++ b/applications/adv_networking_bench/cpp/main.cpp
@@ -33,14 +33,14 @@ class App : public holoscan::Application {
     using namespace holoscan;
 
     HOLOSCAN_LOG_INFO("Initializing advanced network operator");
-    const auto [rx_en, tx_en] = holoscan::advanced_network::adv_net_get_rx_tx_cfg_en(config());
-    const auto mgr_type = holoscan::advanced_network::adv_net_get_manager_type(config());
-    auto output_rx_ports = holoscan::advanced_network::adv_net_get_port_names(config(), "rx");
+    const auto [rx_en, tx_en] = advanced_network::get_rx_tx_configs_enabled(config());
+    const auto mgr_type = advanced_network::get_manager_type(config());
+    auto output_rx_ports = advanced_network::get_port_names(config(), "rx");
 
-    HOLOSCAN_LOG_INFO("Using ANO manager {}", holoscan::advanced_network::manager_type_to_string(mgr_type));
+    HOLOSCAN_LOG_INFO("Using ANO manager {}", advanced_network::manager_type_to_string(mgr_type));
 
     // DPDK is the default manager backend
-    if (mgr_type == holoscan::advanced_network::AnoMgrType::DPDK) {
+    if (mgr_type == advanced_network::ManagerType::DPDK) {
 #if ANO_MGR_DPDK
       if (rx_en) {
         auto adv_net_rx =
@@ -65,7 +65,7 @@ class App : public holoscan::Application {
       exit(1);
 #endif
 
-    } else if (mgr_type == holoscan::advanced_network::AnoMgrType::DOCA) {
+    } else if (mgr_type == advanced_network::ManagerType::DOCA) {
 #if ANO_MGR_GPUNETIO
       if (rx_en) {
         auto bench_rx =
@@ -89,19 +89,19 @@ class App : public holoscan::Application {
       HOLOSCAN_LOG_ERROR("DOCA ANO manager/backend is disabled");
       exit(1);
 #endif
-    } else if (mgr_type == holoscan::advanced_network::AnoMgrType::RIVERMAX) {
+    } else if (mgr_type == advanced_network::ManagerType::RIVERMAX) {
 #if ANO_MGR_RIVERMAX
       if (rx_en) {
-        auto adv_net_rx = make_operator<ops::AdvNetworkOpRx>(
-            "adv_network_rx",
-            output_rx_ports,
-            from_config("advanced_network"),
-            make_condition<BooleanCondition>("is_alive", true));
+        auto adv_net_rx =
+            make_operator<ops::AdvNetworkOpRx>("adv_network_rx",
+                                               output_rx_ports,
+                                               from_config("advanced_network"),
+                                               make_condition<BooleanCondition>("is_alive", true));
         int index = 0;
         for (const auto& port : output_rx_ports) {
           std::string bench_rx_name = "bench_rx_" + std::to_string(index++);
-          auto bench_rx = make_operator<ops::AdvNetworkingBenchDefaultRxOp>(bench_rx_name,
-                                                                         from_config("bench_rx"));
+          auto bench_rx = make_operator<ops::AdvNetworkingBenchDefaultRxOp>(
+              bench_rx_name, from_config("bench_rx"));
           add_flow(adv_net_rx, bench_rx, {{ port, "burst_in" }});
         }
       }
@@ -121,7 +121,8 @@ class App : public holoscan::Application {
 };
 
 int main(int argc, char** argv) {
-  auto app = holoscan::make_application<App>();
+  using namespace holoscan;
+  auto app = make_application<App>();
 
   // Get the configuration
   if (argc < 2) {
@@ -132,10 +133,10 @@ int main(int argc, char** argv) {
   auto config_path = std::filesystem::canonical(argv[0]).parent_path();
   config_path += "/" + std::string(argv[1]);
   app->config(config_path);
-  app->scheduler(app->make_scheduler<holoscan::MultiThreadScheduler>(
+  app->scheduler(app->make_scheduler<MultiThreadScheduler>(
       "multithread-scheduler", app->from_config("scheduler")));
   app->run();
 
-  holoscan::advanced_network::adv_net_shutdown();
+  advanced_network::shutdown();
   return 0;
 }

--- a/applications/adv_networking_bench/python/main.py
+++ b/applications/adv_networking_bench/python/main.py
@@ -21,13 +21,13 @@ from holoscan.conditions import CountCondition
 from holoscan.core import Application, Operator, OperatorSpec
 
 from holohub.advanced_network_common import (
-    AdvNetStatus,
-    adv_net_create_burst_params,
-    adv_net_get_num_pkts,
-    adv_net_get_tx_pkt_burst,
-    adv_net_set_cpu_udp_payload,
-    adv_net_set_hdr,
-    adv_net_tx_burst_available,
+    Status,
+    create_burst_params,
+    get_num_packets,
+    get_tx_packet_burst,
+    is_tx_burst_available,
+    set_cpu_udp_payload,
+    set_header,
 )
 from holohub.advanced_network_tx import AdvNetworkOpTx
 
@@ -51,25 +51,24 @@ class AdvancedNetworkingBenchTxOp(Operator):
         spec.output("msg_out")
 
     def compute(self, op_input, op_output, context):
-        while not adv_net_tx_burst_available(self.batch_size):
+        while not is_tx_burst_available(self.batch_size):
             continue
 
-        msg = adv_net_create_burst_params()
-        adv_net_set_hdr(msg, 0, 0, self.batch_size)
+        msg = create_burst_params()
+        set_header(msg, 0, 0, self.batch_size)
 
-        ret = adv_net_get_tx_pkt_burst(msg)
-        if ret != AdvNetStatus.SUCCESS:
-            logger.error(f"Error returned from adv_net_get_tx_pkt_burst: {ret}")
+        ret = get_tx_packet_burst(msg)
+        if ret != Status.SUCCESS:
+            logger.error(f"Error returned from get_tx_packet_burst: {ret}")
             return
 
-        for num_pkt in range(adv_net_get_num_pkts(msg)):
-            ret = adv_net_set_cpu_udp_payload(
+        for num_pkt in range(get_num_packets(msg)):
+            ret = set_cpu_udp_payload(
                 msg, num_pkt, self.buf.ptr + num_pkt * self.payload_size, self.payload_size
             )
-            if ret != AdvNetStatus.SUCCESS:
+            if ret != Status.SUCCESS:
                 logger.error(
-                    f"Error returned from adv_net_set_cpu_udp_payload: "
-                    f"{ret} != {AdvNetStatus.SUCCESS}"
+                    f"Error returned from set_cpu_udp_payload: " f"{ret} != {Status.SUCCESS}"
                 )
                 return
         print(type(msg))
@@ -88,11 +87,11 @@ class App(Application):
             "cfg" in self.kwargs("advanced_network")
             and "tx" in self.kwargs("advanced_network")["cfg"]
         ):
-            tx = AdvancedNetworkingBenchTxOp(
-                self, CountCondition(self, NUM_MSGS), name="tx", **self.kwargs("bench_tx")
+            bench_tx = AdvancedNetworkingBenchTxOp(
+                self, CountCondition(self, NUM_MSGS), name="bench_tx", **self.kwargs("bench_tx")
             )
             adv_net_tx = AdvNetworkOpTx(self, name="adv_net_tx")
-            self.add_flow(tx, adv_net_tx, {("msg_out", "burst_in")})
+            self.add_flow(bench_tx, adv_net_tx, {("msg_out", "burst_in")})
         else:
             logger.info("No TX config found")
 

--- a/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_rx.cu
+++ b/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_rx.cu
@@ -115,6 +115,8 @@ void place_packet_data(complex_t* out, const void* const* const in, int* sample_
                                                                                  max_waveform_id);
 }
 
+using namespace holoscan::advanced_network;
+
 namespace holoscan::ops {
 
 void AdvConnectorOpRx::setup(OperatorSpec& spec) {

--- a/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_rx.cu
+++ b/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_rx.cu
@@ -118,7 +118,7 @@ void place_packet_data(complex_t* out, const void* const* const in, int* sample_
 namespace holoscan::ops {
 
 void AdvConnectorOpRx::setup(OperatorSpec& spec) {
-  spec.input<std::shared_ptr<AdvNetBurstParams>>("burst_in");
+  spec.input<std::shared_ptr<BurstParams>>("burst_in");
   spec.output<std::shared_ptr<RFArray>>("rf_out");
 
   // Radar settings
@@ -238,7 +238,7 @@ std::vector<AdvConnectorOpRx::RxMsg> AdvConnectorOpRx::free_bufs() {
     if (cudaEventQuery(first.evt) == cudaSuccess) {
       completed.push_back(first);
       for (auto m = 0; m < first.num_batches; m++) {
-        adv_net_free_all_pkts_and_burst_rx(first.msg[m]);
+        free_all_packets_and_burst_rx(first.msg[m]);
       }
       out_q.pop();
     } else {
@@ -292,7 +292,7 @@ void AdvConnectorOpRx::compute(InputContext& op_input, OutputContext& op_output,
   // todo Some sort of warm start for the processing stages?
   int64_t ttl_bytes_in_cur_batch_ = 0;
 
-  auto burst_opt = op_input.receive<AdvNetBurstParams*>("burst_in");
+  auto burst_opt = op_input.receive<BurstParams*>("burst_in");
   if (!burst_opt) {
     free_bufs();
     return;
@@ -300,8 +300,8 @@ void AdvConnectorOpRx::compute(InputContext& op_input, OutputContext& op_output,
   auto burst = burst_opt.value();
 
   // If packets are coming in from our non-GPUDirect queue, free them and move on
-  if (adv_net_get_q_id(burst) == 0) {  // queue 0 is configured to be non-GPUDirect in yaml config
-    adv_net_free_all_pkts_and_burst_rx(burst);
+  if (get_q_id(burst) == 0) {  // queue 0 is configured to be non-GPUDirect in yaml config
+    free_all_packets_and_burst_rx(burst);
     HOLOSCAN_LOG_INFO("Freeing CPU packets on queue 0");
     return;
   }
@@ -311,22 +311,22 @@ void AdvConnectorOpRx::compute(InputContext& op_input, OutputContext& op_output,
   // entire burst buffer pointer is saved and freed once an entire batch is received.
   if (gpu_direct_.get()) {
     if (split_boundary_.get()) {
-      for (int p = 0; p < adv_net_get_num_pkts(burst); p++) {
-        h_dev_ptrs_[cur_idx][aggr_pkts_recv_ + p] = adv_net_get_seg_pkt_ptr(burst, 1, p);
+      for (int p = 0; p < get_num_packets(burst); p++) {
+        h_dev_ptrs_[cur_idx][aggr_pkts_recv_ + p] = get_segment_packet_ptr(burst, 1, p);
         ttl_bytes_in_cur_batch_ +=
-            adv_net_get_seg_pkt_len(burst, 0, p) + adv_net_get_seg_pkt_len(burst, 1, p);
+            get_segment_packet_length(burst, 0, p) + get_segment_packet_length(burst, 1, p);
       }
     } else {
-      for (int p = 0; p < adv_net_get_num_pkts(burst); p++) {
+      for (int p = 0; p < get_num_packets(burst); p++) {
         h_dev_ptrs_[cur_idx][aggr_pkts_recv_ + p] =
-            reinterpret_cast<uint8_t*>(adv_net_get_pkt_ptr(burst, p)) + PADDED_HDR_SIZE;
-        ttl_bytes_in_cur_batch_ += adv_net_get_burst_tot_byte(burst);
+            reinterpret_cast<uint8_t*>(get_packet_ptr(burst, p)) + PADDED_HDR_SIZE;
+        ttl_bytes_in_cur_batch_ += get_burst_tot_byte(burst);
       }
     }
   }
   ttl_bytes_recv_ += ttl_bytes_in_cur_batch_;
 
-  aggr_pkts_recv_ += adv_net_get_num_pkts(burst);
+  aggr_pkts_recv_ += get_num_packets(burst);
 
   HOLOSCAN_LOG_INFO("aggr_pkts_recv_ {} ttl_bytes_recv_ {} batch_size_ {}",
       aggr_pkts_recv_, ttl_bytes_recv_, batch_size_.get());
@@ -375,7 +375,7 @@ void AdvConnectorOpRx::compute(InputContext& op_input, OutputContext& op_output,
         exit(1);
       }
     } else {
-      adv_net_free_all_pkts_and_burst_rx(burst);
+      free_all_packets_and_burst_rx(burst);
     }
     aggr_pkts_recv_ = 0;
     cur_idx = (++cur_idx % num_concurrent);

--- a/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_rx.h
+++ b/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_rx.h
@@ -121,8 +121,8 @@ class AdvConnectorOpRx : public Operator {
   ~AdvConnectorOpRx() {
     HOLOSCAN_LOG_INFO("Finished receiver with {}/{} bytes/packets received",
       ttl_bytes_recv_, ttl_pkts_recv_);
-    adv_net_shutdown();
-    adv_net_print_stats();
+    shutdown();
+    print_stats();
   }
 
   void setup(OperatorSpec& spec) override;
@@ -150,7 +150,7 @@ class AdvConnectorOpRx : public Operator {
 
   // Holds burst buffers that cannot be freed yet
   struct RxMsg {
-    std::array<std::shared_ptr<AdvNetBurstParams>, MAX_ANO_BATCHES> msg;
+    std::array<std::shared_ptr<BurstParams>, MAX_ANO_BATCHES> msg;
     int num_batches;
     cudaStream_t stream;
     cudaEvent_t evt;

--- a/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_rx.h
+++ b/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_rx.h
@@ -121,8 +121,8 @@ class AdvConnectorOpRx : public Operator {
   ~AdvConnectorOpRx() {
     HOLOSCAN_LOG_INFO("Finished receiver with {}/{} bytes/packets received",
       ttl_bytes_recv_, ttl_pkts_recv_);
-    shutdown();
-    print_stats();
+    holoscan::advanced_network::shutdown();
+    holoscan::advanced_network::print_stats();
   }
 
   void setup(OperatorSpec& spec) override;
@@ -150,7 +150,7 @@ class AdvConnectorOpRx : public Operator {
 
   // Holds burst buffers that cannot be freed yet
   struct RxMsg {
-    std::array<std::shared_ptr<BurstParams>, MAX_ANO_BATCHES> msg;
+    std::array<std::shared_ptr<holoscan::advanced_network::BurstParams>, MAX_ANO_BATCHES> msg;
     int num_batches;
     cudaStream_t stream;
     cudaEvent_t evt;

--- a/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_tx.cu
+++ b/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_tx.cu
@@ -21,14 +21,14 @@ namespace holoscan::ops {
 
 void AdvConnectorOpTx::setup(OperatorSpec& spec) {
   spec.input<std::shared_ptr<RFChannel>>("rf_in");
-  spec.output<std::shared_ptr<AdvNetBurstParams>>("burst_out");
+  spec.output<std::shared_ptr<BurstParams>>("burst_out");
 
   // Advanced network operator parameters
-  spec.param<AdvNetConfigYaml>(cfg_,
+  spec.param<NetworkConfig>(cfg_,
                                "cfg",
                                "Configuration",
                                "Configuration for the advanced network operator",
-                               AdvNetConfigYaml());
+                               NetworkConfig());
 
   // Radar parameters
   spec.param<uint16_t>(
@@ -65,7 +65,7 @@ void AdvConnectorOpTx::setup(OperatorSpec& spec) {
 }
 
 void AdvConnectorOpTx::populate_dummy_headers(UDPIPV4Pkt& pkt) {
-  // adv_net_get_mac(port_id_, reinterpret_cast<char*>(&pkt.eth.h_source[0]));
+  // get_mac_addr(port_id_, reinterpret_cast<char*>(&pkt.eth.h_source[0]));
   memcpy(pkt.eth.h_dest, eth_dst_, sizeof(pkt.eth.h_dest));
   pkt.eth.h_proto = htons(0x0800);
 
@@ -90,7 +90,7 @@ void AdvConnectorOpTx::populate_dummy_headers(UDPIPV4Pkt& pkt) {
 
 void AdvConnectorOpTx::initialize() {
   HOLOSCAN_LOG_INFO("AdvConnectorOpTx::initialize()");
-  register_converter<holoscan::advanced_network::AdvNetConfigYaml>();
+  register_converter<holoscan::advanced_network::NetworkConfig>();
   holoscan::Operator::initialize();
 
   // Read some parameters from config
@@ -156,7 +156,7 @@ void AdvConnectorOpTx::initialize() {
     HOLOSCAN_LOG_INFO("Initialized {} streams and events", num_concurrent);
   }
 
-  adv_net_format_eth_addr(eth_dst_, eth_dst_addr_.get());
+  format_eth_addr(eth_dst_, eth_dst_addr_.get());
   inet_pton(AF_INET, ip_src_addr_.get().c_str(), &ip_src_);
   inet_pton(AF_INET, ip_dst_addr_.get().c_str(), &ip_dst_);
 
@@ -183,38 +183,38 @@ void AdvConnectorOpTx::initialize() {
 /**
  * @brief Set UDP headers on Host memory
  */
-AdvNetStatus AdvConnectorOpTx::set_cpu_hdr(AdvNetBurstParams* msg, const int pkt_idx) {
-  AdvNetStatus ret;
+Status AdvConnectorOpTx::set_cpu_hdr(BurstParams* msg, const int pkt_idx) {
+  Status ret;
 
   // Set Ethernet header
-  if ((ret = adv_net_set_eth_hdr(msg, pkt_idx, eth_dst_)) != AdvNetStatus::SUCCESS) {
+  if ((ret = set_eth_header(msg, pkt_idx, eth_dst_)) != Status::SUCCESS) {
     HOLOSCAN_LOG_ERROR("Failed to set Ethernet header for packet {}", pkt_idx);
-    adv_net_free_all_pkts_and_burst_tx(msg);
+    free_all_packets_and_burst_tx(msg);
     return ret;
   }
 
   // Remove Eth + IP size
   const auto ip_len = payload_size_ + PADDED_HDR_SIZE - (14 + 20);
-  if ((ret = adv_net_set_ipv4_hdr(msg, pkt_idx, ip_len, 17, ip_src_, ip_dst_)) !=
-      AdvNetStatus::SUCCESS) {
+  if ((ret = set_ipv4_header(msg, pkt_idx, ip_len, 17, ip_src_, ip_dst_)) !=
+      Status::SUCCESS) {
     HOLOSCAN_LOG_ERROR("Failed to set IP header for packet {}", 0);
-    adv_net_free_all_pkts_and_burst_tx(msg);
+    free_all_packets_and_burst_tx(msg);
     return ret;
   }
 
   // Set UDP header
-  if ((ret = adv_net_set_udp_hdr(msg,
+  if ((ret = set_udp_header(msg,
                                  pkt_idx,
                                  // Remove Eth + IP + UDP headers
                                  payload_size_ + PADDED_HDR_SIZE - (14 + 20 + 8),
                                  udp_src_port_.get(),
-                                 udp_dst_port_.get())) != AdvNetStatus::SUCCESS) {
+                                 udp_dst_port_.get())) != Status::SUCCESS) {
     HOLOSCAN_LOG_ERROR("Failed to set UDP header for packet {}", 0);
-    adv_net_free_all_pkts_and_burst_tx(msg);
+    free_all_packets_and_burst_tx(msg);
     return ret;
   }
 
-  return AdvNetStatus::SUCCESS;
+  return Status::SUCCESS;
 }
 
 /**
@@ -303,7 +303,7 @@ void AdvConnectorOpTx::compute(InputContext& op_input, OutputContext& op_output,
       if (cudaEventQuery(first.evt) == cudaSuccess) {
         // Transmit
         HOLOSCAN_LOG_INFO("AdvConnectorOpTx sending {} packets... ({}, {})",
-                          adv_net_get_num_pkts(first.msg),
+                          get_num_packets(first.msg),
                           first.waveform_id,
                           first.channel_id);
         op_output.emit(first.msg, "burst_out");
@@ -313,7 +313,7 @@ void AdvConnectorOpTx::compute(InputContext& op_input, OutputContext& op_output,
     return;
   }
   HOLOSCAN_LOG_INFO("AdvConnectorOpTx::compute()");
-  AdvNetStatus ret;
+  Status ret;
 
   /**
    * Spin waiting until a buffer is free. This can be stalled by sending
@@ -321,10 +321,10 @@ void AdvConnectorOpTx::compute(InputContext& op_input, OutputContext& op_output,
    * operate much faster than the receiver since it's not having to do any
    * work to construct packets, and just copying from a buffer into memory.
    */
-  auto msg = adv_net_create_burst_params();
-  adv_net_set_hdr(msg, port_id_, queue_id, /* batch_size_ */ num_packets_buf, hds_ > 0 ? 2 : 1);
+  auto msg = create_burst_params();
+  set_header(msg, port_id_, queue_id, /* batch_size_ */ num_packets_buf, hds_ > 0 ? 2 : 1);
 
-  while ((ret = adv_net_get_tx_pkt_burst(msg)) != AdvNetStatus::SUCCESS) {}
+  while ((ret = get_tx_packet_burst(msg)) != Status::SUCCESS) {}
 
   if (!gpu_direct_) {
     // Generate packets from RF data //todo Optimize this process
@@ -347,7 +347,7 @@ void AdvConnectorOpTx::compute(InputContext& op_input, OutputContext& op_output,
         ix_buf++;
       }
     }
-    if (num_packets_buf != ix_buf || adv_net_get_num_pkts(msg) != ix_buf) {
+    if (num_packets_buf != ix_buf || get_num_packets(msg) != ix_buf) {
       HOLOSCAN_LOG_ERROR("Not sending expected number of packets");
     }
 
@@ -357,19 +357,19 @@ void AdvConnectorOpTx::compute(InputContext& op_input, OutputContext& op_output,
   }
 
   // Setup packets
-  for (int num_pkt = 0; num_pkt < adv_net_get_num_pkts(msg); num_pkt++) {
+  for (int num_pkt = 0; num_pkt < get_num_packets(msg); num_pkt++) {
     // For HDS mode or CPU mode populate the packet headers
     if (!gpu_direct_ || hds_ > 0) {
       ret = set_cpu_hdr(msg, num_pkt);  // set packet headers
-      if (ret != AdvNetStatus::SUCCESS) { return; }
+      if (ret != Status::SUCCESS) { return; }
 
       // Only set payload on CPU buffer if we're not using GPUDirect
       if (!gpu_direct_) {
-        if ((ret = adv_net_set_udp_payload(
+        if ((ret = set_udp_payload(
                  msg, num_pkt, packets_buf[num_pkt].get_ptr(), payload_size_)) !=
-            AdvNetStatus::SUCCESS) {
+            Status::SUCCESS) {
           HOLOSCAN_LOG_ERROR("Failed to set UDP payload for packet {}", num_pkt);
-          adv_net_free_all_pkts_and_burst_tx(msg);
+          free_all_packets_and_burst_tx(msg);
           return;
         }
       }
@@ -377,28 +377,28 @@ void AdvConnectorOpTx::compute(InputContext& op_input, OutputContext& op_output,
 
     // Figure out the CPU and GPU length portions for ANO
     if (gpu_direct_ && hds_ == 0) {
-      gpu_bufs[cur_idx][num_pkt] = reinterpret_cast<uint8_t*>(adv_net_get_pkt_ptr(msg, num_pkt));
+      gpu_bufs[cur_idx][num_pkt] = reinterpret_cast<uint8_t*>(get_packet_ptr(msg, num_pkt));
 
-      if ((ret = adv_net_set_pkt_lens(msg, num_pkt, {payload_size_ + PADDED_HDR_SIZE}))
-              != AdvNetStatus::SUCCESS) {
+      if ((ret = set_packet_lengths(msg, num_pkt, {payload_size_ + PADDED_HDR_SIZE}))
+              != Status::SUCCESS) {
         HOLOSCAN_LOG_ERROR("Failed to set lengths for packet {}", num_pkt);
-        adv_net_free_all_pkts_and_burst_tx(msg);
+        free_all_packets_and_burst_tx(msg);
         return;
       }
     } else if (gpu_direct_ && hds_ > 0) {
         gpu_bufs[cur_idx][num_pkt] =
-            reinterpret_cast<uint8_t*>(adv_net_get_seg_pkt_ptr(msg, 1, num_pkt));
-        if ((ret = adv_net_set_pkt_lens(msg, num_pkt, {hds_, payload_size_}))
-              != AdvNetStatus::SUCCESS) {
+            reinterpret_cast<uint8_t*>(get_segment_packet_ptr(msg, 1, num_pkt));
+        if ((ret = set_packet_lengths(msg, num_pkt, {hds_, payload_size_}))
+              != Status::SUCCESS) {
           HOLOSCAN_LOG_ERROR("Failed to set lengths for packet {}", num_pkt);
-          adv_net_free_all_pkts_and_burst_tx(msg);
+          free_all_packets_and_burst_tx(msg);
           return;
         }
     } else {
-      if ((ret = adv_net_set_pkt_lens(msg, num_pkt, {payload_size_ + PADDED_HDR_SIZE}))
-              != AdvNetStatus::SUCCESS) {
+      if ((ret = set_packet_lengths(msg, num_pkt, {payload_size_ + PADDED_HDR_SIZE}))
+              != Status::SUCCESS) {
         HOLOSCAN_LOG_ERROR("Failed to set lengths for packet {}", num_pkt);
-        adv_net_free_all_pkts_and_burst_tx(msg);
+        free_all_packets_and_burst_tx(msg);
         return;
       }
     }
@@ -410,7 +410,7 @@ void AdvConnectorOpTx::compute(InputContext& op_input, OutputContext& op_output,
     copy_headers(gpu_bufs[cur_idx],
                  pkt_header_,
                  PADDED_HDR_SIZE,
-                 adv_net_get_num_pkts(msg),
+                 get_num_packets(msg),
                  streams_[cur_idx]);
   }
 
@@ -435,7 +435,7 @@ void AdvConnectorOpTx::compute(InputContext& op_input, OutputContext& op_output,
     if (cudaEventQuery(first.evt) == cudaSuccess) {
       // Transmit
       HOLOSCAN_LOG_INFO("AdvConnectorOpTx sending {} gpudirect packets... ({}, {})",
-                        adv_net_get_num_pkts(first.msg),
+                        get_num_packets(first.msg),
                         first.waveform_id,
                         first.channel_id);
       op_output.emit(first.msg, "burst_out");
@@ -444,7 +444,7 @@ void AdvConnectorOpTx::compute(InputContext& op_input, OutputContext& op_output,
   } else {
     // Transmit
     HOLOSCAN_LOG_INFO("AdvConnectorOpTx sending {} packets... ({}, {})",
-                      adv_net_get_num_pkts(msg),
+                      get_num_packets(msg),
                       rf_data->waveform_id,
                       rf_data->channel_id);
     op_output.emit(msg, "burst_out");

--- a/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_tx.cu
+++ b/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_tx.cu
@@ -90,7 +90,7 @@ void AdvConnectorOpTx::populate_dummy_headers(UDPIPV4Pkt& pkt) {
 
 void AdvConnectorOpTx::initialize() {
   HOLOSCAN_LOG_INFO("AdvConnectorOpTx::initialize()");
-  register_converter<holoscan::ops::AdvNetConfigYaml>();
+  register_converter<holoscan::advanced_network::AdvNetConfigYaml>();
   holoscan::Operator::initialize();
 
   // Read some parameters from config

--- a/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_tx.cu
+++ b/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_tx.cu
@@ -17,6 +17,8 @@
 
 #include "adv_networking_tx.h"  // TODO: Rename networking connectors
 
+using namespace holoscan::advanced_network;
+
 namespace holoscan::ops {
 
 void AdvConnectorOpTx::setup(OperatorSpec& spec) {

--- a/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_tx.h
+++ b/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_tx.h
@@ -49,7 +49,7 @@ class AdvConnectorOpTx : public Operator {
   static constexpr int MAX_ANO_BATCHES = 10;  // Batches from ANO for one app batch
   static constexpr uint16_t queue_id   = 0;
 
-  Status set_cpu_hdr(BurstParams *msg, const int pkt_idx);
+  Status set_cpu_hdr(holoscan::advanced_network::BurstParams *msg, const int pkt_idx);
   void populate_packets(uint8_t **out_ptr,
                         complex_t *rf_data,
                         uint16_t waveform_id,
@@ -58,14 +58,14 @@ class AdvConnectorOpTx : public Operator {
                         cudaStream_t stream);
 
   struct TxMsg {
-    BurstParams *msg;
+    holoscan::advanced_network::BurstParams *msg;
     uint16_t waveform_id;
     uint16_t channel_id;
     cudaEvent_t evt;
   };
   std::queue<TxMsg> out_q;
 
-  Parameter<NetworkConfig> cfg_;
+  Parameter<holoscan::advanced_network::NetworkConfig> cfg_;
 
   // Radar settings
   Parameter<uint16_t> num_pulses_;

--- a/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_tx.h
+++ b/applications/network_radar_pipeline/cpp/advanced_network_connectors/adv_networking_tx.h
@@ -49,7 +49,7 @@ class AdvConnectorOpTx : public Operator {
   static constexpr int MAX_ANO_BATCHES = 10;  // Batches from ANO for one app batch
   static constexpr uint16_t queue_id   = 0;
 
-  AdvNetStatus set_cpu_hdr(AdvNetBurstParams *msg, const int pkt_idx);
+  Status set_cpu_hdr(BurstParams *msg, const int pkt_idx);
   void populate_packets(uint8_t **out_ptr,
                         complex_t *rf_data,
                         uint16_t waveform_id,
@@ -58,14 +58,14 @@ class AdvConnectorOpTx : public Operator {
                         cudaStream_t stream);
 
   struct TxMsg {
-    AdvNetBurstParams *msg;
+    BurstParams *msg;
     uint16_t waveform_id;
     uint16_t channel_id;
     cudaEvent_t evt;
   };
   std::queue<TxMsg> out_q;
 
-  Parameter<AdvNetConfigYaml> cfg_;
+  Parameter<NetworkConfig> cfg_;
 
   // Radar settings
   Parameter<uint16_t> num_pulses_;

--- a/applications/psd_pipeline/advanced_network_connectors/vita49_rx.cu
+++ b/applications/psd_pipeline/advanced_network_connectors/vita49_rx.cu
@@ -18,7 +18,7 @@
 #include "swap.h"
 #include "swap.cuh"
 
-using in_t = holoscan::ops::AdvNetBurstParams*;
+using in_t = holoscan::advanced_network::AdvNetBurstParams*;
 using out_t = std::tuple<tensor_t<complex, 2>, cudaStream_t>;
 
 constexpr uint32_t CONTEXT_QUEUE_ID = 0;

--- a/applications/psd_pipeline/advanced_network_connectors/vita49_rx.cu
+++ b/applications/psd_pipeline/advanced_network_connectors/vita49_rx.cu
@@ -18,7 +18,8 @@
 #include "swap.h"
 #include "swap.cuh"
 
-using in_t = holoscan::advanced_network::BurstParams*;
+using namespace holoscan::advanced_network;
+using in_t = BurstParams*;
 using out_t = std::tuple<tensor_t<complex, 2>, cudaStream_t>;
 
 constexpr uint32_t CONTEXT_QUEUE_ID = 0;

--- a/applications/psd_pipeline/advanced_network_connectors/vita49_rx.cu
+++ b/applications/psd_pipeline/advanced_network_connectors/vita49_rx.cu
@@ -18,7 +18,7 @@
 #include "swap.h"
 #include "swap.cuh"
 
-using in_t = holoscan::advanced_network::AdvNetBurstParams*;
+using in_t = holoscan::advanced_network::BurstParams*;
 using out_t = std::tuple<tensor_t<complex, 2>, cudaStream_t>;
 
 constexpr uint32_t CONTEXT_QUEUE_ID = 0;
@@ -183,7 +183,7 @@ std::vector<Vita49ConnectorOpRx::RxMsg> Vita49ConnectorOpRx::free_bufs(
     if (cudaEventQuery(first.evt) == cudaSuccess) {
       completed.push_back(first);
       for (auto m = 0; m < first.num_batches; m++) {
-        adv_net_free_all_pkts_and_burst_rx(first.msg[m]);
+        free_all_packets_and_burst_rx(first.msg[m]);
       }
       channel->out_q.pop();
     } else {
@@ -232,11 +232,11 @@ void Vita49ConnectorOpRx::compute(
   auto burst = burst_opt.value();
 
   // If we have a new context packet, get the metadata out and free
-  if (adv_net_get_q_id(burst) == CONTEXT_QUEUE_ID) {
-    for (int p = 0; p < adv_net_get_num_pkts(burst); p++) {
+  if (get_q_id(burst) == CONTEXT_QUEUE_ID) {
+    for (int p = 0; p < get_num_packets(burst); p++) {
       // Assume channel 0 context comes in on flow 0, channel 1 on flow 1, etc.
-      auto channel_num = adv_net_get_pkt_flow_id(burst, p);
-      ContextPacket *ctxt = reinterpret_cast<ContextPacket*>(adv_net_get_seg_pkt_ptr(burst, 1, p));
+      auto channel_num = get_packet_flow_id(burst, p);
+      ContextPacket *ctxt = reinterpret_cast<ContextPacket*>(get_segment_packet_ptr(burst, 1, p));
       HOLOSCAN_LOG_INFO(
           "Got {}context packet (ch: {}) with:\n"
           "      VRT header: 0x{:X}\n"
@@ -281,31 +281,31 @@ void Vita49ConnectorOpRx::compute(
       channel->context_received = true;
       // TODO: when context changes, we should flush data
     }
-    adv_net_free_all_pkts_and_burst_rx(burst);
+    free_all_packets_and_burst_rx(burst);
     return;
   }
 
   // Assumes that channel 0 is queue 1, channel 1 is queue 2, etc.
-  uint16_t channel_num = adv_net_get_q_id(burst) - 1;
+  uint16_t channel_num = get_q_id(burst) - 1;
   process_channel_data(op_output, burst, channel_num);
 }
 
 void Vita49ConnectorOpRx::process_channel_data(
         OutputContext& op_output,
-        AdvNetBurstParams *burst,
+        BurstParams *burst,
         uint16_t channel_num) {
   auto channel = channel_list.at(channel_num);
 
   if (!channel->context_received) {
     HOLOSCAN_LOG_INFO("Waiting to process channel {} data until context is received",
                       channel->channel_num);
-    adv_net_free_all_pkts_and_burst_rx(burst);
+    free_all_packets_and_burst_rx(burst);
     return;
   }
 
   // Grab metadata out of the first packet in the batch
   if (!channel->meta_set) {
-      VitaMetaData *meta = reinterpret_cast<VitaMetaData*>(adv_net_get_seg_pkt_ptr(burst, 1, 0));
+      VitaMetaData *meta = reinterpret_cast<VitaMetaData*>(get_segment_packet_ptr(burst, 1, 0));
       channel->current_meta.vrt_header = get_vrt_header_h(meta);
       channel->current_meta.stream_id = get_stream_id_h(meta);
       channel->current_meta.integer_time = get_integer_time_h(meta);
@@ -314,16 +314,16 @@ void Vita49ConnectorOpRx::process_channel_data(
   }
 
   uint64_t ttl_bytes_in_cur_batch = 0;
-  for (int p = 0; p < adv_net_get_num_pkts(burst); p++) {
+  for (int p = 0; p < get_num_packets(burst); p++) {
       channel->h_dev_ptrs[channel->cur_idx][channel->aggr_pkts_recv + p]
-          = adv_net_get_seg_pkt_ptr(burst, 2, p);
-      ttl_bytes_in_cur_batch += adv_net_get_seg_pkt_len(burst, 0, p)
-          + adv_net_get_seg_pkt_len(burst, 1, p)
-          + adv_net_get_seg_pkt_len(burst, 2, p);
+          = get_segment_packet_ptr(burst, 2, p);
+      ttl_bytes_in_cur_batch += get_segment_packet_length(burst, 0, p)
+          + get_segment_packet_length(burst, 1, p)
+          + get_segment_packet_length(burst, 2, p);
   }
 
   channel->ttl_bytes_recv += ttl_bytes_in_cur_batch;
-  channel->aggr_pkts_recv += adv_net_get_num_pkts(burst);
+  channel->aggr_pkts_recv += get_num_packets(burst);
   channel->cur_msg.msg[channel->cur_msg.num_batches++] = burst;
 
   // Once we've aggregated enough packets, do some work

--- a/applications/psd_pipeline/advanced_network_connectors/vita49_rx.h
+++ b/applications/psd_pipeline/advanced_network_connectors/vita49_rx.h
@@ -67,8 +67,8 @@ class Vita49ConnectorOpRx : public Operator {
   Vita49ConnectorOpRx() = default;
 
   ~Vita49ConnectorOpRx() {
-    shutdown();
-    print_stats();
+    holoscan::advanced_network::shutdown();
+    holoscan::advanced_network::print_stats();
   }
 
   void setup(OperatorSpec& spec) override;
@@ -91,7 +91,7 @@ class Vita49ConnectorOpRx : public Operator {
 
   // Holds burst buffers that cannot be freed yet
   struct RxMsg {
-    std::array<BurstParams *, MAX_ANO_BATCHES> msg;
+    std::array<holoscan::advanced_network::BurstParams *, MAX_ANO_BATCHES> msg;
     int num_batches;
     cudaStream_t stream;
     cudaEvent_t evt;
@@ -121,7 +121,7 @@ class Vita49ConnectorOpRx : public Operator {
   void free_bufs_and_emit_arrays(OutputContext& op_output, std::shared_ptr<struct Channel> channel);
   void process_channel_data(
           OutputContext& op_output,
-          BurstParams *burst,
+          holoscan::advanced_network::BurstParams *burst,
           uint16_t channel_num);
 };  // Vita49ConnectorOpRx
 

--- a/applications/psd_pipeline/advanced_network_connectors/vita49_rx.h
+++ b/applications/psd_pipeline/advanced_network_connectors/vita49_rx.h
@@ -67,8 +67,8 @@ class Vita49ConnectorOpRx : public Operator {
   Vita49ConnectorOpRx() = default;
 
   ~Vita49ConnectorOpRx() {
-    adv_net_shutdown();
-    adv_net_print_stats();
+    shutdown();
+    print_stats();
   }
 
   void setup(OperatorSpec& spec) override;
@@ -91,7 +91,7 @@ class Vita49ConnectorOpRx : public Operator {
 
   // Holds burst buffers that cannot be freed yet
   struct RxMsg {
-    std::array<AdvNetBurstParams *, MAX_ANO_BATCHES> msg;
+    std::array<BurstParams *, MAX_ANO_BATCHES> msg;
     int num_batches;
     cudaStream_t stream;
     cudaEvent_t evt;
@@ -121,7 +121,7 @@ class Vita49ConnectorOpRx : public Operator {
   void free_bufs_and_emit_arrays(OutputContext& op_output, std::shared_ptr<struct Channel> channel);
   void process_channel_data(
           OutputContext& op_output,
-          AdvNetBurstParams *burst,
+          BurstParams *burst,
           uint16_t channel_num);
 };  // Vita49ConnectorOpRx
 

--- a/operators/advanced_network/adv_network_rx.cpp
+++ b/operators/advanced_network/adv_network_rx.cpp
@@ -20,6 +20,8 @@
 #include <memory>
 #include <assert.h>
 
+using namespace holoscan::advanced_network;
+
 namespace holoscan::ops {
 
 struct AdvNetworkOpRx::AdvNetworkOpRxImpl {
@@ -49,7 +51,7 @@ void AdvNetworkOpRx::stop() {
 
 void AdvNetworkOpRx::initialize() {
   HOLOSCAN_LOG_INFO("AdvNetworkOpRx::initialize()");
-  register_converter<holoscan::ops::AdvNetConfigYaml>();
+  register_converter<holoscan::advanced_network::AdvNetConfigYaml>();
 
   holoscan::Operator::initialize();
   if (Init() < 0) { throw std::runtime_error("ANO initialization failed"); }

--- a/operators/advanced_network/adv_network_rx.h
+++ b/operators/advanced_network/adv_network_rx.h
@@ -47,7 +47,7 @@ class AdvNetworkOpRx : public Operator {
 
   void initialize() override;
   int Init();
-  int FreeBurst(holoscan::advanced_network::AdvNetBurstParams* burst);
+  int FreeBurst(holoscan::advanced_network::BurstParams* burst);
 
   // Holoscan functions
   void stop() override;
@@ -69,7 +69,7 @@ class AdvNetworkOpRx : public Operator {
   Parameter<int> batch_size_;
   Parameter<int> max_packet_size_;
   Parameter<uint32_t> num_concurrent_batches_;
-  Parameter<holoscan::advanced_network::AdvNetConfigYaml> cfg_;
+  Parameter<holoscan::advanced_network::NetworkConfig> cfg_;
 };
 
 };  // namespace holoscan::ops

--- a/operators/advanced_network/adv_network_rx.h
+++ b/operators/advanced_network/adv_network_rx.h
@@ -47,7 +47,7 @@ class AdvNetworkOpRx : public Operator {
 
   void initialize() override;
   int Init();
-  int FreeBurst(AdvNetBurstParams* burst);
+  int FreeBurst(holoscan::advanced_network::AdvNetBurstParams* burst);
 
   // Holoscan functions
   void stop() override;
@@ -69,7 +69,7 @@ class AdvNetworkOpRx : public Operator {
   Parameter<int> batch_size_;
   Parameter<int> max_packet_size_;
   Parameter<uint32_t> num_concurrent_batches_;
-  Parameter<AdvNetConfigYaml> cfg_;
+  Parameter<holoscan::advanced_network::AdvNetConfigYaml> cfg_;
 };
 
 };  // namespace holoscan::ops

--- a/operators/advanced_network/adv_network_tx.cpp
+++ b/operators/advanced_network/adv_network_tx.cpp
@@ -20,6 +20,8 @@
 #include <memory>
 #include <assert.h>
 
+using namespace holoscan::advanced_network;
+
 namespace holoscan::ops {
 
 struct AdvNetworkOpTx::AdvNetworkOpTxImpl {
@@ -44,7 +46,7 @@ void AdvNetworkOpTx::stop() {
 
 void AdvNetworkOpTx::initialize() {
   HOLOSCAN_LOG_INFO("AdvNetworkOpTx::initialize()");
-  register_converter<holoscan::ops::AdvNetConfigYaml>();
+  register_converter<holoscan::advanced_network::AdvNetConfigYaml>();
 
   holoscan::Operator::initialize();
   if (Init() < 0) { throw std::runtime_error("ANO initialization failed"); }

--- a/operators/advanced_network/adv_network_tx.h
+++ b/operators/advanced_network/adv_network_tx.h
@@ -37,7 +37,7 @@ class AdvNetworkOpTx : public Operator {
   ~AdvNetworkOpTx() = default;
   void initialize() override;
   int Init();
-  int FreeBurst(holoscan::advanced_network::AdvNetBurstParams* burst);
+  int FreeBurst(holoscan::advanced_network::BurstParams* burst);
 
   // Holoscan functions
   void stop() override;
@@ -47,7 +47,7 @@ class AdvNetworkOpTx : public Operator {
  private:
   void SetFillInfo();
   std::unordered_map<uint32_t, void*> tx_rings_;
-  Parameter<holoscan::advanced_network::AdvNetConfigYaml> cfg_;
+  Parameter<holoscan::advanced_network::NetworkConfig> cfg_;
   AdvNetworkOpTxImpl* impl;
 };
 

--- a/operators/advanced_network/adv_network_tx.h
+++ b/operators/advanced_network/adv_network_tx.h
@@ -37,7 +37,7 @@ class AdvNetworkOpTx : public Operator {
   ~AdvNetworkOpTx() = default;
   void initialize() override;
   int Init();
-  int FreeBurst(AdvNetBurstParams* burst);
+  int FreeBurst(holoscan::advanced_network::AdvNetBurstParams* burst);
 
   // Holoscan functions
   void stop() override;
@@ -47,7 +47,8 @@ class AdvNetworkOpTx : public Operator {
  private:
   void SetFillInfo();
   std::unordered_map<uint32_t, void*> tx_rings_;
-  Parameter<AdvNetConfigYaml> cfg_;
+  Parameter<holoscan::advanced_network::AdvNetConfigYaml> cfg_;
   AdvNetworkOpTxImpl* impl;
 };
+
 };  // namespace holoscan::ops

--- a/operators/advanced_network/advanced_network/common.cpp
+++ b/operators/advanced_network/advanced_network/common.cpp
@@ -38,15 +38,15 @@ namespace holoscan::advanced_network {
 /**
  * @brief Structure for passing packets to/from advanced network operator
  *
- * AdvNetBurstParams is populated by the RX advanced network operator before arriving at the user's
+ * BurstParams is populated by the RX advanced network operator before arriving at the user's
  * operator, and the user populates it prior to sending to the TX advanced network operator. The
  * structure describes metadata about a packet batch and its packet pointers.
  *
  */
 // Declare a static global variable for the manager
-static ANOMgr* g_ano_mgr = nullptr;
+static Manager* g_ano_mgr = nullptr;
 
-const std::unordered_map<AnoLogLevel::Level, std::string> AnoLogLevel::level_to_string_map = {
+const std::unordered_map<LogLevel::Level, std::string> LogLevel::level_to_string_map = {
     {TRACE, "trace"},
     {DEBUG, "debug"},
     {INFO, "info"},
@@ -56,7 +56,7 @@ const std::unordered_map<AnoLogLevel::Level, std::string> AnoLogLevel::level_to_
     {OFF, "off"},
 };
 
-const std::unordered_map<std::string, AnoLogLevel::Level> AnoLogLevel::string_to_level_map = {
+const std::unordered_map<std::string, LogLevel::Level> LogLevel::string_to_level_map = {
     {"trace", TRACE},
     {"debug", DEBUG},
     {"info", INFO},
@@ -66,97 +66,95 @@ const std::unordered_map<std::string, AnoLogLevel::Level> AnoLogLevel::string_to
     {"off", OFF},
 };
 
-[[deprecated("Use adv_net_create_tx_burst_params() instead")]]
-AdvNetBurstParams* adv_net_create_burst_params() {
+[[deprecated("Use create_tx_burst_params() instead")]]
+BurstParams* create_burst_params() {
   ASSERT_ANO_MGR_INITIALIZED();
   return g_ano_mgr->create_tx_burst_params();
 }
 
-AdvNetBurstParams* adv_net_create_tx_burst_params() {
+BurstParams* create_tx_burst_params() {
   ASSERT_ANO_MGR_INITIALIZED();
   return g_ano_mgr->create_tx_burst_params();
 }
 
-void adv_net_initialize_manager(ANOMgr* manager) {
+void initialize_manager(Manager* manager) {
   g_ano_mgr = manager;
 }
 
-ANOMgr* adv_net_get_active_manager() {
+Manager* get_active_manager() {
   return g_ano_mgr;
 }
 
-AnoMgrType adv_net_get_manager_type() {
-  return AnoMgrFactory::get_manager_type();
+ManagerType get_manager_type() {
+  return ManagerFactory::get_manager_type();
 }
 
 template <typename Config>
-AnoMgrType adv_net_get_manager_type(const Config& config) {
-  return AnoMgrFactory::get_manager_type(config);
+ManagerType get_manager_type(const Config& config) {
+  return ManagerFactory::get_manager_type(config);
 }
 
-template AnoMgrType adv_net_get_manager_type<Config>(const Config&);
+template ManagerType get_manager_type<Config>(const Config&);
 
-void adv_net_free_pkt(AdvNetBurstParams* burst, int pkt) {
+void free_packet(BurstParams* burst, int pkt) {
   ASSERT_ANO_MGR_INITIALIZED();
-  g_ano_mgr->free_pkt(burst, pkt);
+  g_ano_mgr->free_packet(burst, pkt);
 }
 
-void adv_net_free_pkt_seg(AdvNetBurstParams* burst, int seg, int pkt) {
+void free_packet_segment(BurstParams* burst, int seg, int pkt) {
   ASSERT_ANO_MGR_INITIALIZED();
-  g_ano_mgr->free_pkt_seg(burst, seg, pkt);
+  g_ano_mgr->free_packet_segment(burst, seg, pkt);
 }
 
-uint16_t adv_net_get_pkt_len(AdvNetBurstParams* burst, int idx) {
+uint16_t get_packet_length(BurstParams* burst, int idx) {
   ASSERT_ANO_MGR_INITIALIZED();
-  return g_ano_mgr->get_pkt_len(burst, idx);
+  return g_ano_mgr->get_packet_length(burst, idx);
 }
 
-
-uint16_t adv_net_get_pkt_flow_id(AdvNetBurstParams* burst, int idx) {
+uint16_t get_packet_flow_id(BurstParams* burst, int idx) {
   ASSERT_ANO_MGR_INITIALIZED();
-  return g_ano_mgr->get_pkt_flow_id(burst, idx);
+  return g_ano_mgr->get_packet_flow_id(burst, idx);
 }
 
-
-uint64_t adv_net_get_burst_tot_byte(AdvNetBurstParams* burst) {
+uint64_t get_burst_tot_byte(BurstParams* burst) {
   ASSERT_ANO_MGR_INITIALIZED();
   return g_ano_mgr->get_burst_tot_byte(burst);
 }
 
-uint16_t adv_net_get_seg_pkt_len(AdvNetBurstParams* burst, int seg, int idx) {
+uint16_t get_segment_packet_length(BurstParams* burst, int seg, int idx) {
   ASSERT_ANO_MGR_INITIALIZED();
-  return g_ano_mgr->get_seg_pkt_len(burst, seg, idx);
+  return g_ano_mgr->get_segment_packet_length(burst, seg, idx);
 }
 
-void adv_net_free_all_seg_pkts(AdvNetBurstParams* burst, int seg) {
+void free_all_segment_packets(BurstParams* burst, int seg) {
   ASSERT_ANO_MGR_INITIALIZED();
-  g_ano_mgr->free_all_seg_pkts(burst, seg);
+  g_ano_mgr->free_all_segment_packets(burst, seg);
 }
 
-void adv_net_free_all_burst_pkts(AdvNetBurstParams* burst) {
+void free_all_burst_packets(BurstParams* burst) {
   ASSERT_ANO_MGR_INITIALIZED();
-  g_ano_mgr->free_all_pkts(burst);
+  g_ano_mgr->free_all_packets(burst);
 }
 
-void adv_net_free_all_pkts_and_burst_rx(AdvNetBurstParams* burst) {
-  adv_net_free_all_burst_pkts(burst);
+void free_all_packets_and_burst_rx(BurstParams* burst) {
+  free_all_burst_packets(burst);
   ASSERT_ANO_MGR_INITIALIZED();
   g_ano_mgr->free_rx_burst(burst);
 }
 
-void adv_net_free_all_pkts_and_burst_tx(AdvNetBurstParams* burst) {
-  adv_net_free_all_burst_pkts(burst);
+void free_all_packets_and_burst_tx(BurstParams* burst) {
+  free_all_burst_packets(burst);
   ASSERT_ANO_MGR_INITIALIZED();
   g_ano_mgr->free_tx_burst(burst);
 }
 
-void adv_net_free_seg_pkts_and_burst(AdvNetBurstParams* burst, int seg) {
+void free_segment_packets_and_burst(BurstParams* burst, int seg) {
   ASSERT_ANO_MGR_INITIALIZED();
-  g_ano_mgr->free_all_seg_pkts(burst, seg);
+  g_ano_mgr->free_all_segment_packets(burst, seg);
   g_ano_mgr->free_rx_burst(burst);
 }
 
-void adv_net_format_eth_addr(char* dst, std::string addr) {
+void format_eth_addr(char* dst, std::string addr) {
   std::istringstream iss(addr);
   std::string byteString;
 
@@ -172,75 +170,74 @@ void adv_net_format_eth_addr(char* dst, std::string addr) {
   }
 }
 
-AdvNetStatus adv_net_get_mac(int port, char* mac) {
+Status get_mac_addr(int port, char* mac) {
   ASSERT_ANO_MGR_INITIALIZED();
-  return g_ano_mgr->get_mac(port, mac);
+  return g_ano_mgr->get_mac_addr(port, mac);
 }
 
-bool adv_net_tx_burst_available(AdvNetBurstParams* burst) {
+bool is_tx_burst_available(BurstParams* burst) {
   ASSERT_ANO_MGR_INITIALIZED();
-  return g_ano_mgr->tx_burst_available(burst);
+  return g_ano_mgr->is_tx_burst_available(burst);
 }
 
-int adv_net_address_to_port(const std::string& addr) {
+int address_to_port(const std::string& addr) {
   ASSERT_ANO_MGR_INITIALIZED();
   return g_ano_mgr->address_to_port(addr);
 }
 
-AdvNetStatus adv_net_get_tx_pkt_burst(AdvNetBurstParams* burst) {
+Status get_tx_packet_burst(BurstParams* burst) {
   ASSERT_ANO_MGR_INITIALIZED();
-  if (!g_ano_mgr->tx_burst_available(burst)) return AdvNetStatus::NO_FREE_BURST_BUFFERS;
-  return g_ano_mgr->get_tx_pkt_burst(burst);
+  if (!g_ano_mgr->is_tx_burst_available(burst)) return Status::NO_FREE_BURST_BUFFERS;
+  return g_ano_mgr->get_tx_packet_burst(burst);
 }
 
-AdvNetStatus adv_net_set_eth_hdr(AdvNetBurstParams* burst, int idx, char* dst_addr) {
+Status set_eth_header(BurstParams* burst, int idx, char* dst_addr) {
   ASSERT_ANO_MGR_INITIALIZED();
-  return g_ano_mgr->set_eth_hdr(burst, idx, dst_addr);
+  return g_ano_mgr->set_eth_header(burst, idx, dst_addr);
 }
 
-AdvNetStatus adv_net_set_ipv4_hdr(AdvNetBurstParams* burst, int idx, int ip_len, uint8_t proto,
-                                  unsigned int src_host, unsigned int dst_host) {
+Status set_ipv4_header(BurstParams* burst, int idx, int ip_len, uint8_t proto,
+                       unsigned int src_host, unsigned int dst_host) {
   ASSERT_ANO_MGR_INITIALIZED();
-  return g_ano_mgr->set_ipv4_hdr(burst, idx, ip_len, proto, src_host, dst_host);
+  return g_ano_mgr->set_ipv4_header(burst, idx, ip_len, proto, src_host, dst_host);
 }
 
-AdvNetStatus adv_net_set_udp_hdr(AdvNetBurstParams* burst, int idx, int udp_len, uint16_t src_port,
-                                 uint16_t dst_port) {
+Status set_udp_header(BurstParams* burst, int idx, int udp_len, uint16_t src_port,
+                      uint16_t dst_port) {
   ASSERT_ANO_MGR_INITIALIZED();
-  return g_ano_mgr->set_udp_hdr(burst, idx, udp_len, src_port, dst_port);
+  return g_ano_mgr->set_udp_header(burst, idx, udp_len, src_port, dst_port);
 }
 
-AdvNetStatus adv_net_set_udp_payload(AdvNetBurstParams* burst, int idx, void* data, int len) {
+Status set_udp_payload(BurstParams* burst, int idx, void* data, int len) {
   ASSERT_ANO_MGR_INITIALIZED();
   return g_ano_mgr->set_udp_payload(burst, idx, data, len);
 }
 
-AdvNetStatus adv_net_set_pkt_lens(AdvNetBurstParams* burst, int idx,
-                                  const std::initializer_list<int>& lens) {
+Status set_packet_lengths(BurstParams* burst, int idx, const std::initializer_list<int>& lens) {
   ASSERT_ANO_MGR_INITIALIZED();
-  return g_ano_mgr->set_pkt_lens(burst, idx, lens);
+  return g_ano_mgr->set_packet_lengths(burst, idx, lens);
 }
 
-AdvNetStatus adv_net_set_pkt_tx_time(AdvNetBurstParams* burst, int idx, uint64_t time) {
+Status set_packet_tx_time(BurstParams* burst, int idx, uint64_t time) {
   ASSERT_ANO_MGR_INITIALIZED();
-  return g_ano_mgr->set_pkt_tx_time(burst, idx, time);
+  return g_ano_mgr->set_packet_tx_time(burst, idx, time);
 }
 
-int64_t adv_net_get_num_pkts(AdvNetBurstParams* burst) {
+int64_t get_num_packets(BurstParams* burst) {
   return burst->hdr.hdr.num_pkts;
 }
 
-int64_t adv_net_get_q_id(AdvNetBurstParams* burst) {
+int64_t get_q_id(BurstParams* burst) {
   assert(burst != nullptr && "burst is null");
   return burst->hdr.hdr.q_id;
 }
 
-void adv_net_set_num_pkts(AdvNetBurstParams* burst, int64_t num) {
+void set_num_packets(BurstParams* burst, int64_t num) {
   assert(burst != nullptr && "burst is null");
   burst->hdr.hdr.num_pkts = num;
 }
 
-void adv_net_set_hdr(AdvNetBurstParams* burst, uint16_t port, uint16_t q, int64_t num, int segs) {
+void set_header(BurstParams* burst, uint16_t port, uint16_t q, int64_t num, int segs) {
   assert(burst != nullptr && "burst is null");
   burst->hdr.hdr.num_pkts = num;
   burst->hdr.hdr.port_id = port;
@@ -248,53 +245,52 @@ void adv_net_set_hdr(AdvNetBurstParams* burst, uint16_t port, uint16_t q, int64_
   burst->hdr.hdr.num_segs = segs;
 }
 
-void adv_net_free_tx_burst(AdvNetBurstParams* burst) {
+void free_tx_burst(BurstParams* burst) {
   ASSERT_ANO_MGR_INITIALIZED();
   g_ano_mgr->free_tx_burst(burst);
 }
 
-void adv_net_free_tx_meta(AdvNetBurstParams* burst) {
+void free_tx_metadata(BurstParams* burst) {
   ASSERT_ANO_MGR_INITIALIZED();
-  g_ano_mgr->free_tx_meta(burst);
+  g_ano_mgr->free_tx_metadata(burst);
 }
 
-
-void adv_net_free_rx_burst(AdvNetBurstParams* burst) {
+void free_rx_burst(BurstParams* burst) {
   ASSERT_ANO_MGR_INITIALIZED();
   g_ano_mgr->free_rx_burst(burst);
 }
 
-void adv_net_free_rx_meta(AdvNetBurstParams* burst) {
+void free_rx_metadata(BurstParams* burst) {
   ASSERT_ANO_MGR_INITIALIZED();
-  g_ano_mgr->free_rx_meta(burst);
+  g_ano_mgr->free_rx_metadata(burst);
 }
 
-void* adv_net_get_seg_pkt_ptr(AdvNetBurstParams* burst, int seg, int idx) {
+void* get_segment_packet_ptr(BurstParams* burst, int seg, int idx) {
   ASSERT_ANO_MGR_INITIALIZED();
-  return g_ano_mgr->get_seg_pkt_ptr(burst, seg, idx);
+  return g_ano_mgr->get_segment_packet_ptr(burst, seg, idx);
 }
 
-void* adv_net_get_pkt_ptr(AdvNetBurstParams* burst, int idx) {
+void* get_packet_ptr(BurstParams* burst, int idx) {
   ASSERT_ANO_MGR_INITIALIZED();
-  return g_ano_mgr->get_pkt_ptr(burst, idx);
+  return g_ano_mgr->get_packet_ptr(burst, idx);
 }
 
-std::optional<uint16_t> adv_net_get_port_from_ifname(const std::string& name) {
+std::optional<uint16_t> get_port_from_ifname(const std::string& name) {
   ASSERT_ANO_MGR_INITIALIZED();
   return g_ano_mgr->get_port_from_ifname(name);
 }
 
-void adv_net_shutdown() {
+void shutdown() {
   ASSERT_ANO_MGR_INITIALIZED();
   g_ano_mgr->shutdown();
 }
 
-void adv_net_print_stats() {
+void print_stats() {
   ASSERT_ANO_MGR_INITIALIZED();
   g_ano_mgr->print_stats();
 }
 
-std::unordered_set<std::string> adv_net_get_port_names(const Config& conf, const std::string& dir) {
+std::unordered_set<std::string> get_port_names(const Config& conf, const std::string& dir) {
   std::unordered_set<std::string> output_ports;
   std::string default_output_name;
 
@@ -335,7 +331,7 @@ std::unordered_set<std::string> adv_net_get_port_names(const Config& conf, const
  * @param flow The FlowConfig object to populate.
  * @return true if parsing was successful, false otherwise.
  */
-bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_flow_config(
+bool YAML::convert<holoscan::advanced_network::NetworkConfig>::parse_flow_config(
     const YAML::Node& flow_item, holoscan::advanced_network::FlowConfig& flow) {
   try {
     flow.name_ = flow_item["name"].as<std::string>();
@@ -367,14 +363,15 @@ bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_flow_con
  * @brief Parse memory region configuration from a YAML node.
  *
  * @param mr The YAML node containing the memory region configuration.
- * @param tmr The MemoryRegion object to populate.
+ * @param tmr The MemoryRegionConfig object to populate.
  * @return true if parsing was successful, false otherwise.
  */
-bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_memory_region_config(
-    const YAML::Node& mr, holoscan::advanced_network::MemoryRegion& tmr) {
+bool YAML::convert<holoscan::advanced_network::NetworkConfig>::parse_memory_region_config(
+    const YAML::Node& mr, holoscan::advanced_network::MemoryRegionConfig& tmr) {
   try {
     tmr.name_ = mr["name"].as<std::string>();
-    tmr.kind_ = holoscan::advanced_network::GetMemoryKindFromString(mr["kind"].template as<std::string>());
+    tmr.kind_ =
+        holoscan::advanced_network::GetMemoryKindFromString(mr["kind"].template as<std::string>());
     tmr.buf_size_ = mr["buf_size"].as<size_t>();
     tmr.num_bufs_ = mr["num_bufs"].as<size_t>();
     tmr.affinity_ = mr["affinity"].as<uint32_t>();
@@ -385,7 +382,7 @@ bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_memory_r
     }
     tmr.owned_ = mr["owned"].template as<bool>(true);
   } catch (const std::exception& e) {
-    HOLOSCAN_LOG_ERROR("Error parsing MemoryRegion: {}", e.what());
+    HOLOSCAN_LOG_ERROR("Error parsing MemoryRegionConfig: {}", e.what());
     return false;
   }
   return true;
@@ -398,7 +395,8 @@ bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_memory_r
  * @param common The CommonQueueConfig object to populate.
  * @return true if parsing was successful, false otherwise.
  */
-bool parse_common_queue_config(const YAML::Node& q_item, holoscan::advanced_network::CommonQueueConfig& common) {
+bool parse_common_queue_config(const YAML::Node& q_item,
+                               holoscan::advanced_network::CommonQueueConfig& common) {
   try {
     common.name_ = q_item["name"].as<std::string>();
     common.id_ = q_item["id"].as<int>();
@@ -428,7 +426,7 @@ bool parse_common_queue_config(const YAML::Node& q_item, holoscan::advanced_netw
  * @param q The RxQueueConfig object to populate.
  * @return true if parsing was successful, false otherwise.
  */
-bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_rx_queue_common_config(
+bool YAML::convert<holoscan::advanced_network::NetworkConfig>::parse_rx_queue_common_config(
     const YAML::Node& q_item, holoscan::advanced_network::RxQueueConfig& q) {
   if (!parse_common_queue_config(q_item, q.common_)) { return false; }
   try {
@@ -448,22 +446,22 @@ bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_rx_queue
  * @param q The RxQueueConfig object to populate.
  * @return true if parsing was successful, false otherwise.
  */
-bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_rx_queue_config(
-    const YAML::Node& q_item, const holoscan::advanced_network::AnoMgrType& manager_type,
+bool YAML::convert<holoscan::advanced_network::NetworkConfig>::parse_rx_queue_config(
+    const YAML::Node& q_item, const holoscan::advanced_network::ManagerType& manager_type,
     holoscan::advanced_network::RxQueueConfig& q) {
   try {
-    holoscan::advanced_network::AnoMgrType _manager_type = manager_type;
+    holoscan::advanced_network::ManagerType _manager_type = manager_type;
 
     if (!parse_rx_queue_common_config(q_item, q)) { return false; }
 
-    if (manager_type == holoscan::advanced_network::AnoMgrType::DEFAULT) {
-      _manager_type = holoscan::advanced_network::AnoMgrFactory::get_default_manager_type();
+    if (manager_type == holoscan::advanced_network::ManagerType::DEFAULT) {
+      _manager_type = holoscan::advanced_network::ManagerFactory::get_default_manager_type();
     }
 #if ANO_MGR_RIVERMAX
-    if (_manager_type == holoscan::advanced_network::AnoMgrType::RIVERMAX) {
-      holoscan::advanced_network::AdvNetStatus status =
+    if (_manager_type == holoscan::advanced_network::ManagerType::RIVERMAX) {
+      holoscan::advanced_network::Status status =
           holoscan::advanced_network::RmaxMgr::parse_rx_queue_rivermax_config(q_item, q);
-      if (status != holoscan::advanced_network::AdvNetStatus::SUCCESS) {
+      if (status != holoscan::advanced_network::Status::SUCCESS) {
         HOLOSCAN_LOG_ERROR("Failed to parse RX Queue config for Rivermax");
         return false;
       }
@@ -483,7 +481,7 @@ bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_rx_queue
  * @param q The TxQueueConfig object to populate.
  * @return true if parsing was successful, false otherwise.
  */
-bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_tx_queue_common_config(
+bool YAML::convert<holoscan::advanced_network::NetworkConfig>::parse_tx_queue_common_config(
     const YAML::Node& q_item, holoscan::advanced_network::TxQueueConfig& q) {
   if (!parse_common_queue_config(q_item, q.common_)) { return false; }
   try {
@@ -505,23 +503,23 @@ bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_tx_queue
  * @param q The TxQueueConfig object to populate.
  * @return true if parsing was successful, false otherwise.
  */
-bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_tx_queue_config(
-    const YAML::Node& q_item, const holoscan::advanced_network::AnoMgrType& manager_type,
+bool YAML::convert<holoscan::advanced_network::NetworkConfig>::parse_tx_queue_config(
+    const YAML::Node& q_item, const holoscan::advanced_network::ManagerType& manager_type,
     holoscan::advanced_network::TxQueueConfig& q) {
   try {
-    holoscan::advanced_network::AnoMgrType _manager_type = manager_type;
+    holoscan::advanced_network::ManagerType _manager_type = manager_type;
 
-    if (manager_type == holoscan::advanced_network::AnoMgrType::DEFAULT) {
-      _manager_type = holoscan::advanced_network::AnoMgrFactory::get_default_manager_type();
+    if (manager_type == holoscan::advanced_network::ManagerType::DEFAULT) {
+      _manager_type = holoscan::advanced_network::ManagerFactory::get_default_manager_type();
     }
 
     if (!parse_tx_queue_common_config(q_item, q)) { return false; }
 
 #if ANO_MGR_RIVERMAX
-    if (_manager_type == holoscan::advanced_network::AnoMgrType::RIVERMAX) {
-      holoscan::advanced_network::AdvNetStatus status =
+    if (_manager_type == holoscan::advanced_network::ManagerType::RIVERMAX) {
+      holoscan::advanced_network::Status status =
           holoscan::advanced_network::RmaxMgr::parse_tx_queue_rivermax_config(q_item, q);
-      if (status != holoscan::advanced_network::AdvNetStatus::SUCCESS) {
+      if (status != holoscan::advanced_network::Status::SUCCESS) {
         HOLOSCAN_LOG_ERROR("Failed to parse TX Queue config for Rivermax");
         return false;
       }

--- a/operators/advanced_network/advanced_network/common.cpp
+++ b/operators/advanced_network/advanced_network/common.cpp
@@ -33,7 +33,7 @@
 
 #define ASSERT_ANO_MGR_INITIALIZED() \
   assert(g_ano_mgr != nullptr && "ANO Manager is not initialized")
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 /**
  * @brief Structure for passing packets to/from advanced network operator
@@ -326,7 +326,7 @@ std::unordered_set<std::string> adv_net_get_port_names(const Config& conf, const
   return output_ports;
 }
 
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network
 
 /**
  * @brief Parse flow configuration from a YAML node.
@@ -335,12 +335,12 @@ std::unordered_set<std::string> adv_net_get_port_names(const Config& conf, const
  * @param flow The FlowConfig object to populate.
  * @return true if parsing was successful, false otherwise.
  */
-bool YAML::convert<holoscan::ops::AdvNetConfigYaml>::parse_flow_config(
-    const YAML::Node& flow_item, holoscan::ops::FlowConfig& flow) {
+bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_flow_config(
+    const YAML::Node& flow_item, holoscan::advanced_network::FlowConfig& flow) {
   try {
     flow.name_ = flow_item["name"].as<std::string>();
     flow.id_ = flow_item["id"].as<int>();
-    flow.action_.type_ = holoscan::ops::FlowType::QUEUE;
+    flow.action_.type_ = holoscan::advanced_network::FlowType::QUEUE;
     flow.action_.id_ = flow_item["action"]["id"].as<int>();
   } catch (const std::exception& e) {
     HOLOSCAN_LOG_ERROR("Error parsing FlowConfig: {}", e.what());
@@ -370,18 +370,18 @@ bool YAML::convert<holoscan::ops::AdvNetConfigYaml>::parse_flow_config(
  * @param tmr The MemoryRegion object to populate.
  * @return true if parsing was successful, false otherwise.
  */
-bool YAML::convert<holoscan::ops::AdvNetConfigYaml>::parse_memory_region_config(
-    const YAML::Node& mr, holoscan::ops::MemoryRegion& tmr) {
+bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_memory_region_config(
+    const YAML::Node& mr, holoscan::advanced_network::MemoryRegion& tmr) {
   try {
     tmr.name_ = mr["name"].as<std::string>();
-    tmr.kind_ = holoscan::ops::GetMemoryKindFromString(mr["kind"].template as<std::string>());
+    tmr.kind_ = holoscan::advanced_network::GetMemoryKindFromString(mr["kind"].template as<std::string>());
     tmr.buf_size_ = mr["buf_size"].as<size_t>();
     tmr.num_bufs_ = mr["num_bufs"].as<size_t>();
     tmr.affinity_ = mr["affinity"].as<uint32_t>();
     try {
-      tmr.access_ = holoscan::ops::GetMemoryAccessPropertiesFromList(mr["access"]);
+      tmr.access_ = holoscan::advanced_network::GetMemoryAccessPropertiesFromList(mr["access"]);
     } catch (const std::exception& e) {
-      tmr.access_ = holoscan::ops::MEM_ACCESS_LOCAL;
+      tmr.access_ = holoscan::advanced_network::MEM_ACCESS_LOCAL;
     }
     tmr.owned_ = mr["owned"].template as<bool>(true);
   } catch (const std::exception& e) {
@@ -398,7 +398,7 @@ bool YAML::convert<holoscan::ops::AdvNetConfigYaml>::parse_memory_region_config(
  * @param common The CommonQueueConfig object to populate.
  * @return true if parsing was successful, false otherwise.
  */
-bool parse_common_queue_config(const YAML::Node& q_item, holoscan::ops::CommonQueueConfig& common) {
+bool parse_common_queue_config(const YAML::Node& q_item, holoscan::advanced_network::CommonQueueConfig& common) {
   try {
     common.name_ = q_item["name"].as<std::string>();
     common.id_ = q_item["id"].as<int>();
@@ -428,8 +428,8 @@ bool parse_common_queue_config(const YAML::Node& q_item, holoscan::ops::CommonQu
  * @param q The RxQueueConfig object to populate.
  * @return true if parsing was successful, false otherwise.
  */
-bool YAML::convert<holoscan::ops::AdvNetConfigYaml>::parse_rx_queue_common_config(
-    const YAML::Node& q_item, holoscan::ops::RxQueueConfig& q) {
+bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_rx_queue_common_config(
+    const YAML::Node& q_item, holoscan::advanced_network::RxQueueConfig& q) {
   if (!parse_common_queue_config(q_item, q.common_)) { return false; }
   try {
     q.output_port_ = q_item["output_port"].as<std::string>();
@@ -448,22 +448,22 @@ bool YAML::convert<holoscan::ops::AdvNetConfigYaml>::parse_rx_queue_common_confi
  * @param q The RxQueueConfig object to populate.
  * @return true if parsing was successful, false otherwise.
  */
-bool YAML::convert<holoscan::ops::AdvNetConfigYaml>::parse_rx_queue_config(
-    const YAML::Node& q_item, const holoscan::ops::AnoMgrType& manager_type,
-    holoscan::ops::RxQueueConfig& q) {
+bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_rx_queue_config(
+    const YAML::Node& q_item, const holoscan::advanced_network::AnoMgrType& manager_type,
+    holoscan::advanced_network::RxQueueConfig& q) {
   try {
-    holoscan::ops::AnoMgrType _manager_type = manager_type;
+    holoscan::advanced_network::AnoMgrType _manager_type = manager_type;
 
     if (!parse_rx_queue_common_config(q_item, q)) { return false; }
 
-    if (manager_type == holoscan::ops::AnoMgrType::DEFAULT) {
-      _manager_type = holoscan::ops::AnoMgrFactory::get_default_manager_type();
+    if (manager_type == holoscan::advanced_network::AnoMgrType::DEFAULT) {
+      _manager_type = holoscan::advanced_network::AnoMgrFactory::get_default_manager_type();
     }
 #if ANO_MGR_RIVERMAX
-    if (_manager_type == holoscan::ops::AnoMgrType::RIVERMAX) {
-      holoscan::ops::AdvNetStatus status =
-          holoscan::ops::RmaxMgr::parse_rx_queue_rivermax_config(q_item, q);
-      if (status != holoscan::ops::AdvNetStatus::SUCCESS) {
+    if (_manager_type == holoscan::advanced_network::AnoMgrType::RIVERMAX) {
+      holoscan::advanced_network::AdvNetStatus status =
+          holoscan::advanced_network::RmaxMgr::parse_rx_queue_rivermax_config(q_item, q);
+      if (status != holoscan::advanced_network::AdvNetStatus::SUCCESS) {
         HOLOSCAN_LOG_ERROR("Failed to parse RX Queue config for Rivermax");
         return false;
       }
@@ -483,8 +483,8 @@ bool YAML::convert<holoscan::ops::AdvNetConfigYaml>::parse_rx_queue_config(
  * @param q The TxQueueConfig object to populate.
  * @return true if parsing was successful, false otherwise.
  */
-bool YAML::convert<holoscan::ops::AdvNetConfigYaml>::parse_tx_queue_common_config(
-    const YAML::Node& q_item, holoscan::ops::TxQueueConfig& q) {
+bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_tx_queue_common_config(
+    const YAML::Node& q_item, holoscan::advanced_network::TxQueueConfig& q) {
   if (!parse_common_queue_config(q_item, q.common_)) { return false; }
   try {
     const auto& offload = q_item["offloads"];
@@ -505,23 +505,23 @@ bool YAML::convert<holoscan::ops::AdvNetConfigYaml>::parse_tx_queue_common_confi
  * @param q The TxQueueConfig object to populate.
  * @return true if parsing was successful, false otherwise.
  */
-bool YAML::convert<holoscan::ops::AdvNetConfigYaml>::parse_tx_queue_config(
-    const YAML::Node& q_item, const holoscan::ops::AnoMgrType& manager_type,
-    holoscan::ops::TxQueueConfig& q) {
+bool YAML::convert<holoscan::advanced_network::AdvNetConfigYaml>::parse_tx_queue_config(
+    const YAML::Node& q_item, const holoscan::advanced_network::AnoMgrType& manager_type,
+    holoscan::advanced_network::TxQueueConfig& q) {
   try {
-    holoscan::ops::AnoMgrType _manager_type = manager_type;
+    holoscan::advanced_network::AnoMgrType _manager_type = manager_type;
 
-    if (manager_type == holoscan::ops::AnoMgrType::DEFAULT) {
-      _manager_type = holoscan::ops::AnoMgrFactory::get_default_manager_type();
+    if (manager_type == holoscan::advanced_network::AnoMgrType::DEFAULT) {
+      _manager_type = holoscan::advanced_network::AnoMgrFactory::get_default_manager_type();
     }
 
     if (!parse_tx_queue_common_config(q_item, q)) { return false; }
 
 #if ANO_MGR_RIVERMAX
-    if (_manager_type == holoscan::ops::AnoMgrType::RIVERMAX) {
-      holoscan::ops::AdvNetStatus status =
-          holoscan::ops::RmaxMgr::parse_tx_queue_rivermax_config(q_item, q);
-      if (status != holoscan::ops::AdvNetStatus::SUCCESS) {
+    if (_manager_type == holoscan::advanced_network::AnoMgrType::RIVERMAX) {
+      holoscan::advanced_network::AdvNetStatus status =
+          holoscan::advanced_network::RmaxMgr::parse_tx_queue_rivermax_config(q_item, q);
+      if (status != holoscan::advanced_network::AdvNetStatus::SUCCESS) {
         HOLOSCAN_LOG_ERROR("Failed to parse TX Queue config for Rivermax");
         return false;
       }

--- a/operators/advanced_network/advanced_network/common.h
+++ b/operators/advanced_network/advanced_network/common.h
@@ -30,10 +30,10 @@
 namespace holoscan::advanced_network {
 
 // this part is purely optional, just a helper for the user
-AdvNetBurstParams* adv_net_create_burst_params();
-AdvNetBurstParams* adv_net_create_tx_burst_params();
+BurstParams* create_burst_params();
+BurstParams* create_tx_burst_params();
 
-enum class AdvNetErrorGlobalStats {
+enum class ErrorGlobalStats {
   OUT_OF_RX_BUFFERS = 0,
   RX_QUEUE_FULL = 1,
   METADATA_BUF_DEPLETED = 2,
@@ -41,16 +41,15 @@ enum class AdvNetErrorGlobalStats {
   SENTINEL = 3,
 };
 
-
 namespace detail {
-inline AdvNetDirection DirectionStringToType(const std::string& dir) {
+inline Direction DirectionStringToType(const std::string& dir) {
   if (dir == "rx") {
-    return AdvNetDirection::RX;
+    return Direction::RX;
   } else if (dir == "tx") {
-    return AdvNetDirection::TX;
+    return Direction::TX;
   }
 
-  return AdvNetDirection::TX_RX;
+  return Direction::TX_RX;
 }
 };  // namespace detail
 
@@ -71,21 +70,21 @@ inline int EnabledDirections(const std::string& dir) {
  *
  * @return Manager type
  */
-AnoMgrType adv_net_get_manager_type();
+ManagerType get_manager_type();
 
 /**
  * @brief Returns a manager type
  *
- * @param config YML Configuration structure (e.g. AdvNetConfigYaml)
+ * @param config YML Configuration structure (e.g. NetworkConfig)
  * @return Manager type
  */
 template <typename Config>
-AnoMgrType adv_net_get_manager_type(const Config& config);
+ManagerType get_manager_type(const Config& config);
 
 /**
- * @brief Returns a raw packet pointer from a pointer in AdvNetBurstParams
+ * @brief Returns a raw packet pointer from a pointer in BurstParams
  *
- * The AdvNetBurstParams structure contains pointers to opaque packets which are not accessible
+ * The BurstParams structure contains pointers to opaque packets which are not accessible
  * directly by the user. This function fetches the CPU packet pointer at index idx
  * from the burst.
  *
@@ -94,12 +93,12 @@ AnoMgrType adv_net_get_manager_type(const Config& config);
  * @param idx Index of packet
  * @return Pointer to packet data
  */
-void* adv_net_get_seg_pkt_ptr(AdvNetBurstParams* burst, int seg, int idx);
+void* get_segment_packet_ptr(BurstParams* burst, int seg, int idx);
 
 /**
- * @brief Returns a raw packet pointer from a pointer in AdvNetBurstParams
+ * @brief Returns a raw packet pointer from a pointer in BurstParams
  *
- * The AdvNetBurstParams structure contains pointers to opaque packets which are not accessible
+ * The BurstParams structure contains pointers to opaque packets which are not accessible
  * directly by the user. This function fetches the GPU packet pointer at index idx
  * from the burst.
  *
@@ -107,7 +106,7 @@ void* adv_net_get_seg_pkt_ptr(AdvNetBurstParams* burst, int seg, int idx);
  * @param idx Index of packet
  * @return Pointer to packet data
  */
-void* adv_net_get_pkt_ptr(AdvNetBurstParams* burst, int idx);
+void* get_packet_ptr(BurstParams* burst, int idx);
 
 /**
  * @brief Get packet length of a segment of a packet
@@ -117,7 +116,7 @@ void* adv_net_get_pkt_ptr(AdvNetBurstParams* burst, int idx);
  * @param idx Index of packet
  * @return uint16_t Length of packet
  */
-uint16_t adv_net_get_seg_pkt_len(AdvNetBurstParams* burst, int seg, int idx);
+uint16_t get_segment_packet_length(BurstParams* burst, int seg, int idx);
 
 /**
  * @brief Get packet length of an entire packet
@@ -126,7 +125,7 @@ uint16_t adv_net_get_seg_pkt_len(AdvNetBurstParams* burst, int seg, int idx);
  * @param idx Index of packet
  * @return uint16_t Length of packet
  */
-uint16_t adv_net_get_pkt_len(AdvNetBurstParams* burst, int idx);
+uint16_t get_packet_length(BurstParams* burst, int idx);
 
 /**
  * @brief Get flow ID of a packet
@@ -138,7 +137,7 @@ uint16_t adv_net_get_pkt_len(AdvNetBurstParams* burst, int idx);
  * @param idx Index of packet
  * @return uint16_t Flow ID
  */
-uint16_t adv_net_get_pkt_flow_id(AdvNetBurstParams* burst, int idx);
+uint16_t get_packet_flow_id(BurstParams* burst, int idx);
 
 /**
  * @brief Populate a TX packet burst buffer
@@ -147,13 +146,13 @@ uint16_t adv_net_get_pkt_flow_id(AdvNetBurstParams* burst, int idx);
  * allocated packets and fill with the desired data/headers.
  *
  * @param burst Burst structure to populate
- * @return AdvNetStatus indicating status. Valid values are:
+ * @return Status indicating status. Valid values are:
  *    SUCCESS: Packets allocated
  *    NULL_PTR: Burst or packet pools uninitialized
  *    NO_FREE_BURST_BUFFERS: No burst buffers to allocate
  *    NO_FREE_CPU_PACKET_BUFFERS: Not enough CPU packet buffers available
  */
-AdvNetStatus adv_net_get_tx_pkt_burst(AdvNetBurstParams* burst);
+Status get_tx_packet_burst(BurstParams* burst);
 
 /**
  * @brief Set IPv4 header in packet
@@ -161,10 +160,10 @@ AdvNetStatus adv_net_get_tx_pkt_burst(AdvNetBurstParams* burst);
  * @param burst Burst structure to populate
  * @param idx Index of packet
  * @param dst_addr Ethernet destination address
- * @return AdvNetStatus indicating status. Valid values are:
+ * @return Status indicating status. Valid values are:
  *    SUCCESS: Packet populated successfully
  */
-AdvNetStatus adv_net_set_eth_hdr(AdvNetBurstParams* burst, int idx, char* dst_addr);
+Status set_eth_header(BurstParams* burst, int idx, char* dst_addr);
 
 /**
  * @brief Set IPv4 header in packet
@@ -175,11 +174,11 @@ AdvNetStatus adv_net_set_eth_hdr(AdvNetBurstParams* burst, int idx, char* dst_ad
  * @param proto L4 protocol
  * @param src_host Source host in host byte order
  * @param dst_host Destination host in host byte order
- * @return AdvNetStatus indicating status. Valid values are:
+ * @return Status indicating status. Valid values are:
  *    SUCCESS: Packet populated successfully
  */
-AdvNetStatus adv_net_set_ipv4_hdr(AdvNetBurstParams* burst, int idx, int ip_len, uint8_t proto,
-                                  unsigned int src_host, unsigned int dst_host);
+Status set_ipv4_header(BurstParams* burst, int idx, int ip_len, uint8_t proto,
+                       unsigned int src_host, unsigned int dst_host);
 
 /**
  * @brief Set UDP header in packet
@@ -189,11 +188,11 @@ AdvNetStatus adv_net_set_ipv4_hdr(AdvNetBurstParams* burst, int idx, int ip_len,
  * @param udp_len Length of packet after UDP header
  * @param src_port Source port
  * @param dst_port Destination port
- * @return AdvNetStatus indicating status. Valid values are:
+ * @return Status indicating status. Valid values are:
  *    SUCCESS: Packet populated successfully
  */
-AdvNetStatus adv_net_set_udp_hdr(AdvNetBurstParams* burst, int idx, int udp_len, uint16_t src_port,
-                                 uint16_t dst_port);
+Status set_udp_header(BurstParams* burst, int idx, int udp_len, uint16_t src_port,
+                      uint16_t dst_port);
 
 /**
  * @brief Set UDP payload in packet
@@ -202,10 +201,10 @@ AdvNetStatus adv_net_set_udp_hdr(AdvNetBurstParams* burst, int idx, int udp_len,
  * @param idx Index of packet
  * @param data Payload data after UDP header
  * @param len Length of payload
- * @return AdvNetStatus indicating status. Valid values are:
+ * @return Status indicating status. Valid values are:
  *    SUCCESS: Packet populated successfully
  */
-AdvNetStatus adv_net_set_udp_payload(AdvNetBurstParams* burst, int idx, void* data, int len);
+Status set_udp_payload(BurstParams* burst, int idx, void* data, int len);
 
 /**
  * @brief Test if a TX burst is available
@@ -219,7 +218,7 @@ AdvNetStatus adv_net_set_udp_payload(AdvNetBurstParams* burst, int idx, void* da
  * @return true Burst is available
  * @return false Burst is not available
  */
-bool adv_net_tx_burst_available(AdvNetBurstParams* burst);
+bool is_tx_burst_available(BurstParams* burst);
 
 /**
  * @brief Free all packets and burst from one segment
@@ -229,7 +228,7 @@ bool adv_net_tx_burst_available(AdvNetBurstParams* burst);
  *
  * @param burst Burst to free
  */
-void adv_net_free_seg_pkts_and_burst(AdvNetBurstParams* burst, int seg);
+void free_segment_packets_and_burst(BurstParams* burst, int seg);
 
 /**
  * @brief Free all packets and an RX burst
@@ -238,7 +237,7 @@ void adv_net_free_seg_pkts_and_burst(AdvNetBurstParams* burst, int seg);
  *
  * @param burst Burst structure containing packet lists
  */
-void adv_net_free_all_pkts_and_burst_rx(AdvNetBurstParams* burst);
+void free_all_packets_and_burst_rx(BurstParams* burst);
 
 /**
  * @brief Free all packets and a TX burst
@@ -247,7 +246,7 @@ void adv_net_free_all_pkts_and_burst_rx(AdvNetBurstParams* burst);
  *
  * @param burst Burst structure containing packet lists
  */
-void adv_net_free_all_pkts_and_burst_tx(AdvNetBurstParams* burst);
+void free_all_packets_and_burst_tx(BurstParams* burst);
 
 /**
  * @brief Set packet lengths in metadata
@@ -257,11 +256,10 @@ void adv_net_free_all_pkts_and_burst_tx(AdvNetBurstParams* burst);
  * @param burst Burst structure containing packet lists
  * @param idx Index of packet
  * @param lens Lengths of each segment
- * @return AdvNetStatus indicating status. Valid values are:
+ * @return Status indicating status. Valid values are:
  *    SUCCESS: Packet populated successfully
  */
-AdvNetStatus adv_net_set_pkt_lens(AdvNetBurstParams* burst, int idx,
-                                  const std::initializer_list<int>& lens);
+Status set_packet_lengths(BurstParams* burst, int idx, const std::initializer_list<int>& lens);
 
 /**
  * @brief Set packet TX time
@@ -274,13 +272,12 @@ AdvNetStatus adv_net_set_pkt_lens(AdvNetBurstParams* burst, int idx,
  * @param burst Burst structure containing packet lists
  * @param idx Index of packet
  * @param time PTP time to transmit
- * @return AdvNetStatus indicating status. Valid values are:
+ * @return Status indicating status. Valid values are:
  *    SUCCESS: Time set successfully
  */
-AdvNetStatus adv_net_set_pkt_tx_time(AdvNetBurstParams* burst, int idx, uint64_t time);
+Status set_packet_tx_time(BurstParams* burst, int idx, uint64_t time);
 
-
-uint64_t adv_net_get_burst_tot_byte(AdvNetBurstParams* burst);
+uint64_t get_burst_tot_byte(BurstParams* burst);
 
 /**
  * @brief Frees all segments of a single packet
@@ -288,8 +285,7 @@ uint64_t adv_net_get_burst_tot_byte(AdvNetBurstParams* burst);
  * @param burst Burst structure containing packet lists
  * @param idx Index of packet
  */
-void adv_net_free_pkt(AdvNetBurstParams* burst, int idx);
-
+void free_packet(BurstParams* burst, int idx);
 
 /**
  * @brief Frees a single segment from a single packet
@@ -298,7 +294,7 @@ void adv_net_free_pkt(AdvNetBurstParams* burst, int idx);
  * @param seg Segment of packet in scatter list
  * @param idx Index of packet
  */
-void adv_net_free_pkt_seg(AdvNetBurstParams* burst, int seg, int idx);
+void free_packet_segment(BurstParams* burst, int seg, int idx);
 
 /**
  * @brief Free all packets for a single segment in a burst
@@ -307,7 +303,7 @@ void adv_net_free_pkt_seg(AdvNetBurstParams* burst, int seg, int idx);
  *
  * @param burst Burst structure containing packet lists
  */
-void adv_net_free_all_seg_pkts(AdvNetBurstParams* burst, int seg);
+void free_all_segment_packets(BurstParams* burst, int seg);
 
 /**
  * @brief Free a receive burst
@@ -317,7 +313,7 @@ void adv_net_free_all_seg_pkts(AdvNetBurstParams* burst, int seg);
  *
  * @param burst
  */
-void adv_net_free_rx_burst(AdvNetBurstParams* burst);
+void free_rx_burst(BurstParams* burst);
 
 /**
  * @brief Free a transmit burst buffer
@@ -327,7 +323,7 @@ void adv_net_free_rx_burst(AdvNetBurstParams* burst);
  *
  * @param burst Burst structure to free
  */
-void adv_net_free_tx_burst(AdvNetBurstParams* burst);
+void free_tx_burst(BurstParams* burst);
 
 /**
  * @brief Free a receive TX meta buffer
@@ -337,7 +333,7 @@ void adv_net_free_tx_burst(AdvNetBurstParams* burst);
  *
  * @param burst Burst structure to free
  */
-void adv_net_free_tx_meta(AdvNetBurstParams* burst);
+void free_tx_metadata(BurstParams* burst);
 
 /**
  * @brief Free a receive RX meta buffer
@@ -347,21 +343,21 @@ void adv_net_free_tx_meta(AdvNetBurstParams* burst);
  *
  * @param burst Burst structure to free
  */
-void adv_net_free_rx_meta(AdvNetBurstParams* burst);
+void free_rx_metadata(BurstParams* burst);
 
 /**
  * @brief Get the number of packets in a burst
  *
  * @param burst Burst structure with packets
  */
-int64_t adv_net_get_num_pkts(AdvNetBurstParams* burst);
+int64_t get_num_packets(BurstParams* burst);
 
 /**
  * @brief Get the queue ID of a burst
  *
  * @param burst Burst structure with packets
  */
-int64_t adv_net_get_q_id(AdvNetBurstParams* burst);
+int64_t get_q_id(BurstParams* burst);
 
 /**
  * @brief Get mac address of an interface
@@ -369,9 +365,9 @@ int64_t adv_net_get_q_id(AdvNetBurstParams* burst);
  * @param addr Address of interface from config file
  * @param port Port ID of interface
  *
- * @returns AdvNetStatus::SUCCESS on success
+ * @returns Status::SUCCESS on success
  */
-AdvNetStatus adv_net_get_mac(int port, char* mac);
+Status get_mac_addr(int port, char* mac);
 
 /**
  * @brief Get mac address of an interface
@@ -380,7 +376,7 @@ AdvNetStatus adv_net_get_mac(int port, char* mac);
  *
  * @returns Port number or -1 for not found
  */
-int adv_net_address_to_port(const std::string& addr);
+int address_to_port(const std::string& addr);
 
 /**
  * @brief Set the number of packets in a burst
@@ -388,7 +384,7 @@ int adv_net_address_to_port(const std::string& addr);
  * @param burst Burst structure
  * @param num Number of packets
  */
-void adv_net_set_num_pkts(AdvNetBurstParams* burst, int64_t num);
+void set_num_packets(BurstParams* burst, int64_t num);
 
 /**
  * @brief Set the header fields in a burst
@@ -399,7 +395,7 @@ void adv_net_set_num_pkts(AdvNetBurstParams* burst, int64_t num);
  * @param num Number of packets
  * @param segs Number of segments
  */
-void adv_net_set_hdr(AdvNetBurstParams* burst, uint16_t port, uint16_t q, int64_t num, int segs);
+void set_header(BurstParams* burst, uint16_t port, uint16_t q, int64_t num, int segs);
 
 /**
  * @brief First MAC address string to char buffer
@@ -407,22 +403,22 @@ void adv_net_set_hdr(AdvNetBurstParams* burst, uint16_t port, uint16_t q, int64_
  * @param dst Destination buffer
  * @param addr MAC address as string in format xx:xx:xx:xx:xx:xx
  */
-void adv_net_format_eth_addr(char* dst, std::string addr);
+void format_eth_addr(char* dst, std::string addr);
 
-std::optional<uint16_t> adv_net_get_port_from_ifname(const std::string& name);
+std::optional<uint16_t> get_port_from_ifname(const std::string& name);
 
 /**
  * @brief Shut down ANO and do any cleanup necessary. Freeing memory is done
  * in the manager's destructor.
  *
  */
-void adv_net_shutdown();
+void shutdown();
 
 /**
  * @brief Print port statistics
  *
  */
-void adv_net_print_stats();
+void print_stats();
 
 /**
  * @brief Get the list (set) of rx/tx ports from a node
@@ -432,13 +428,13 @@ void adv_net_print_stats();
  *
  * @returns unordered set of rx/tx port names
  */
-std::unordered_set<std::string> adv_net_get_port_names(const Config& conf, const std::string& dir);
+std::unordered_set<std::string> get_port_names(const Config& conf, const std::string& dir);
 
 };  // namespace holoscan::advanced_network
 
 template <>
-struct YAML::convert<holoscan::advanced_network::AdvNetConfigYaml> {
-  static Node encode(const holoscan::advanced_network::AdvNetConfigYaml& input_spec) {
+struct YAML::convert<holoscan::advanced_network::NetworkConfig> {
+  static Node encode(const holoscan::advanced_network::NetworkConfig& input_spec) {
     Node node;
     // node["type"] = inputTypeToString(input_spec.type_);
     // node["name"] = input_spec.tensor_name_;
@@ -459,17 +455,18 @@ struct YAML::convert<holoscan::advanced_network::AdvNetConfigYaml> {
    * @param flow The FlowConfig object to populate.
    * @return true if parsing was successful, false otherwise.
    */
-  static bool parse_flow_config(const YAML::Node& flow_item, holoscan::advanced_network::FlowConfig& flow);
+  static bool parse_flow_config(const YAML::Node& flow_item,
+                                holoscan::advanced_network::FlowConfig& flow);
 
   /**
    * @brief Parse memory region configuration from a YAML node.
    *
    * @param mr The YAML node containing the memory region configuration.
-   * @param tmr The MemoryRegion object to populate.
+   * @param tmr The MemoryRegionConfig object to populate.
    * @return true if parsing was successful, false otherwise.
    */
-  static bool parse_memory_region_config(const YAML::Node& mr,
-                                         holoscan::advanced_network::MemoryRegion& memory_region);
+  static bool parse_memory_region_config(
+      const YAML::Node& mr, holoscan::advanced_network::MemoryRegionConfig& memory_region);
 
   /**
    * @brief Parse common RX queue configuration from a YAML node.
@@ -479,7 +476,7 @@ struct YAML::convert<holoscan::advanced_network::AdvNetConfigYaml> {
    * @return true if parsing was successful, false otherwise.
    */
   static bool parse_rx_queue_config(const YAML::Node& q_item,
-                                    const holoscan::advanced_network::AnoMgrType& manager_type,
+                                    const holoscan::advanced_network::ManagerType& manager_type,
                                     holoscan::advanced_network::RxQueueConfig& rx_queue_config);
 
   /**
@@ -490,8 +487,8 @@ struct YAML::convert<holoscan::advanced_network::AdvNetConfigYaml> {
    * @param q The RxQueueConfig object to populate.
    * @return true if parsing was successful, false otherwise.
    */
-  static bool parse_rx_queue_common_config(const YAML::Node& q_item,
-                                           holoscan::advanced_network::RxQueueConfig& rx_queue_config);
+  static bool parse_rx_queue_common_config(
+      const YAML::Node& q_item, holoscan::advanced_network::RxQueueConfig& rx_queue_config);
 
   /**
    * @brief Parse common TX queue configuration from a YAML node.
@@ -501,7 +498,7 @@ struct YAML::convert<holoscan::advanced_network::AdvNetConfigYaml> {
    * @return true if parsing was successful, false otherwise.
    */
   static bool parse_tx_queue_config(const YAML::Node& q_item,
-                                    const holoscan::advanced_network::AnoMgrType& manager_type,
+                                    const holoscan::advanced_network::ManagerType& manager_type,
                                     holoscan::advanced_network::TxQueueConfig& tx_queue_config);
 
   /**
@@ -512,21 +509,21 @@ struct YAML::convert<holoscan::advanced_network::AdvNetConfigYaml> {
    * @param q The TxQueueConfig object to populate.
    * @return true if parsing was successful, false otherwise.
    */
-  static bool parse_tx_queue_common_config(const YAML::Node& q_item,
-                                           holoscan::advanced_network::TxQueueConfig& tx_queue_config);
+  static bool parse_tx_queue_common_config(
+      const YAML::Node& q_item, holoscan::advanced_network::TxQueueConfig& tx_queue_config);
 
   /**
-   * @brief Decode the YAML node into an AdvNetConfigYaml object.
+   * @brief Decode the YAML node into an NetworkConfig object.
    *
-   * This function parses the provided YAML node and populates the given AdvNetConfigYaml object.
+   * This function parses the provided YAML node and populates the given NetworkConfig object.
    * It handles various configurations such as version, master core, manager type, debug flag,
    * memory regions, interfaces, RX queues, TX queues, and flows.
    *
    * @param node The YAML node containing the configuration.
-   * @param input_spec The AdvNetConfigYaml object to populate.
+   * @param input_spec The NetworkConfig object to populate.
    * @return true if decoding was successful, false otherwise.
    */
-  static bool decode(const Node& node, holoscan::advanced_network::AdvNetConfigYaml& input_spec) {
+  static bool decode(const Node& node, holoscan::advanced_network::NetworkConfig& input_spec) {
     if (!node.IsMap()) {
       GXF_LOG_ERROR("InputSpec: expected a map");
       return false;
@@ -540,7 +537,7 @@ struct YAML::convert<holoscan::advanced_network::AdvNetConfigYaml> {
         input_spec.common_.manager_type = holoscan::advanced_network::manager_type_from_string(
             node["manager"].as<std::string>(holoscan::advanced_network::ANO_MGR_STR__DEFAULT));
       } catch (const std::exception& e) {
-        input_spec.common_.manager_type = holoscan::advanced_network::AnoMgrType::DEFAULT;
+        input_spec.common_.manager_type = holoscan::advanced_network::ManagerType::DEFAULT;
       }
 
       try {
@@ -548,17 +545,17 @@ struct YAML::convert<holoscan::advanced_network::AdvNetConfigYaml> {
       } catch (const std::exception& e) { input_spec.debug_ = false; }
 
       try {
-        input_spec.log_level_ =
-            holoscan::advanced_network::AnoLogLevel::from_string(node["log_level"].as<std::string>(
-                holoscan::advanced_network::AnoLogLevel::to_string(holoscan::advanced_network::AnoLogLevel::WARN)));
+        input_spec.log_level_ = holoscan::advanced_network::LogLevel::from_string(
+            node["log_level"].as<std::string>(holoscan::advanced_network::LogLevel::to_string(
+                holoscan::advanced_network::LogLevel::WARN)));
       } catch (const std::exception& e) {
-        input_spec.log_level_ = holoscan::advanced_network::AnoLogLevel::WARN;
+        input_spec.log_level_ = holoscan::advanced_network::LogLevel::WARN;
       }
 
       try {
         const auto& mrs = node["memory_regions"];
         for (const auto& mr : mrs) {
-          holoscan::advanced_network::MemoryRegion tmr;
+          holoscan::advanced_network::MemoryRegionConfig tmr;
           if (!parse_memory_region_config(mr, tmr)) {
             HOLOSCAN_LOG_ERROR("Failed to parse memory region config");
             return false;
@@ -577,14 +574,14 @@ struct YAML::convert<holoscan::advanced_network::AdvNetConfigYaml> {
       try {
         const auto& intfs = node["interfaces"];
         for (const auto& intf : intfs) {
-          holoscan::advanced_network::AdvNetConfigInterface ifcfg;
+          holoscan::advanced_network::InterfaceConfig ifcfg;
 
           ifcfg.name_ = intf["name"].as<std::string>();
           ifcfg.address_ = intf["address"].as<std::string>();
 
           try {
             const auto& rx = intf["rx"];
-            holoscan::advanced_network::AdvNetRxConfig rx_cfg;
+            holoscan::advanced_network::RxConfig rx_cfg;
 
             try {
               rx_cfg.flow_isolation_ = rx["flow_isolation"].as<bool>();
@@ -618,7 +615,7 @@ struct YAML::convert<holoscan::advanced_network::AdvNetConfigYaml> {
 
           try {
             const auto& tx = intf["tx"];
-            holoscan::advanced_network::AdvNetTxConfig tx_cfg;
+            holoscan::advanced_network::TxConfig tx_cfg;
 
             try {
               tx_cfg.accurate_send_ = tx["accurate_send"].as<bool>();

--- a/operators/advanced_network/advanced_network/common.h
+++ b/operators/advanced_network/advanced_network/common.h
@@ -27,7 +27,7 @@
 #include "advanced_network/types.h"
 #include "holoscan/holoscan.hpp"
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 // this part is purely optional, just a helper for the user
 AdvNetBurstParams* adv_net_create_burst_params();
@@ -434,11 +434,11 @@ void adv_net_print_stats();
  */
 std::unordered_set<std::string> adv_net_get_port_names(const Config& conf, const std::string& dir);
 
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network
 
 template <>
-struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
-  static Node encode(const holoscan::ops::AdvNetConfigYaml& input_spec) {
+struct YAML::convert<holoscan::advanced_network::AdvNetConfigYaml> {
+  static Node encode(const holoscan::advanced_network::AdvNetConfigYaml& input_spec) {
     Node node;
     // node["type"] = inputTypeToString(input_spec.type_);
     // node["name"] = input_spec.tensor_name_;
@@ -459,7 +459,7 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
    * @param flow The FlowConfig object to populate.
    * @return true if parsing was successful, false otherwise.
    */
-  static bool parse_flow_config(const YAML::Node& flow_item, holoscan::ops::FlowConfig& flow);
+  static bool parse_flow_config(const YAML::Node& flow_item, holoscan::advanced_network::FlowConfig& flow);
 
   /**
    * @brief Parse memory region configuration from a YAML node.
@@ -469,7 +469,7 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
    * @return true if parsing was successful, false otherwise.
    */
   static bool parse_memory_region_config(const YAML::Node& mr,
-                                         holoscan::ops::MemoryRegion& memory_region);
+                                         holoscan::advanced_network::MemoryRegion& memory_region);
 
   /**
    * @brief Parse common RX queue configuration from a YAML node.
@@ -479,8 +479,8 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
    * @return true if parsing was successful, false otherwise.
    */
   static bool parse_rx_queue_config(const YAML::Node& q_item,
-                                    const holoscan::ops::AnoMgrType& manager_type,
-                                    holoscan::ops::RxQueueConfig& rx_queue_config);
+                                    const holoscan::advanced_network::AnoMgrType& manager_type,
+                                    holoscan::advanced_network::RxQueueConfig& rx_queue_config);
 
   /**
    * @brief Parse RX queue configuration from a YAML node.
@@ -491,7 +491,7 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
    * @return true if parsing was successful, false otherwise.
    */
   static bool parse_rx_queue_common_config(const YAML::Node& q_item,
-                                           holoscan::ops::RxQueueConfig& rx_queue_config);
+                                           holoscan::advanced_network::RxQueueConfig& rx_queue_config);
 
   /**
    * @brief Parse common TX queue configuration from a YAML node.
@@ -501,8 +501,8 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
    * @return true if parsing was successful, false otherwise.
    */
   static bool parse_tx_queue_config(const YAML::Node& q_item,
-                                    const holoscan::ops::AnoMgrType& manager_type,
-                                    holoscan::ops::TxQueueConfig& tx_queue_config);
+                                    const holoscan::advanced_network::AnoMgrType& manager_type,
+                                    holoscan::advanced_network::TxQueueConfig& tx_queue_config);
 
   /**
    * @brief Parse TX queue configuration from a YAML node.
@@ -513,7 +513,7 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
    * @return true if parsing was successful, false otherwise.
    */
   static bool parse_tx_queue_common_config(const YAML::Node& q_item,
-                                           holoscan::ops::TxQueueConfig& tx_queue_config);
+                                           holoscan::advanced_network::TxQueueConfig& tx_queue_config);
 
   /**
    * @brief Decode the YAML node into an AdvNetConfigYaml object.
@@ -526,7 +526,7 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
    * @param input_spec The AdvNetConfigYaml object to populate.
    * @return true if decoding was successful, false otherwise.
    */
-  static bool decode(const Node& node, holoscan::ops::AdvNetConfigYaml& input_spec) {
+  static bool decode(const Node& node, holoscan::advanced_network::AdvNetConfigYaml& input_spec) {
     if (!node.IsMap()) {
       GXF_LOG_ERROR("InputSpec: expected a map");
       return false;
@@ -537,10 +537,10 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
       input_spec.common_.version = node["version"].as<int32_t>();
       input_spec.common_.master_core_ = node["master_core"].as<int32_t>();
       try {
-        input_spec.common_.manager_type = holoscan::ops::manager_type_from_string(
-            node["manager"].as<std::string>(holoscan::ops::ANO_MGR_STR__DEFAULT));
+        input_spec.common_.manager_type = holoscan::advanced_network::manager_type_from_string(
+            node["manager"].as<std::string>(holoscan::advanced_network::ANO_MGR_STR__DEFAULT));
       } catch (const std::exception& e) {
-        input_spec.common_.manager_type = holoscan::ops::AnoMgrType::DEFAULT;
+        input_spec.common_.manager_type = holoscan::advanced_network::AnoMgrType::DEFAULT;
       }
 
       try {
@@ -549,16 +549,16 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
 
       try {
         input_spec.log_level_ =
-            holoscan::ops::AnoLogLevel::from_string(node["log_level"].as<std::string>(
-                holoscan::ops::AnoLogLevel::to_string(holoscan::ops::AnoLogLevel::WARN)));
+            holoscan::advanced_network::AnoLogLevel::from_string(node["log_level"].as<std::string>(
+                holoscan::advanced_network::AnoLogLevel::to_string(holoscan::advanced_network::AnoLogLevel::WARN)));
       } catch (const std::exception& e) {
-        input_spec.log_level_ = holoscan::ops::AnoLogLevel::WARN;
+        input_spec.log_level_ = holoscan::advanced_network::AnoLogLevel::WARN;
       }
 
       try {
         const auto& mrs = node["memory_regions"];
         for (const auto& mr : mrs) {
-          holoscan::ops::MemoryRegion tmr;
+          holoscan::advanced_network::MemoryRegion tmr;
           if (!parse_memory_region_config(mr, tmr)) {
             HOLOSCAN_LOG_ERROR("Failed to parse memory region config");
             return false;
@@ -577,21 +577,21 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
       try {
         const auto& intfs = node["interfaces"];
         for (const auto& intf : intfs) {
-          holoscan::ops::AdvNetConfigInterface ifcfg;
+          holoscan::advanced_network::AdvNetConfigInterface ifcfg;
 
           ifcfg.name_ = intf["name"].as<std::string>();
           ifcfg.address_ = intf["address"].as<std::string>();
 
           try {
             const auto& rx = intf["rx"];
-            holoscan::ops::AdvNetRxConfig rx_cfg;
+            holoscan::advanced_network::AdvNetRxConfig rx_cfg;
 
             try {
               rx_cfg.flow_isolation_ = rx["flow_isolation"].as<bool>();
             } catch (const std::exception& e) { rx_cfg.flow_isolation_ = false; }
 
             for (const auto& q_item : rx["queues"]) {
-              holoscan::ops::RxQueueConfig q;
+              holoscan::advanced_network::RxQueueConfig q;
               if (!parse_rx_queue_config(q_item, input_spec.common_.manager_type, q)) {
                 HOLOSCAN_LOG_ERROR("Failed to parse RxQueueConfig");
                 return false;
@@ -605,7 +605,7 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
             }
 
             for (const auto& flow_item : rx["flows"]) {
-              holoscan::ops::FlowConfig flow;
+              holoscan::advanced_network::FlowConfig flow;
               if (!parse_flow_config(flow_item, flow)) {
                 HOLOSCAN_LOG_ERROR("Failed to parse FlowConfig");
                 return false;
@@ -618,14 +618,14 @@ struct YAML::convert<holoscan::ops::AdvNetConfigYaml> {
 
           try {
             const auto& tx = intf["tx"];
-            holoscan::ops::AdvNetTxConfig tx_cfg;
+            holoscan::advanced_network::AdvNetTxConfig tx_cfg;
 
             try {
               tx_cfg.accurate_send_ = tx["accurate_send"].as<bool>();
             } catch (const std::exception& e) { tx_cfg.accurate_send_ = false; }
 
             for (const auto& q_item : tx["queues"]) {
-              holoscan::ops::TxQueueConfig q;
+              holoscan::advanced_network::TxQueueConfig q;
               if (!parse_tx_queue_config(q_item, input_spec.common_.manager_type, q)) {
                 HOLOSCAN_LOG_ERROR("Failed to parse TxQueueConfig");
                 return false;

--- a/operators/advanced_network/advanced_network/manager.cpp
+++ b/operators/advanced_network/advanced_network/manager.cpp
@@ -34,7 +34,7 @@
 
 #include "holoscan/holoscan.hpp"
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 // Initialize static members
 std::unique_ptr<ANOMgr> AnoMgrFactory::AnoMgrInstance_ = nullptr;  // Initialize static members
@@ -103,11 +103,11 @@ AnoMgrType AnoMgrFactory::get_manager_type(const Config& config) {
       std::string manager = node["manager"].template as<std::string>(ANO_MGR_STR__DEFAULT);
       return manager_type_from_string(manager);
     } catch (const std::exception& e) {
-      return manager_type_from_string(holoscan::ops::ANO_MGR_STR__DEFAULT);
+      return manager_type_from_string(holoscan::advanced_network::ANO_MGR_STR__DEFAULT);
     }
   }
 
-  return manager_type_from_string(holoscan::ops::ANO_MGR_STR__DEFAULT);
+  return manager_type_from_string(holoscan::advanced_network::ANO_MGR_STR__DEFAULT);
 }
 
 template AnoMgrType AnoMgrFactory::get_manager_type<Config>(const Config&);
@@ -241,4 +241,4 @@ void ANOMgr::init_rx_core_q_map() {
   }
 }
 
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/manager.h
+++ b/operators/advanced_network/advanced_network/manager.h
@@ -31,57 +31,57 @@ struct AllocRegion {
  * @brief (Almost) ABC representing an interface into an ANO backend implementation
  *
  */
-class ANOMgr {
+class Manager {
  public:
   static constexpr size_t MAX_RX_Q_PER_CORE = 16;
 
   virtual void initialize() = 0;
   virtual bool is_initialized() const { return initialized_; }
-  virtual bool set_config_and_initialize(const AdvNetConfigYaml& cfg) = 0;
+  virtual bool set_config_and_initialize(const NetworkConfig& cfg) = 0;
   virtual void run() = 0;
 
   // Common free functions to override
-  virtual void* get_pkt_ptr(AdvNetBurstParams* burst, int idx) = 0;
-  virtual uint16_t get_pkt_len(AdvNetBurstParams* burst, int idx) = 0;
-  virtual void* get_seg_pkt_ptr(AdvNetBurstParams* burst, int seg, int idx) = 0;
-  virtual uint16_t get_seg_pkt_len(AdvNetBurstParams* burst, int seg, int idx) = 0;
-  virtual uint16_t get_pkt_flow_id(AdvNetBurstParams* burst, int idx) = 0;
-  virtual void* get_pkt_extra_info(AdvNetBurstParams* burst, int idx) = 0;
-  virtual AdvNetStatus get_tx_pkt_burst(AdvNetBurstParams* burst) = 0;
-  virtual AdvNetStatus set_eth_hdr(AdvNetBurstParams* burst, int idx, char* dst_addr) = 0;
-  virtual AdvNetStatus set_ipv4_hdr(AdvNetBurstParams* burst, int idx, int ip_len, uint8_t proto,
+  virtual void* get_packet_ptr(BurstParams* burst, int idx) = 0;
+  virtual uint16_t get_packet_length(BurstParams* burst, int idx) = 0;
+  virtual void* get_segment_packet_ptr(BurstParams* burst, int seg, int idx) = 0;
+  virtual uint16_t get_segment_packet_length(BurstParams* burst, int seg, int idx) = 0;
+  virtual uint16_t get_packet_flow_id(BurstParams* burst, int idx) = 0;
+  virtual void* get_packet_extra_info(BurstParams* burst, int idx) = 0;
+  virtual Status get_tx_packet_burst(BurstParams* burst) = 0;
+  virtual Status set_eth_header(BurstParams* burst, int idx, char* dst_addr) = 0;
+  virtual Status set_ipv4_header(BurstParams* burst, int idx, int ip_len, uint8_t proto,
                                     unsigned int src_host, unsigned int dst_host) = 0;
-  virtual AdvNetStatus set_udp_hdr(AdvNetBurstParams* burst, int idx, int udp_len,
+  virtual Status set_udp_header(BurstParams* burst, int idx, int udp_len,
                                    uint16_t src_port, uint16_t dst_port) = 0;
-  virtual AdvNetStatus set_udp_payload(AdvNetBurstParams* burst, int idx, void* data, int len) = 0;
-  virtual bool tx_burst_available(AdvNetBurstParams* burst) = 0;
+  virtual Status set_udp_payload(BurstParams* burst, int idx, void* data, int len) = 0;
+  virtual bool is_tx_burst_available(BurstParams* burst) = 0;
 
-  virtual AdvNetStatus set_pkt_lens(AdvNetBurstParams* burst, int idx,
+  virtual Status set_packet_lengths(BurstParams* burst, int idx,
                                     const std::initializer_list<int>& lens) = 0;
-  virtual void free_all_seg_pkts(AdvNetBurstParams* burst, int seg) = 0;
-  virtual void free_all_pkts(AdvNetBurstParams* burst) = 0;
-  virtual void free_pkt_seg(AdvNetBurstParams* burst, int seg, int pkt) = 0;
-  virtual void free_pkt(AdvNetBurstParams* burst, int pkt) = 0;
-  virtual void free_rx_burst(AdvNetBurstParams* burst) = 0;
-  virtual void free_tx_burst(AdvNetBurstParams* burst) = 0;
-  virtual AdvNetStatus set_pkt_tx_time(AdvNetBurstParams* burst, int idx, uint64_t time) = 0;
+  virtual void free_all_segment_packets(BurstParams* burst, int seg) = 0;
+  virtual void free_all_packets(BurstParams* burst) = 0;
+  virtual void free_packet_segment(BurstParams* burst, int seg, int pkt) = 0;
+  virtual void free_packet(BurstParams* burst, int pkt) = 0;
+  virtual void free_rx_burst(BurstParams* burst) = 0;
+  virtual void free_tx_burst(BurstParams* burst) = 0;
+  virtual Status set_packet_tx_time(BurstParams* burst, int idx, uint64_t time) = 0;
   virtual void shutdown() = 0;
   virtual void print_stats() = 0;
-  virtual uint64_t get_burst_tot_byte(AdvNetBurstParams* burst) = 0;
-  virtual AdvNetBurstParams* create_tx_burst_params() = 0;
+  virtual uint64_t get_burst_tot_byte(BurstParams* burst) = 0;
+  virtual BurstParams* create_tx_burst_params() = 0;
 
   /* Internal functions used by ANO operators */
   virtual std::optional<uint16_t> get_port_from_ifname(const std::string& name) = 0;
-  virtual AdvNetStatus get_rx_burst(AdvNetBurstParams** burst) = 0;
-  virtual void free_rx_meta(AdvNetBurstParams* burst) = 0;
-  virtual void free_tx_meta(AdvNetBurstParams* burst) = 0;
-  virtual AdvNetStatus get_tx_meta_buf(AdvNetBurstParams** burst) = 0;
-  virtual AdvNetStatus send_tx_burst(AdvNetBurstParams* burst) = 0;
-  virtual AdvNetStatus get_mac(int port, char* mac) = 0;
+  virtual Status get_rx_burst(BurstParams** burst) = 0;
+  virtual void free_rx_metadata(BurstParams* burst) = 0;
+  virtual void free_tx_metadata(BurstParams* burst) = 0;
+  virtual Status get_tx_metadata_buffer(BurstParams** burst) = 0;
+  virtual Status send_tx_burst(BurstParams* burst) = 0;
+  virtual Status get_mac_addr(int port, char* mac) = 0;
   virtual int address_to_port(const std::string& addr) = 0;
   virtual bool validate_config() const;
 
-  virtual ~ANOMgr() = default;
+  virtual ~Manager() = default;
 
  protected:
   static constexpr int MAX_IFS = 4;
@@ -91,51 +91,51 @@ class ANOMgr {
   static constexpr uint32_t JUMBO_FRAME_MAX_SIZE = 0x2600;
   static constexpr uint32_t NON_JUMBO_FRAME_MAX_SIZE = 1518;
   bool initialized_ = false;
-  AdvNetConfigYaml cfg_;
+  NetworkConfig cfg_;
   std::unordered_map<std::string, AllocRegion> ar_;
   std::unordered_map<uint32_t, std::vector<std::pair<uint16_t, uint16_t>>> rx_core_q_map;
 
-  virtual AdvNetStatus allocate_memory_regions();
+  virtual Status allocate_memory_regions();
   virtual void adjust_memory_regions() {}
   void init_rx_core_q_map();
 };
 
-class AnoMgrFactory {
+class ManagerFactory {
  public:
-  static void set_manager_type(AnoMgrType type) {
-    if (AnoMgrType_ != AnoMgrType::UNKNOWN && AnoMgrType_ != type) {
+  static void set_manager_type(ManagerType type) {
+    if (ManagerType_ != ManagerType::UNKNOWN && ManagerType_ != type) {
       throw std::logic_error("Manager type is already set with another manager type.");
     }
-    if (type == AnoMgrType::DEFAULT) {
-      AnoMgrType_ = get_default_manager_type();
+    if (type == ManagerType::DEFAULT) {
+      ManagerType_ = get_default_manager_type();
     } else {
-      AnoMgrType_ = type;
+      ManagerType_ = type;
     }
   }
 
-  static AnoMgrType get_manager_type() { return AnoMgrType_; }
+  static ManagerType get_manager_type() { return ManagerType_; }
 
   template <typename Config>
-  static AnoMgrType get_manager_type(const Config& config);
+  static ManagerType get_manager_type(const Config& config);
 
-  static AnoMgrType get_default_manager_type();
+  static ManagerType get_default_manager_type();
 
-  static ANOMgr& get_active_manager() {
-    if (AnoMgrType_ == AnoMgrType::UNKNOWN) { throw std::logic_error("AnoMgrType not set"); }
-    if (!AnoMgrInstance_) { AnoMgrInstance_ = create_instance(AnoMgrType_); }
-    return *AnoMgrInstance_;
+  static Manager& get_active_manager() {
+    if (ManagerType_ == ManagerType::UNKNOWN) { throw std::logic_error("ManagerType not set"); }
+    if (!ManagerInstance_) { ManagerInstance_ = create_instance(ManagerType_); }
+    return *ManagerInstance_;
   }
 
  private:
-  AnoMgrFactory() = default;
-  ~AnoMgrFactory() = default;
-  AnoMgrFactory(const AnoMgrFactory&) = delete;
-  AnoMgrFactory& operator=(const AnoMgrFactory&) = delete;
+  ManagerFactory() = default;
+  ~ManagerFactory() = default;
+  ManagerFactory(const ManagerFactory&) = delete;
+  ManagerFactory& operator=(const ManagerFactory&) = delete;
 
-  static std::unique_ptr<ANOMgr> AnoMgrInstance_;
-  static AnoMgrType AnoMgrType_;
+  static std::unique_ptr<Manager> ManagerInstance_;
+  static ManagerType ManagerType_;
 
-  static std::unique_ptr<ANOMgr> create_instance(AnoMgrType type);
+  static std::unique_ptr<Manager> create_instance(ManagerType type);
 };
 
 };  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/manager.h
+++ b/operators/advanced_network/advanced_network/manager.h
@@ -20,7 +20,7 @@
 #include "advanced_network/types.h"
 #include <optional>
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 struct AllocRegion {
   std::string mr_name_;
@@ -138,4 +138,4 @@ class AnoMgrFactory {
   static std::unique_ptr<ANOMgr> create_instance(AnoMgrType type);
 };
 
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
@@ -33,7 +33,7 @@
 
 using namespace std::chrono;
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 std::atomic<bool> force_quit = false;
 
@@ -1993,4 +1993,4 @@ AdvNetBurstParams* DpdkMgr::create_tx_burst_params() {
   return burst;
 }
 
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.h
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.h
@@ -51,7 +51,7 @@
 #include "advanced_network/common.h"
 #include "adv_network_dpdk_stats.h"
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 struct DPDKQueueConfig {
   std::vector<struct rte_mempool*> pools;
@@ -245,4 +245,4 @@ class DpdkMgr : public ANOMgr {
   int num_init = 0;
 };
 
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_stats.cpp
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_stats.cpp
@@ -22,7 +22,7 @@
 
 namespace holoscan::advanced_network {
 
-void AdvNetworkDpdkStats::Init(const AdvNetConfigYaml &cfg) {
+void DpdkStats::Init(const NetworkConfig &cfg) {
   cfg_ = cfg;
   init_ = true;
 
@@ -164,7 +164,7 @@ void AdvNetworkDpdkStats::Init(const AdvNetConfigYaml &cfg) {
   HOLOSCAN_LOG_INFO("Initialized DPDK stats");
 }
 
-void AdvNetworkDpdkStats::Shutdown() {
+void DpdkStats::Shutdown() {
   init_ = false;
 
   force_quit_.store(true);
@@ -174,7 +174,7 @@ void AdvNetworkDpdkStats::Shutdown() {
  * @brief Constantly polls and updates the stats for the DPDK manager. The result of this polling
    can be used by the user's application to check for errors or other issues.
  */
-void AdvNetworkDpdkStats::Run() {
+void DpdkStats::Run() {
   cpu_set_t cpuset;
 
   auto thread = pthread_self();

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_stats.cpp
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_stats.cpp
@@ -20,7 +20,9 @@
 #include <thread>
 #include <chrono>
 
-void AdvNetworkDpdkStats::Init(const holoscan::ops::AdvNetConfigYaml &cfg) {
+namespace holoscan::advanced_network {
+
+void AdvNetworkDpdkStats::Init(const AdvNetConfigYaml &cfg) {
   cfg_ = cfg;
   init_ = true;
 
@@ -275,3 +277,5 @@ void AdvNetworkDpdkStats::Run() {
     std::this_thread::sleep_for(std::chrono::milliseconds(POLLING_INTERVAL_MS));
   }
 }
+
+}  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_stats.h
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_stats.h
@@ -22,6 +22,8 @@
 #include <vector>
 #include <array>
 
+namespace holoscan::advanced_network {
+
 class AdvNetworkDpdkStats {
  public:
     AdvNetworkDpdkStats() = default;
@@ -43,7 +45,7 @@ class AdvNetworkDpdkStats {
       force_quit_.store(true);
     }
 
-    void Init(const holoscan::ops::AdvNetConfigYaml &cfg);
+    void Init(const AdvNetConfigYaml &cfg);
     void Shutdown();
 
  private:
@@ -66,7 +68,7 @@ class AdvNetworkDpdkStats {
       }
     };
 
-    holoscan::ops::AdvNetConfigYaml cfg_;
+    AdvNetConfigYaml cfg_;
     bool init_ = false;
     int core_;
     std::unordered_map<int, PortXStats> xstats_;  // Map from port_id to xstats
@@ -77,3 +79,5 @@ class AdvNetworkDpdkStats {
     // Key: (port_id << 16) | queue_id, Value: comma-separated list of memory region names
     std::unordered_map<uint32_t, std::string> port_queue_memory_regions_;
 };
+
+}  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_stats.h
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_stats.h
@@ -24,11 +24,11 @@
 
 namespace holoscan::advanced_network {
 
-class AdvNetworkDpdkStats {
+class DpdkStats {
  public:
-    AdvNetworkDpdkStats() = default;
+    DpdkStats() = default;
     void Run();
-    ~AdvNetworkDpdkStats() {
+    ~DpdkStats() {
       // Free allocated memory for xstats
       for (auto& [port_id, port_stats] : xstats_) {
         if (port_stats.xstats) {
@@ -45,7 +45,7 @@ class AdvNetworkDpdkStats {
       force_quit_.store(true);
     }
 
-    void Init(const AdvNetConfigYaml &cfg);
+    void Init(const NetworkConfig &cfg);
     void Shutdown();
 
  private:
@@ -68,7 +68,7 @@ class AdvNetworkDpdkStats {
       }
     };
 
-    AdvNetConfigYaml cfg_;
+    NetworkConfig cfg_;
     bool init_ = false;
     int core_;
     std::unordered_map<int, PortXStats> xstats_;  // Map from port_id to xstats

--- a/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.cpp
@@ -32,7 +32,7 @@
 
 using namespace std::chrono;
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 DocaMgr doca_mgr{};
 
@@ -1833,4 +1833,4 @@ void DocaMgr::print_stats() {
   return;
 }
 
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.h
+++ b/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.h
@@ -83,7 +83,7 @@ static uint64_t next_power_of_two(uint64_t x) {
   return x + 1;
 }
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 static constexpr int JUMBFRAME_SIZE = 9100;
 static constexpr int DEFAULT_NUM_TX_BURST = 256;
@@ -273,4 +273,4 @@ class DocaMgr : public ANOMgr {
 };
 
 extern DocaMgr doca_mgr;
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.h
+++ b/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.h
@@ -111,7 +111,7 @@ class DocaLogLevel {
     throw std::logic_error(
         "Unrecognized log level, available options trace/debug/info/warn/error/critical/disable");
   }
-  static doca_log_level from_ano_log_level(AnoLogLevel::Level ano_level) {
+  static doca_log_level from_ano_log_level(LogLevel::Level ano_level) {
     auto it = ano_to_doca_log_level_map.find(ano_level);
     if (it != ano_to_doca_log_level_map.end()) { return it->second; }
     return DOCA_LOG_LEVEL_DISABLE;
@@ -119,7 +119,7 @@ class DocaLogLevel {
 
  private:
   static const std::unordered_map<doca_log_level, std::string> level_to_string_description_map;
-  static const std::unordered_map<AnoLogLevel::Level, doca_log_level> ano_to_doca_log_level_map;
+  static const std::unordered_map<LogLevel::Level, doca_log_level> ano_to_doca_log_level_map;
 };
 
 class DocaRxQueue {
@@ -179,12 +179,12 @@ class DocaTxQueue {
   enum doca_gpu_mem_type mtype;
 };
 
-class DocaMgr : public ANOMgr {
+class DocaMgr : public Manager {
  public:
   static_assert(MAX_INTERFACES <= RTE_MAX_ETHPORTS, "Too many interfaces configured");
   DocaMgr() = default;
   ~DocaMgr();
-  bool set_config_and_initialize(const AdvNetConfigYaml& cfg) override;
+  bool set_config_and_initialize(const NetworkConfig& cfg) override;
   void initialize() override;
   void run() override;
   // int SetupPoolsAndRings();
@@ -194,45 +194,45 @@ class DocaMgr : public ANOMgr {
   uint16_t default_num_tx_desc = 8192;
   int num_ports = 0;
 
-  void* get_seg_pkt_ptr(AdvNetBurstParams* burst, int seg, int idx) override;
-  void* get_pkt_ptr(AdvNetBurstParams* burst, int idx) override;
-  uint16_t get_pkt_len(AdvNetBurstParams* burst, int idx) override;
-  uint16_t get_seg_pkt_len(AdvNetBurstParams* burst, int seg, int idx) override;
-  void* get_pkt_extra_info(AdvNetBurstParams* burst, int idx) override;
-  uint16_t get_pkt_flow_id(AdvNetBurstParams* burst, int idx) override;
-  AdvNetStatus get_tx_pkt_burst(AdvNetBurstParams* burst) override;
-  AdvNetStatus set_eth_hdr(AdvNetBurstParams* burst, int idx, char* dst_addr) override;
-  AdvNetStatus set_ipv4_hdr(AdvNetBurstParams* burst, int idx, int ip_len, uint8_t proto,
+  void* get_segment_packet_ptr(BurstParams* burst, int seg, int idx) override;
+  void* get_packet_ptr(BurstParams* burst, int idx) override;
+  uint16_t get_packet_length(BurstParams* burst, int idx) override;
+  uint16_t get_segment_packet_length(BurstParams* burst, int seg, int idx) override;
+  void* get_packet_extra_info(BurstParams* burst, int idx) override;
+  uint16_t get_packet_flow_id(BurstParams* burst, int idx) override;
+  Status get_tx_packet_burst(BurstParams* burst) override;
+  Status set_eth_header(BurstParams* burst, int idx, char* dst_addr) override;
+  Status set_ipv4_header(BurstParams* burst, int idx, int ip_len, uint8_t proto,
                             unsigned int src_host, unsigned int dst_host) override;
-  AdvNetStatus set_udp_hdr(AdvNetBurstParams* burst, int idx, int udp_len, uint16_t src_port,
+  Status set_udp_header(BurstParams* burst, int idx, int udp_len, uint16_t src_port,
                            uint16_t dst_port) override;
-  AdvNetStatus set_udp_payload(AdvNetBurstParams* burst, int idx, void* data, int len) override;
-  bool tx_burst_available(AdvNetBurstParams* burst) override;
+  Status set_udp_payload(BurstParams* burst, int idx, void* data, int len) override;
+  bool is_tx_burst_available(BurstParams* burst) override;
 
-  AdvNetStatus set_pkt_lens(AdvNetBurstParams* burst, int idx,
+  Status set_packet_lengths(BurstParams* burst, int idx,
                             const std::initializer_list<int>& lens) override;
-  void free_all_seg_pkts(AdvNetBurstParams* burst, int seg) override{};
-  void free_pkt_seg(AdvNetBurstParams* burst, int seg, int pkt) override{};
-  void free_pkt(AdvNetBurstParams* burst, int pkt) override{};
-  void free_all_pkts(AdvNetBurstParams* burst) override{};
-  void free_rx_burst(AdvNetBurstParams* burst) override;
-  void free_tx_burst(AdvNetBurstParams* burst) override;
+  void free_all_segment_packets(BurstParams* burst, int seg) override{};
+  void free_packet_segment(BurstParams* burst, int seg, int pkt) override{};
+  void free_packet(BurstParams* burst, int pkt) override{};
+  void free_all_packets(BurstParams* burst) override{};
+  void free_rx_burst(BurstParams* burst) override;
+  void free_tx_burst(BurstParams* burst) override;
   std::optional<uint16_t> get_port_from_ifname(const std::string& name) override;
 
-  AdvNetStatus get_rx_burst(AdvNetBurstParams** burst) override;
-  AdvNetStatus set_pkt_tx_time(AdvNetBurstParams* burst, int idx, uint64_t timestamp);
-  void free_rx_meta(AdvNetBurstParams* burst) override;
-  void free_tx_meta(AdvNetBurstParams* burst) override;
-  AdvNetStatus get_tx_meta_buf(AdvNetBurstParams** burst) override;
-  AdvNetStatus send_tx_burst(AdvNetBurstParams* burst) override;
-  AdvNetStatus get_mac(int port, char* mac) override;
+  Status get_rx_burst(BurstParams** burst) override;
+  Status set_packet_tx_time(BurstParams* burst, int idx, uint64_t timestamp);
+  void free_rx_metadata(BurstParams* burst) override;
+  void free_tx_metadata(BurstParams* burst) override;
+  Status get_tx_metadata_buffer(BurstParams** burst) override;
+  Status send_tx_burst(BurstParams* burst) override;
+  Status get_mac_addr(int port, char* mac) override;
   int address_to_port(const std::string& addr) override;
   void shutdown() override;
   void print_stats() override;
   bool validate_config() const override;
 
-  uint64_t get_burst_tot_byte(AdvNetBurstParams* burst) override;
-  AdvNetBurstParams* create_tx_burst_params() override;
+  uint64_t get_burst_tot_byte(BurstParams* burst) override;
+  BurstParams* create_tx_burst_params() override;
 
  private:
   doca_error_t init_doca_devices();
@@ -240,11 +240,11 @@ class DocaMgr : public ANOMgr {
   doca_error_t create_default_pipe(int port_id, uint32_t cnt_defq);
   struct doca_flow_port* init_doca_flow(uint16_t port_id, uint8_t rxq_num);
   int setup_pools_and_rings(int max_tx_batch);
-  std::string GetQueueName(int port, int q, AdvNetDirection dir);
+  std::string GetQueueName(int port, int q, Direction dir);
   std::unordered_map<uint32_t, struct rte_ring*> tx_rings;
   struct rte_ring* rx_ring;
-  struct rte_mempool* rx_meta;
-  struct rte_mempool* tx_meta;
+  struct rte_mempool* rx_metadata;
+  struct rte_mempool* tx_metadata;
   std::unordered_map<uint32_t, DocaRxQueue*> rx_q_map_;
   std::unordered_map<uint32_t, DocaTxQueue*> tx_q_map_;
   std::array<struct rte_eth_conf, MAX_INTERFACES> local_port_conf;
@@ -264,7 +264,7 @@ class DocaMgr : public ANOMgr {
   int num_init = 0;
   struct doca_flow_pipe* rxq_pipe_default;             /* DOCA Flow receive pipe default */
   struct doca_flow_pipe_entry* root_udp_entry_default; /* DOCA Flow root entry */
-  AdvNetBurstParams burst[MAX_TX_BURST];
+  BurstParams burst[MAX_TX_BURST];
   std::atomic<uint32_t> burst_tx_idx;
 
   std::thread worker_th[16];

--- a/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr_obj.cpp
+++ b/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr_obj.cpp
@@ -28,7 +28,7 @@
 
 using namespace std::chrono;
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 DocaRxQueue::DocaRxQueue(struct doca_dev* dev_, struct doca_gpu* gdev_,
                          struct doca_flow_port* df_port_, uint16_t qid_, int max_pkt_num_,
@@ -523,4 +523,4 @@ DocaTxQueue::~DocaTxQueue() {
   HOLOSCAN_LOG_INFO("DocaTxQueue destroyed\n");
 }
 
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/managers/rivermax/adv_network_rmax_mgr.h
+++ b/operators/advanced_network/advanced_network/managers/rivermax/adv_network_rmax_mgr.h
@@ -22,7 +22,7 @@
 
 #include "advanced_network/manager.h"
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 class RmaxMgr : public ANOMgr {
  public:
@@ -79,4 +79,4 @@ class RmaxMgr : public ANOMgr {
   std::unique_ptr<RmaxMgr::RmaxMgrImpl> pImpl;
 };
 
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/managers/rivermax/adv_network_rmax_mgr.h
+++ b/operators/advanced_network/advanced_network/managers/rivermax/adv_network_rmax_mgr.h
@@ -24,54 +24,54 @@
 
 namespace holoscan::advanced_network {
 
-class RmaxMgr : public ANOMgr {
+class RmaxMgr : public Manager {
  public:
   RmaxMgr();
   ~RmaxMgr();
-  bool set_config_and_initialize(const AdvNetConfigYaml& cfg) override;
+  bool set_config_and_initialize(const NetworkConfig& cfg) override;
   void initialize() override;
   void run() override;
 
-  static AdvNetStatus parse_rx_queue_rivermax_config(const YAML::Node& q_item, RxQueueConfig& q);
-  static AdvNetStatus parse_tx_queue_rivermax_config(const YAML::Node& q_item, TxQueueConfig& q);
+  static Status parse_rx_queue_rivermax_config(const YAML::Node& q_item, RxQueueConfig& q);
+  static Status parse_tx_queue_rivermax_config(const YAML::Node& q_item, TxQueueConfig& q);
 
-  void* get_seg_pkt_ptr(AdvNetBurstParams* burst, int seg, int idx) override;
-  void* get_pkt_ptr(AdvNetBurstParams* burst, int idx) override;
-  uint16_t get_seg_pkt_len(AdvNetBurstParams* burst, int seg, int idx) override;
-  uint16_t get_pkt_len(AdvNetBurstParams* burst, int idx) override;
-  uint16_t get_pkt_flow_id(AdvNetBurstParams* burst, int idx) override;
-  void* get_pkt_extra_info(AdvNetBurstParams* burst, int idx) override;
-  AdvNetStatus get_tx_pkt_burst(AdvNetBurstParams* burst) override;
-  AdvNetStatus set_eth_hdr(AdvNetBurstParams* burst, int idx, char* dst_addr) override;
-  AdvNetStatus set_ipv4_hdr(AdvNetBurstParams* burst, int idx, int ip_len, uint8_t proto,
+  void* get_segment_packet_ptr(BurstParams* burst, int seg, int idx) override;
+  void* get_packet_ptr(BurstParams* burst, int idx) override;
+  uint16_t get_segment_packet_length(BurstParams* burst, int seg, int idx) override;
+  uint16_t get_packet_length(BurstParams* burst, int idx) override;
+  uint16_t get_packet_flow_id(BurstParams* burst, int idx) override;
+  void* get_packet_extra_info(BurstParams* burst, int idx) override;
+  Status get_tx_packet_burst(BurstParams* burst) override;
+  Status set_eth_header(BurstParams* burst, int idx, char* dst_addr) override;
+  Status set_ipv4_header(BurstParams* burst, int idx, int ip_len, uint8_t proto,
                             unsigned int src_host, unsigned int dst_host) override;
-  AdvNetStatus set_udp_hdr(AdvNetBurstParams* burst, int idx, int udp_len, uint16_t src_port,
+  Status set_udp_header(BurstParams* burst, int idx, int udp_len, uint16_t src_port,
                            uint16_t dst_port) override;
-  AdvNetStatus set_udp_payload(AdvNetBurstParams* burst, int idx, void* data, int len) override;
-  bool tx_burst_available(AdvNetBurstParams* burst) override;
+  Status set_udp_payload(BurstParams* burst, int idx, void* data, int len) override;
+  bool is_tx_burst_available(BurstParams* burst) override;
 
-  AdvNetStatus set_pkt_lens(AdvNetBurstParams* burst, int idx,
+  Status set_packet_lengths(BurstParams* burst, int idx,
                             const std::initializer_list<int>& lens) override;
-  void free_all_seg_pkts(AdvNetBurstParams* burst, int seg) override;
-  void free_all_pkts(AdvNetBurstParams* burst) override;
-  void free_pkt_seg(AdvNetBurstParams* burst, int seg, int pkt) override;
-  void free_pkt(AdvNetBurstParams* burst, int pkt) override;
-  void free_rx_burst(AdvNetBurstParams* burst) override;
-  void free_tx_burst(AdvNetBurstParams* burst) override;
+  void free_all_segment_packets(BurstParams* burst, int seg) override;
+  void free_all_packets(BurstParams* burst) override;
+  void free_packet_segment(BurstParams* burst, int seg, int pkt) override;
+  void free_packet(BurstParams* burst, int pkt) override;
+  void free_rx_burst(BurstParams* burst) override;
+  void free_tx_burst(BurstParams* burst) override;
 
   std::optional<uint16_t> get_port_from_ifname(const std::string& name) override;
 
-  AdvNetStatus get_rx_burst(AdvNetBurstParams** burst) override;
-  AdvNetStatus set_pkt_tx_time(AdvNetBurstParams* burst, int idx, uint64_t timestamp);
-  void free_rx_meta(AdvNetBurstParams* burst) override;
-  void free_tx_meta(AdvNetBurstParams* burst) override;
-  AdvNetStatus get_tx_meta_buf(AdvNetBurstParams** burst) override;
-  AdvNetStatus send_tx_burst(AdvNetBurstParams* burst) override;
+  Status get_rx_burst(BurstParams** burst) override;
+  Status set_packet_tx_time(BurstParams* burst, int idx, uint64_t timestamp);
+  void free_rx_metadata(BurstParams* burst) override;
+  void free_tx_metadata(BurstParams* burst) override;
+  Status get_tx_metadata_buffer(BurstParams** burst) override;
+  Status send_tx_burst(BurstParams* burst) override;
   void shutdown() override;
   void print_stats() override;
-  uint64_t get_burst_tot_byte(AdvNetBurstParams* burst) override;
-  AdvNetBurstParams* create_tx_burst_params() override;
-  AdvNetStatus get_mac(int port, char* mac) override;
+  uint64_t get_burst_tot_byte(BurstParams* burst) override;
+  BurstParams* create_tx_burst_params() override;
+  Status get_mac_addr(int port, char* mac) override;
   int address_to_port(const std::string& addr) override;
 
  private:

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_ano_data_types.h
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_ano_data_types.h
@@ -225,7 +225,7 @@ class RmaxLogLevel {
    * @param ano_level The Ano log level to convert.
    * @return The corresponding Rmax log level.
    */
-  static Level from_ano_log_level(AnoLogLevel::Level ano_level) {
+  static Level from_ano_log_level(LogLevel::Level ano_level) {
     auto it = ano_to_rmax_log_level_map.find(ano_level);
     if (it != ano_to_rmax_log_level_map.end()) { return it->second; }
     return OFF;
@@ -239,7 +239,7 @@ class RmaxLogLevel {
   /**
    * A map of Ano log level to Rmax log level.
    */
-  static const std::unordered_map<AnoLogLevel::Level, Level> ano_to_rmax_log_level_map;
+  static const std::unordered_map<LogLevel::Level, Level> ano_to_rmax_log_level_map;
 };
 
 }  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_ano_data_types.h
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_ano_data_types.h
@@ -20,9 +20,8 @@
 
 #include "advanced_network/types.h"
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
-// using namespace holoscan::ops;
 class RmaxBurst;
 
 class IAnoBurstsCollection {
@@ -243,6 +242,6 @@ class RmaxLogLevel {
   static const std::unordered_map<AnoLogLevel::Level, Level> ano_to_rmax_log_level_map;
 };
 
-}  // namespace holoscan::ops
+}  // namespace holoscan::advanced_network
 
 #endif  // RMAX_ANO_DATA_TYPES_H_

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/adv_network_rmax_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/adv_network_rmax_mgr.cpp
@@ -62,15 +62,15 @@ const std::unordered_map<RmaxLogLevel::Level, std::tuple<std::string, std::strin
 /**
  * A map of Ano log level to Rmax log level.
  */
-const std::unordered_map<AnoLogLevel::Level, RmaxLogLevel::Level>
+const std::unordered_map<LogLevel::Level, RmaxLogLevel::Level>
     RmaxLogLevel::ano_to_rmax_log_level_map = {
-        {AnoLogLevel::TRACE, TRACE},
-        {AnoLogLevel::DEBUG, DEBUG},
-        {AnoLogLevel::INFO, INFO},
-        {AnoLogLevel::WARN, WARN},
-        {AnoLogLevel::ERROR, ERROR},
-        {AnoLogLevel::CRITICAL, CRITICAL},
-        {AnoLogLevel::OFF, OFF},
+        {LogLevel::TRACE, TRACE},
+        {LogLevel::DEBUG, DEBUG},
+        {LogLevel::INFO, INFO},
+        {LogLevel::WARN, WARN},
+        {LogLevel::ERROR, ERROR},
+        {LogLevel::CRITICAL, CRITICAL},
+        {LogLevel::OFF, OFF},
 };
 
 /**
@@ -84,45 +84,44 @@ class RmaxMgr::RmaxMgrImpl {
   RmaxMgrImpl() = default;
   ~RmaxMgrImpl();
 
-  bool set_config_and_initialize(const AdvNetConfigYaml& cfg);
+  bool set_config_and_initialize(const NetworkConfig& cfg);
   void initialize();
   void run();
 
-  void* get_seg_pkt_ptr(AdvNetBurstParams* burst, int seg, int idx);
-  void* get_pkt_ptr(AdvNetBurstParams* burst, int idx);
-  uint16_t get_seg_pkt_len(AdvNetBurstParams* burst, int seg, int idx);
-  uint16_t get_pkt_len(AdvNetBurstParams* burst, int idx);
-  void* get_pkt_extra_info(AdvNetBurstParams* burst, int idx);
-  AdvNetStatus get_tx_pkt_burst(AdvNetBurstParams* burst);
-  AdvNetStatus set_eth_hdr(AdvNetBurstParams* burst, int idx, char* dst_addr);
-  AdvNetStatus set_ipv4_hdr(AdvNetBurstParams* burst, int idx, int ip_len, uint8_t proto,
-                            unsigned int src_host, unsigned int dst_host);
-  AdvNetStatus set_udp_hdr(AdvNetBurstParams* burst, int idx, int udp_len, uint16_t src_port,
-                           uint16_t dst_port);
-  AdvNetStatus set_udp_payload(AdvNetBurstParams* burst, int idx, void* data, int len);
-  bool tx_burst_available(AdvNetBurstParams* burst);
+  void* get_segment_packet_ptr(BurstParams* burst, int seg, int idx);
+  void* get_packet_ptr(BurstParams* burst, int idx);
+  uint16_t get_segment_packet_length(BurstParams* burst, int seg, int idx);
+  uint16_t get_packet_length(BurstParams* burst, int idx);
+  void* get_packet_extra_info(BurstParams* burst, int idx);
+  Status get_tx_packet_burst(BurstParams* burst);
+  Status set_eth_header(BurstParams* burst, int idx, char* dst_addr);
+  Status set_ipv4_header(BurstParams* burst, int idx, int ip_len, uint8_t proto,
+                         unsigned int src_host, unsigned int dst_host);
+  Status set_udp_header(BurstParams* burst, int idx, int udp_len, uint16_t src_port,
+                        uint16_t dst_port);
+  Status set_udp_payload(BurstParams* burst, int idx, void* data, int len);
+  bool is_tx_burst_available(BurstParams* burst);
 
-  AdvNetStatus set_pkt_lens(AdvNetBurstParams* burst, int idx,
-                            const std::initializer_list<int>& lens);
-  void free_all_seg_pkts(AdvNetBurstParams* burst, int seg);
-  void free_all_pkts(AdvNetBurstParams* burst);
-  void free_pkt_seg(AdvNetBurstParams* burst, int seg, int pkt);
-  void free_pkt(AdvNetBurstParams* burst, int pkt);
-  void free_rx_burst(AdvNetBurstParams* burst);
-  void free_tx_burst(AdvNetBurstParams* burst);
+  Status set_packet_lengths(BurstParams* burst, int idx, const std::initializer_list<int>& lens);
+  void free_all_segment_packets(BurstParams* burst, int seg);
+  void free_all_packets(BurstParams* burst);
+  void free_packet_segment(BurstParams* burst, int seg, int pkt);
+  void free_packet(BurstParams* burst, int pkt);
+  void free_rx_burst(BurstParams* burst);
+  void free_tx_burst(BurstParams* burst);
   void format_eth_addr(char* dst, std::string addr);
   std::optional<uint16_t> get_port_from_ifname(const std::string& name);
-  AdvNetStatus get_rx_burst(AdvNetBurstParams** burst);
-  AdvNetStatus set_pkt_tx_time(AdvNetBurstParams* burst, int idx, uint64_t timestamp);
-  void free_rx_meta(AdvNetBurstParams* burst);
-  void free_tx_meta(AdvNetBurstParams* burst);
-  AdvNetStatus get_tx_meta_buf(AdvNetBurstParams** burst);
-  AdvNetStatus send_tx_burst(AdvNetBurstParams* burst);
+  Status get_rx_burst(BurstParams** burst);
+  Status set_packet_tx_time(BurstParams* burst, int idx, uint64_t timestamp);
+  void free_rx_metadata(BurstParams* burst);
+  void free_tx_metadata(BurstParams* burst);
+  Status get_tx_metadata_buffer(BurstParams** burst);
+  Status send_tx_burst(BurstParams* burst);
   void shutdown();
   void print_stats();
-  uint64_t get_burst_tot_byte(AdvNetBurstParams* burst);
-  AdvNetBurstParams* create_tx_burst_params();
-  AdvNetStatus get_mac(int port, char* mac);
+  uint64_t get_burst_tot_byte(BurstParams* burst);
+  BurstParams* create_tx_burst_params();
+  Status get_mac_addr(int port, char* mac);
   int address_to_port(const std::string& addr);
 
  private:
@@ -134,7 +133,7 @@ class RmaxMgr::RmaxMgrImpl {
  private:
   static constexpr int DEFAULT_NUM_RX_BURST = 64;
 
-  AdvNetConfigYaml cfg_;
+  NetworkConfig cfg_;
   std::unordered_map<uint32_t,
                      std::unique_ptr<ral::services::rmax_ipo_receiver::RmaxIPOReceiverService>>
       rx_services;
@@ -159,7 +158,7 @@ std::atomic<bool> force_quit = false;
  * @param cfg The configuration YAML.
  * @return True if the initialization was successful, false otherwise.
  */
-bool RmaxMgr::RmaxMgrImpl::set_config_and_initialize(const AdvNetConfigYaml& cfg) {
+bool RmaxMgr::RmaxMgrImpl::set_config_and_initialize(const NetworkConfig& cfg) {
   if (!this->initialized_) {
     cfg_ = cfg;
 
@@ -196,12 +195,13 @@ void RmaxMgr::RmaxMgrImpl::initialize() {
     HOLOSCAN_LOG_ERROR("Failed to parse configuration for Rivermax ANO Manager");
     return;
   }
-  HOLOSCAN_LOG_INFO(
-      "Setting Rivermax Log Level to: {}",
-      holoscan::advanced_network::RmaxLogLevel::to_description_string(config_manager.get_rmax_log_level()));
-  rivermax_setparam("RIVERMAX_LOG_LEVEL",
-                    holoscan::advanced_network::RmaxLogLevel::to_cmd_string(config_manager.get_rmax_log_level()),
-                    true);
+  HOLOSCAN_LOG_INFO("Setting Rivermax Log Level to: {}",
+                    holoscan::advanced_network::RmaxLogLevel::to_description_string(
+                        config_manager.get_rmax_log_level()));
+  rivermax_setparam(
+      "RIVERMAX_LOG_LEVEL",
+      holoscan::advanced_network::RmaxLogLevel::to_cmd_string(config_manager.get_rmax_log_level()),
+      true);
 
   auto rx_config_manager = std::dynamic_pointer_cast<RxConfigManager>(
       config_manager.get_config_manager(RmaxConfigContainer::ConfigType::RX));
@@ -386,7 +386,7 @@ void RmaxMgr::RmaxMgrImpl::flush_packets(int port) {
  * @param idx The packet index within the segment.
  * @return Pointer to the packet.
  */
-void* RmaxMgr::RmaxMgrImpl::get_seg_pkt_ptr(AdvNetBurstParams* burst, int seg, int idx) {
+void* RmaxMgr::RmaxMgrImpl::get_segment_packet_ptr(BurstParams* burst, int seg, int idx) {
   return burst->pkts[seg][idx];
 }
 
@@ -397,7 +397,7 @@ void* RmaxMgr::RmaxMgrImpl::get_seg_pkt_ptr(AdvNetBurstParams* burst, int seg, i
  * @param idx The packet index.
  * @return Pointer to the packet.
  */
-void* RmaxMgr::RmaxMgrImpl::get_pkt_ptr(AdvNetBurstParams* burst, int idx) {
+void* RmaxMgr::RmaxMgrImpl::get_packet_ptr(BurstParams* burst, int idx) {
   return burst->pkts[0][idx];
 }
 
@@ -409,7 +409,7 @@ void* RmaxMgr::RmaxMgrImpl::get_pkt_ptr(AdvNetBurstParams* burst, int idx) {
  * @param idx The packet index within the segment.
  * @return Length of the packet.
  */
-uint16_t RmaxMgr::RmaxMgrImpl::get_seg_pkt_len(AdvNetBurstParams* burst, int seg, int idx) {
+uint16_t RmaxMgr::RmaxMgrImpl::get_segment_packet_length(BurstParams* burst, int seg, int idx) {
   return burst->pkt_lens[seg][idx];
 }
 
@@ -420,7 +420,7 @@ uint16_t RmaxMgr::RmaxMgrImpl::get_seg_pkt_len(AdvNetBurstParams* burst, int seg
  * @param idx The packet index.
  * @return Length of the packet.
  */
-uint16_t RmaxMgr::RmaxMgrImpl::get_pkt_len(AdvNetBurstParams* burst, int idx) {
+uint16_t RmaxMgr::RmaxMgrImpl::get_packet_length(BurstParams* burst, int idx) {
   return burst->pkt_lens[0][idx];
 }
 
@@ -431,7 +431,7 @@ uint16_t RmaxMgr::RmaxMgrImpl::get_pkt_len(AdvNetBurstParams* burst, int idx) {
  * @param idx The packet index.
  * @return Pointer to the extra information.
  */
-void* RmaxMgr::RmaxMgrImpl::get_pkt_extra_info(AdvNetBurstParams* burst, int idx) {
+void* RmaxMgr::RmaxMgrImpl::get_packet_extra_info(BurstParams* burst, int idx) {
   RmaxBurst* rmax_burst = static_cast<RmaxBurst*>(burst);
   if (rmax_burst->is_packet_info_per_packet()) return burst->pkt_extra_info[idx];
   return nullptr;
@@ -443,21 +443,20 @@ void* RmaxMgr::RmaxMgrImpl::get_pkt_extra_info(AdvNetBurstParams* burst, int idx
  * @param burst The burst parameters.
  * @param idx The packet index.
  * @param timestamp The transmission timestamp.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::RmaxMgrImpl::set_pkt_tx_time(AdvNetBurstParams* burst, int idx,
-                                                   uint64_t timestamp) {
-  return AdvNetStatus::SUCCESS;
+Status RmaxMgr::RmaxMgrImpl::set_packet_tx_time(BurstParams* burst, int idx, uint64_t timestamp) {
+  return Status::SUCCESS;
 }
 
 /**
  * @brief Gets a burst of TX packets.
  *
  * @param burst The burst parameters.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::RmaxMgrImpl::get_tx_pkt_burst(AdvNetBurstParams* burst) {
-  return AdvNetStatus::NO_FREE_BURST_BUFFERS;
+Status RmaxMgr::RmaxMgrImpl::get_tx_packet_burst(BurstParams* burst) {
+  return Status::NO_FREE_BURST_BUFFERS;
 }
 
 /**
@@ -466,10 +465,10 @@ AdvNetStatus RmaxMgr::RmaxMgrImpl::get_tx_pkt_burst(AdvNetBurstParams* burst) {
  * @param burst The burst parameters.
  * @param idx The packet index.
  * @param dst_addr The destination address.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::RmaxMgrImpl::set_eth_hdr(AdvNetBurstParams* burst, int idx, char* dst_addr) {
-  return AdvNetStatus::SUCCESS;
+Status RmaxMgr::RmaxMgrImpl::set_eth_header(BurstParams* burst, int idx, char* dst_addr) {
+  return Status::SUCCESS;
 }
 
 /**
@@ -481,12 +480,11 @@ AdvNetStatus RmaxMgr::RmaxMgrImpl::set_eth_hdr(AdvNetBurstParams* burst, int idx
  * @param proto The protocol.
  * @param src_host The source host address.
  * @param dst_host The destination host address.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::RmaxMgrImpl::set_ipv4_hdr(AdvNetBurstParams* burst, int idx, int ip_len,
-                                                uint8_t proto, unsigned int src_host,
-                                                unsigned int dst_host) {
-  return AdvNetStatus::SUCCESS;
+Status RmaxMgr::RmaxMgrImpl::set_ipv4_header(BurstParams* burst, int idx, int ip_len, uint8_t proto,
+                                             unsigned int src_host, unsigned int dst_host) {
+  return Status::SUCCESS;
 }
 
 /**
@@ -497,11 +495,11 @@ AdvNetStatus RmaxMgr::RmaxMgrImpl::set_ipv4_hdr(AdvNetBurstParams* burst, int id
  * @param udp_len The length of the UDP packet.
  * @param src_port The source port.
  * @param dst_port The destination port.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::RmaxMgrImpl::set_udp_hdr(AdvNetBurstParams* burst, int idx, int udp_len,
-                                               uint16_t src_port, uint16_t dst_port) {
-  return AdvNetStatus::SUCCESS;
+Status RmaxMgr::RmaxMgrImpl::set_udp_header(BurstParams* burst, int idx, int udp_len,
+                                            uint16_t src_port, uint16_t dst_port) {
+  return Status::SUCCESS;
 }
 
 /**
@@ -511,11 +509,10 @@ AdvNetStatus RmaxMgr::RmaxMgrImpl::set_udp_hdr(AdvNetBurstParams* burst, int idx
  * @param idx The packet index.
  * @param data The payload data.
  * @param len The length of the payload data.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::RmaxMgrImpl::set_udp_payload(AdvNetBurstParams* burst, int idx, void* data,
-                                                   int len) {
-  return AdvNetStatus::SUCCESS;
+Status RmaxMgr::RmaxMgrImpl::set_udp_payload(BurstParams* burst, int idx, void* data, int len) {
+  return Status::SUCCESS;
 }
 
 /**
@@ -524,7 +521,7 @@ AdvNetStatus RmaxMgr::RmaxMgrImpl::set_udp_payload(AdvNetBurstParams* burst, int
  * @param burst The burst parameters.
  * @return True if a TX burst is available, false otherwise.
  */
-bool RmaxMgr::RmaxMgrImpl::tx_burst_available(AdvNetBurstParams* burst) {
+bool RmaxMgr::RmaxMgrImpl::is_tx_burst_available(BurstParams* burst) {
   return false;
 }
 
@@ -534,11 +531,11 @@ bool RmaxMgr::RmaxMgrImpl::tx_burst_available(AdvNetBurstParams* burst) {
  * @param burst The burst parameters.
  * @param idx The packet index.
  * @param lens The list of lengths.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::RmaxMgrImpl::set_pkt_lens(AdvNetBurstParams* burst, int idx,
+Status RmaxMgr::RmaxMgrImpl::set_packet_lengths(BurstParams* burst, int idx,
                                                 const std::initializer_list<int>& lens) {
-  return AdvNetStatus::SUCCESS;
+  return Status::SUCCESS;
 }
 
 /**
@@ -547,14 +544,14 @@ AdvNetStatus RmaxMgr::RmaxMgrImpl::set_pkt_lens(AdvNetBurstParams* burst, int id
  * @param burst The burst parameters.
  * @param seg The segment index.
  */
-void RmaxMgr::RmaxMgrImpl::free_all_seg_pkts(AdvNetBurstParams* burst, int seg) {}
+void RmaxMgr::RmaxMgrImpl::free_all_segment_packets(BurstParams* burst, int seg) {}
 
 /**
  * @brief Frees all packets.
  *
  * @param burst The burst parameters.
  */
-void RmaxMgr::RmaxMgrImpl::free_all_pkts(AdvNetBurstParams* burst) {}
+void RmaxMgr::RmaxMgrImpl::free_all_packets(BurstParams* burst) {}
 
 /**
  * @brief Frees a specific packet in a segment.
@@ -563,7 +560,7 @@ void RmaxMgr::RmaxMgrImpl::free_all_pkts(AdvNetBurstParams* burst) {}
  * @param seg The segment index.
  * @param pkt The packet index within the segment.
  */
-void RmaxMgr::RmaxMgrImpl::free_pkt_seg(AdvNetBurstParams* burst, int seg, int pkt) {}
+void RmaxMgr::RmaxMgrImpl::free_packet_segment(BurstParams* burst, int seg, int pkt) {}
 
 /**
  * @brief Frees a specific packet.
@@ -571,14 +568,14 @@ void RmaxMgr::RmaxMgrImpl::free_pkt_seg(AdvNetBurstParams* burst, int seg, int p
  * @param burst The burst parameters.
  * @param pkt The packet index.
  */
-void RmaxMgr::RmaxMgrImpl::free_pkt(AdvNetBurstParams* burst, int pkt) {}
+void RmaxMgr::RmaxMgrImpl::free_packet(BurstParams* burst, int pkt) {}
 
 /**
  * @brief Frees the RX burst.
  *
  * @param burst The burst parameters.
  */
-void RmaxMgr::RmaxMgrImpl::free_rx_burst(AdvNetBurstParams* burst) {
+void RmaxMgr::RmaxMgrImpl::free_rx_burst(BurstParams* burst) {
   uint32_t key =
       RmaxBurst::burst_tag_from_port_and_queue_id(burst->hdr.hdr.port_id, burst->hdr.hdr.q_id);
 
@@ -604,7 +601,7 @@ void RmaxMgr::RmaxMgrImpl::free_rx_burst(AdvNetBurstParams* burst) {
  *
  * @param burst The burst parameters.
  */
-void RmaxMgr::RmaxMgrImpl::free_tx_burst(AdvNetBurstParams* burst) {}
+void RmaxMgr::RmaxMgrImpl::free_tx_burst(BurstParams* burst) {}
 
 /**
  * @brief Gets the port number from an interface name.
@@ -627,13 +624,13 @@ std::optional<uint16_t> RmaxMgr::RmaxMgrImpl::get_port_from_ifname(const std::st
  * @brief Dequeues an RX burst.
  *
  * @param burst Pointer to the burst parameters.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::RmaxMgrImpl::get_rx_burst(AdvNetBurstParams** burst) {
+Status RmaxMgr::RmaxMgrImpl::get_rx_burst(BurstParams** burst) {
   auto out_burst = rx_bursts_out_queue->dequeue_burst().get();
-  *burst = static_cast<AdvNetBurstParams*>(out_burst);
-  if (*burst == nullptr) { return AdvNetStatus::NOT_READY; }
-  return AdvNetStatus::SUCCESS;
+  *burst = static_cast<BurstParams*>(out_burst);
+  if (*burst == nullptr) { return Status::NOT_READY; }
+  return Status::SUCCESS;
 }
 
 /**
@@ -641,33 +638,33 @@ AdvNetStatus RmaxMgr::RmaxMgrImpl::get_rx_burst(AdvNetBurstParams** burst) {
  *
  * @param burst The burst parameters.
  */
-void RmaxMgr::RmaxMgrImpl::free_rx_meta(AdvNetBurstParams* burst) {}
+void RmaxMgr::RmaxMgrImpl::free_rx_metadata(BurstParams* burst) {}
 
 /**
  * @brief Frees the TX metadata.
  *
  * @param burst The burst parameters.
  */
-void RmaxMgr::RmaxMgrImpl::free_tx_meta(AdvNetBurstParams* burst) {}
+void RmaxMgr::RmaxMgrImpl::free_tx_metadata(BurstParams* burst) {}
 
 /**
  * @brief Gets the TX metadata buffer.
  *
  * @param burst Pointer to the burst parameters.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::RmaxMgrImpl::get_tx_meta_buf(AdvNetBurstParams** burst) {
-  return AdvNetStatus::SUCCESS;
+Status RmaxMgr::RmaxMgrImpl::get_tx_metadata_buffer(BurstParams** burst) {
+  return Status::SUCCESS;
 }
 
 /**
  * @brief Sends a TX burst.
  *
  * @param burst The burst parameters.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::RmaxMgrImpl::send_tx_burst(AdvNetBurstParams* burst) {
-  return AdvNetStatus::SUCCESS;
+Status RmaxMgr::RmaxMgrImpl::send_tx_burst(BurstParams* burst) {
+  return Status::SUCCESS;
 }
 
 /**
@@ -696,7 +693,7 @@ void RmaxMgr::RmaxMgrImpl::print_stats() {
  * @param burst The burst parameters.
  * @return Total byte count of the burst.
  */
-uint64_t RmaxMgr::RmaxMgrImpl::get_burst_tot_byte(AdvNetBurstParams* burst) {
+uint64_t RmaxMgr::RmaxMgrImpl::get_burst_tot_byte(BurstParams* burst) {
   return 0;
 }
 
@@ -705,8 +702,8 @@ uint64_t RmaxMgr::RmaxMgrImpl::get_burst_tot_byte(AdvNetBurstParams* burst) {
  *
  * @return Pointer to the created burst parameters.
  */
-AdvNetBurstParams* RmaxMgr::RmaxMgrImpl::create_tx_burst_params() {
-  return new AdvNetBurstParams();
+BurstParams* RmaxMgr::RmaxMgrImpl::create_tx_burst_params() {
+  return new BurstParams();
 }
 
 /**
@@ -714,10 +711,10 @@ AdvNetBurstParams* RmaxMgr::RmaxMgrImpl::create_tx_burst_params() {
  *
  * @param port The port number.
  * @param mac Pointer to the MAC address buffer.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::RmaxMgrImpl::get_mac(int port, char* mac) {
-  return AdvNetStatus::NOT_SUPPORTED;
+Status RmaxMgr::RmaxMgrImpl::get_mac_addr(int port, char* mac) {
+  return Status::NOT_SUPPORTED;
 }
 
 /**
@@ -751,7 +748,7 @@ RmaxMgr::~RmaxMgr() = default;
  * @param cfg The configuration YAML.
  * @return True if the initialization was successful, false otherwise.
  */
-bool RmaxMgr::set_config_and_initialize(const AdvNetConfigYaml& cfg) {
+bool RmaxMgr::set_config_and_initialize(const NetworkConfig& cfg) {
   bool res = true;
   if (!this->initialized_) {
     res = pImpl->set_config_and_initialize(cfg);
@@ -782,9 +779,9 @@ void RmaxMgr::run() {
  *
  * @param q_item The YAML node containing the RX queue configuration.
  * @param q The RxQueueConfig structure to be populated.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::parse_rx_queue_rivermax_config(const YAML::Node& q_item, RxQueueConfig& q) {
+Status RmaxMgr::parse_rx_queue_rivermax_config(const YAML::Node& q_item, RxQueueConfig& q) {
   return RmaxConfigParser::parse_rx_queue_rivermax_config(q_item, q);
 }
 
@@ -793,9 +790,9 @@ AdvNetStatus RmaxMgr::parse_rx_queue_rivermax_config(const YAML::Node& q_item, R
  *
  * @param q_item The YAML node containing the queue item.
  * @param q The TX queue configuration to be populated.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::parse_tx_queue_rivermax_config(const YAML::Node& q_item, TxQueueConfig& q) {
+Status RmaxMgr::parse_tx_queue_rivermax_config(const YAML::Node& q_item, TxQueueConfig& q) {
   return RmaxConfigParser::parse_tx_queue_rivermax_config(q_item, q);
 }
 
@@ -807,8 +804,8 @@ AdvNetStatus RmaxMgr::parse_tx_queue_rivermax_config(const YAML::Node& q_item, T
  * @param idx The packet index within the segment.
  * @return Pointer to the packet.
  */
-void* RmaxMgr::get_seg_pkt_ptr(AdvNetBurstParams* burst, int seg, int idx) {
-  return pImpl->get_seg_pkt_ptr(burst, seg, idx);
+void* RmaxMgr::get_segment_packet_ptr(BurstParams* burst, int seg, int idx) {
+  return pImpl->get_segment_packet_ptr(burst, seg, idx);
 }
 
 /**
@@ -818,8 +815,8 @@ void* RmaxMgr::get_seg_pkt_ptr(AdvNetBurstParams* burst, int seg, int idx) {
  * @param idx The packet index.
  * @return Pointer to the packet.
  */
-void* RmaxMgr::get_pkt_ptr(AdvNetBurstParams* burst, int idx) {
-  return pImpl->get_pkt_ptr(burst, idx);
+void* RmaxMgr::get_packet_ptr(BurstParams* burst, int idx) {
+  return pImpl->get_packet_ptr(burst, idx);
 }
 
 /**
@@ -830,8 +827,8 @@ void* RmaxMgr::get_pkt_ptr(AdvNetBurstParams* burst, int idx) {
  * @param idx The packet index within the segment.
  * @return Length of the packet.
  */
-uint16_t RmaxMgr::get_seg_pkt_len(AdvNetBurstParams* burst, int seg, int idx) {
-  return pImpl->get_seg_pkt_len(burst, seg, idx);
+uint16_t RmaxMgr::get_segment_packet_length(BurstParams* burst, int seg, int idx) {
+  return pImpl->get_segment_packet_length(burst, seg, idx);
 }
 
 /**
@@ -841,8 +838,8 @@ uint16_t RmaxMgr::get_seg_pkt_len(AdvNetBurstParams* burst, int seg, int idx) {
  * @param idx The packet index.
  * @return Length of the packet.
  */
-uint16_t RmaxMgr::get_pkt_len(AdvNetBurstParams* burst, int idx) {
-  return pImpl->get_pkt_len(burst, idx);
+uint16_t RmaxMgr::get_packet_length(BurstParams* burst, int idx) {
+  return pImpl->get_packet_length(burst, idx);
 }
 
 /**
@@ -852,7 +849,7 @@ uint16_t RmaxMgr::get_pkt_len(AdvNetBurstParams* burst, int idx) {
  * @param idx The packet index.
  * @return Flow ID of the packet
  */
-uint16_t RmaxMgr::get_pkt_flow_id(AdvNetBurstParams* burst, int idx) {
+uint16_t RmaxMgr::get_packet_flow_id(BurstParams* burst, int idx) {
   return 0;
 }
 
@@ -863,18 +860,18 @@ uint16_t RmaxMgr::get_pkt_flow_id(AdvNetBurstParams* burst, int idx) {
  * @param idx The packet index.
  * @return Pointer to the extra information.
  */
-void* RmaxMgr::get_pkt_extra_info(AdvNetBurstParams* burst, int idx) {
-  return pImpl->get_pkt_extra_info(burst, idx);
+void* RmaxMgr::get_packet_extra_info(BurstParams* burst, int idx) {
+  return pImpl->get_packet_extra_info(burst, idx);
 }
 
 /**
  * @brief Gets a burst of TX packets.
  *
  * @param burst The burst parameters.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::get_tx_pkt_burst(AdvNetBurstParams* burst) {
-  return pImpl->get_tx_pkt_burst(burst);
+Status RmaxMgr::get_tx_packet_burst(BurstParams* burst) {
+  return pImpl->get_tx_packet_burst(burst);
 }
 
 /**
@@ -883,10 +880,10 @@ AdvNetStatus RmaxMgr::get_tx_pkt_burst(AdvNetBurstParams* burst) {
  * @param burst The burst parameters.
  * @param idx The packet index.
  * @param dst_addr The destination address.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::set_eth_hdr(AdvNetBurstParams* burst, int idx, char* dst_addr) {
-  return pImpl->set_eth_hdr(burst, idx, dst_addr);
+Status RmaxMgr::set_eth_header(BurstParams* burst, int idx, char* dst_addr) {
+  return pImpl->set_eth_header(burst, idx, dst_addr);
 }
 
 /**
@@ -898,11 +895,11 @@ AdvNetStatus RmaxMgr::set_eth_hdr(AdvNetBurstParams* burst, int idx, char* dst_a
  * @param proto The protocol.
  * @param src_host The source host address.
  * @param dst_host The destination host address.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::set_ipv4_hdr(AdvNetBurstParams* burst, int idx, int ip_len, uint8_t proto,
-                                   unsigned int src_host, unsigned int dst_host) {
-  return pImpl->set_ipv4_hdr(burst, idx, ip_len, proto, src_host, dst_host);
+Status RmaxMgr::set_ipv4_header(BurstParams* burst, int idx, int ip_len, uint8_t proto,
+                                unsigned int src_host, unsigned int dst_host) {
+  return pImpl->set_ipv4_header(burst, idx, ip_len, proto, src_host, dst_host);
 }
 
 /**
@@ -913,11 +910,11 @@ AdvNetStatus RmaxMgr::set_ipv4_hdr(AdvNetBurstParams* burst, int idx, int ip_len
  * @param udp_len The length of the UDP packet.
  * @param src_port The source port.
  * @param dst_port The destination port.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::set_udp_hdr(AdvNetBurstParams* burst, int idx, int udp_len, uint16_t src_port,
-                                  uint16_t dst_port) {
-  return pImpl->set_udp_hdr(burst, idx, udp_len, src_port, dst_port);
+Status RmaxMgr::set_udp_header(BurstParams* burst, int idx, int udp_len, uint16_t src_port,
+                               uint16_t dst_port) {
+  return pImpl->set_udp_header(burst, idx, udp_len, src_port, dst_port);
 }
 
 /**
@@ -927,9 +924,9 @@ AdvNetStatus RmaxMgr::set_udp_hdr(AdvNetBurstParams* burst, int idx, int udp_len
  * @param idx The packet index.
  * @param data The payload data.
  * @param len The length of the payload data.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::set_udp_payload(AdvNetBurstParams* burst, int idx, void* data, int len) {
+Status RmaxMgr::set_udp_payload(BurstParams* burst, int idx, void* data, int len) {
   return pImpl->set_udp_payload(burst, idx, data, len);
 }
 
@@ -939,8 +936,8 @@ AdvNetStatus RmaxMgr::set_udp_payload(AdvNetBurstParams* burst, int idx, void* d
  * @param burst The burst parameters.
  * @return True if a TX burst is available, false otherwise.
  */
-bool RmaxMgr::tx_burst_available(AdvNetBurstParams* burst) {
-  return pImpl->tx_burst_available(burst);
+bool RmaxMgr::is_tx_burst_available(BurstParams* burst) {
+  return pImpl->is_tx_burst_available(burst);
 }
 
 /**
@@ -949,11 +946,11 @@ bool RmaxMgr::tx_burst_available(AdvNetBurstParams* burst) {
  * @param burst The burst parameters.
  * @param idx The packet index.
  * @param lens The list of lengths.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::set_pkt_lens(AdvNetBurstParams* burst, int idx,
+Status RmaxMgr::set_packet_lengths(BurstParams* burst, int idx,
                                    const std::initializer_list<int>& lens) {
-  return pImpl->set_pkt_lens(burst, idx, lens);
+  return pImpl->set_packet_lengths(burst, idx, lens);
 }
 
 /**
@@ -962,8 +959,8 @@ AdvNetStatus RmaxMgr::set_pkt_lens(AdvNetBurstParams* burst, int idx,
  * @param burst The burst parameters.
  * @param seg The segment index.
  */
-void RmaxMgr::free_all_seg_pkts(AdvNetBurstParams* burst, int seg) {
-  pImpl->free_all_seg_pkts(burst, seg);
+void RmaxMgr::free_all_segment_packets(BurstParams* burst, int seg) {
+  pImpl->free_all_segment_packets(burst, seg);
 }
 
 /**
@@ -971,8 +968,8 @@ void RmaxMgr::free_all_seg_pkts(AdvNetBurstParams* burst, int seg) {
  *
  * @param burst The burst parameters.
  */
-void RmaxMgr::free_all_pkts(AdvNetBurstParams* burst) {
-  pImpl->free_all_pkts(burst);
+void RmaxMgr::free_all_packets(BurstParams* burst) {
+  pImpl->free_all_packets(burst);
 }
 
 /**
@@ -982,8 +979,8 @@ void RmaxMgr::free_all_pkts(AdvNetBurstParams* burst) {
  * @param seg The segment index.
  * @param pkt The packet index within the segment.
  */
-void RmaxMgr::free_pkt_seg(AdvNetBurstParams* burst, int seg, int pkt) {
-  pImpl->free_pkt_seg(burst, seg, pkt);
+void RmaxMgr::free_packet_segment(BurstParams* burst, int seg, int pkt) {
+  pImpl->free_packet_segment(burst, seg, pkt);
 }
 
 /**
@@ -992,8 +989,8 @@ void RmaxMgr::free_pkt_seg(AdvNetBurstParams* burst, int seg, int pkt) {
  * @param burst The burst parameters.
  * @param pkt The packet index.
  */
-void RmaxMgr::free_pkt(AdvNetBurstParams* burst, int pkt) {
-  pImpl->free_pkt(burst, pkt);
+void RmaxMgr::free_packet(BurstParams* burst, int pkt) {
+  pImpl->free_packet(burst, pkt);
 }
 
 /**
@@ -1001,7 +998,7 @@ void RmaxMgr::free_pkt(AdvNetBurstParams* burst, int pkt) {
  *
  * @param burst The burst parameters.
  */
-void RmaxMgr::free_rx_burst(AdvNetBurstParams* burst) {
+void RmaxMgr::free_rx_burst(BurstParams* burst) {
   pImpl->free_rx_burst(burst);
 }
 
@@ -1010,7 +1007,7 @@ void RmaxMgr::free_rx_burst(AdvNetBurstParams* burst) {
  *
  * @param burst The burst parameters.
  */
-void RmaxMgr::free_tx_burst(AdvNetBurstParams* burst) {
+void RmaxMgr::free_tx_burst(BurstParams* burst) {
   pImpl->free_tx_burst(burst);
 }
 
@@ -1028,9 +1025,9 @@ std::optional<uint16_t> RmaxMgr::get_port_from_ifname(const std::string& name) {
  * @brief Gets an RX burst.
  *
  * @param burst Pointer to the burst parameters.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::get_rx_burst(AdvNetBurstParams** burst) {
+Status RmaxMgr::get_rx_burst(BurstParams** burst) {
   return pImpl->get_rx_burst(burst);
 }
 
@@ -1040,10 +1037,10 @@ AdvNetStatus RmaxMgr::get_rx_burst(AdvNetBurstParams** burst) {
  * @param burst The burst parameters.
  * @param idx The packet index.
  * @param timestamp The transmission timestamp.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::set_pkt_tx_time(AdvNetBurstParams* burst, int idx, uint64_t timestamp) {
-  return pImpl->set_pkt_tx_time(burst, idx, timestamp);
+Status RmaxMgr::set_packet_tx_time(BurstParams* burst, int idx, uint64_t timestamp) {
+  return pImpl->set_packet_tx_time(burst, idx, timestamp);
 }
 
 /**
@@ -1051,8 +1048,8 @@ AdvNetStatus RmaxMgr::set_pkt_tx_time(AdvNetBurstParams* burst, int idx, uint64_
  *
  * @param burst The burst parameters.
  */
-void RmaxMgr::free_rx_meta(AdvNetBurstParams* burst) {
-  pImpl->free_rx_meta(burst);
+void RmaxMgr::free_rx_metadata(BurstParams* burst) {
+  pImpl->free_rx_metadata(burst);
 }
 
 /**
@@ -1060,27 +1057,27 @@ void RmaxMgr::free_rx_meta(AdvNetBurstParams* burst) {
  *
  * @param burst The burst parameters.
  */
-void RmaxMgr::free_tx_meta(AdvNetBurstParams* burst) {
-  pImpl->free_tx_meta(burst);
+void RmaxMgr::free_tx_metadata(BurstParams* burst) {
+  pImpl->free_tx_metadata(burst);
 }
 
 /**
  * @brief Gets the TX metadata buffer.
  *
  * @param burst Pointer to the burst parameters.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::get_tx_meta_buf(AdvNetBurstParams** burst) {
-  return pImpl->get_tx_meta_buf(burst);
+Status RmaxMgr::get_tx_metadata_buffer(BurstParams** burst) {
+  return pImpl->get_tx_metadata_buffer(burst);
 }
 
 /**
  * @brief Sends a TX burst.
  *
  * @param burst The burst parameters.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::send_tx_burst(AdvNetBurstParams* burst) {
+Status RmaxMgr::send_tx_burst(BurstParams* burst) {
   return pImpl->send_tx_burst(burst);
 }
 
@@ -1104,7 +1101,7 @@ void RmaxMgr::print_stats() {
  * @param burst The burst parameters.
  * @return Total byte count of the burst.
  */
-uint64_t RmaxMgr::get_burst_tot_byte(AdvNetBurstParams* burst) {
+uint64_t RmaxMgr::get_burst_tot_byte(BurstParams* burst) {
   return pImpl->get_burst_tot_byte(burst);
 }
 
@@ -1113,7 +1110,7 @@ uint64_t RmaxMgr::get_burst_tot_byte(AdvNetBurstParams* burst) {
  *
  * @return Pointer to the created burst parameters.
  */
-AdvNetBurstParams* RmaxMgr::create_tx_burst_params() {
+BurstParams* RmaxMgr::create_tx_burst_params() {
   return pImpl->create_tx_burst_params();
 }
 
@@ -1122,10 +1119,10 @@ AdvNetBurstParams* RmaxMgr::create_tx_burst_params() {
  *
  * @param port The port number.
  * @param mac Pointer to the MAC address buffer.
- * @return AdvNetStatus indicating the success or failure of the operation.
+ * @return Status indicating the success or failure of the operation.
  */
-AdvNetStatus RmaxMgr::get_mac(int port, char* mac) {
-  return pImpl->get_mac(port, mac);
+Status RmaxMgr::get_mac_addr(int port, char* mac) {
+  return pImpl->get_mac_addr(port, mac);
 }
 
 /**

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/adv_network_rmax_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/adv_network_rmax_mgr.cpp
@@ -41,7 +41,7 @@
 
 using namespace std::chrono;
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 using namespace ral::services::rmax_ipo_receiver;
 
@@ -198,9 +198,9 @@ void RmaxMgr::RmaxMgrImpl::initialize() {
   }
   HOLOSCAN_LOG_INFO(
       "Setting Rivermax Log Level to: {}",
-      holoscan::ops::RmaxLogLevel::to_description_string(config_manager.get_rmax_log_level()));
+      holoscan::advanced_network::RmaxLogLevel::to_description_string(config_manager.get_rmax_log_level()));
   rivermax_setparam("RIVERMAX_LOG_LEVEL",
-                    holoscan::ops::RmaxLogLevel::to_cmd_string(config_manager.get_rmax_log_level()),
+                    holoscan::advanced_network::RmaxLogLevel::to_cmd_string(config_manager.get_rmax_log_level()),
                     true);
 
   auto rx_config_manager = std::dynamic_pointer_cast<RxConfigManager>(
@@ -1138,4 +1138,4 @@ int RmaxMgr::address_to_port(const std::string& addr) {
   return pImpl->address_to_port(addr);
 }
 
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/burst_manager.cpp
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/burst_manager.cpp
@@ -36,7 +36,7 @@
 using namespace ral::lib::core;
 using namespace ral::lib::services;
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 /**
  * @brief A non-blocking queue implementation.
@@ -536,4 +536,4 @@ RxBurstsManager::~RxBurstsManager() {
   }
 }
 
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/burst_manager.h
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/burst_manager.h
@@ -34,7 +34,7 @@ using namespace ral::services;
  * @class RmaxBurst
  * @brief Represents a burst of packets in the advanced network.
  */
-class RmaxBurst : public AdvNetBurstParams {
+class RmaxBurst : public BurstParams {
  public:
   static constexpr int MAX_PKT_IN_BURST = 9100;
 
@@ -379,13 +379,13 @@ class RxBurstsManager {
    * @throws logic_error If shared output queue is used.
    * @return ReturnStatus indicating the success or failure of the operation.
    */
-  inline ReturnStatus get_rx_burst(AdvNetBurstParams** burst) {
+  inline ReturnStatus get_rx_burst(BurstParams** burst) {
     if (m_using_shared_out_queue) {
       throw std::logic_error("Cannot get RX burst when using shared output queue");
     }
 
     auto out_burst = m_rx_bursts_out_queue->dequeue_burst().get();
-    *burst = static_cast<AdvNetBurstParams*>(out_burst);
+    *burst = static_cast<BurstParams*>(out_burst);
     if (*burst == nullptr) { return ReturnStatus::failure; }
     return ReturnStatus::success;
   }

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/burst_manager.h
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/burst_manager.h
@@ -27,7 +27,7 @@
 #include "adv_network_types.h"
 #include <holoscan/logger/logger.hpp>
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 using namespace ral::services;
 
 /**
@@ -465,6 +465,6 @@ class RxBurstsManager {
   std::unique_ptr<RmaxBurst::BurstHandler> m_burst_handler;
 };
 
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network
 
 #endif /* BURST_MANAGER_H_ */

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/packet_processor.h
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/packet_processor.h
@@ -27,7 +27,7 @@
 #include "burst_manager.h"
 #include "adv_network_types.h"
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 using namespace ral::services;
 
 /**
@@ -145,6 +145,6 @@ class RxPacketProcessor : public IPacketProcessor {
   std::shared_ptr<RxBurstsManager> m_rx_burst_manager;
 };
 
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network
 
 #endif /* PACKET_PROCESSOR_H_ */

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/rmax_chunk_consumer_ano.h
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/rmax_chunk_consumer_ano.h
@@ -27,7 +27,7 @@
 #include "packet_processor.h"
 #include "adv_network_types.h"
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 using namespace ral::services;
 
 /**
@@ -121,6 +121,6 @@ inline std::tuple<ReturnStatus, size_t, size_t> RmaxChunkConsumerAno::consume_ch
   return {status, processed_packets, chunk_size - processed_packets};
 }
 
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network
 
 #endif /* RMAX_CHUNK_CONSUMER_ANO_H_ */

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/rmax_config_manager.cpp
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/rmax_config_manager.cpp
@@ -22,7 +22,7 @@
 
 #include "rmax_config_manager.h"
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 static constexpr int USECS_IN_SECOND = 1000000;
 
@@ -795,4 +795,4 @@ void RmaxRxQueueConfig::dump_parameters() const {
   }
 }
 
-}  // namespace holoscan::ops
+}  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/rmax_config_manager.h
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/rmax_config_manager.h
@@ -38,7 +38,7 @@ using namespace ral::services::rmax_ipo_receiver;
  * This structure holds the configuration settings for an Rmax RX queue,
  * including packet size, chunk size, IP addresses, ports, and other parameters.
  */
-struct RmaxRxQueueConfig : public AnoMgrExtraQueueConfig {
+struct RmaxRxQueueConfig : public ManagerExtraQueueConfig {
   uint16_t max_packet_size = 0;
   size_t max_chunk_size;
   size_t packets_buffers_size;
@@ -64,7 +64,7 @@ struct RmaxRxQueueConfig : public AnoMgrExtraQueueConfig {
   ~RmaxRxQueueConfig() = default;
 
   RmaxRxQueueConfig(const RmaxRxQueueConfig& other)
-      : AnoMgrExtraQueueConfig(other),
+      : ManagerExtraQueueConfig(other),
         max_packet_size(other.max_packet_size),
         max_chunk_size(other.max_chunk_size),
         packets_buffers_size(other.packets_buffers_size),
@@ -87,7 +87,7 @@ struct RmaxRxQueueConfig : public AnoMgrExtraQueueConfig {
 
   RmaxRxQueueConfig& operator=(const RmaxRxQueueConfig& other) {
     if (this != &other) {
-      AnoMgrExtraQueueConfig::operator=(other);
+      ManagerExtraQueueConfig::operator=(other);
       max_packet_size = other.max_packet_size;
       max_chunk_size = other.max_chunk_size;
       packets_buffers_size = other.packets_buffers_size;
@@ -143,7 +143,7 @@ class IConfigManager {
    * @param rmax_apps_lib Shared pointer to the RmaxAppsLibFacade.
    * @return True if the configuration was successfully set, false otherwise.
    */
-  virtual bool set_configuration(const AdvNetConfigYaml& cfg,
+  virtual bool set_configuration(const NetworkConfig& cfg,
                                  std::shared_ptr<ral::lib::RmaxAppsLibFacade> rmax_apps_lib) = 0;
 };
 
@@ -235,7 +235,7 @@ class RxConfigManager : public IRxConfigManager {
    * @param rmax_apps_lib Shared pointer to the RmaxAppsLibFacade.
    * @return True if the configuration was successfully set, false otherwise.
    */
-  bool set_configuration(const AdvNetConfigYaml& cfg,
+  bool set_configuration(const NetworkConfig& cfg,
                          std::shared_ptr<ral::lib::RmaxAppsLibFacade> rmax_apps_lib) override {
     cfg_ = cfg;
     rmax_apps_lib_ = rmax_apps_lib;
@@ -300,7 +300,8 @@ class RxConfigManager : public IRxConfigManager {
    * @return true if the configuration is successful, false otherwise.
    */
   bool config_memory_allocator_from_single_mrs(RmaxRxQueueConfig& rmax_rx_config,
-                                               const RxQueueConfig& q, const MemoryRegion& mr);
+                                               const RxQueueConfig& q,
+                                               const MemoryRegionConfig& mr);
 
   /**
    * @brief Configures the memory allocator for dual memory regions.
@@ -317,8 +318,9 @@ class RxConfigManager : public IRxConfigManager {
    */
 
   bool config_memory_allocator_from_dual_mrs(RmaxRxQueueConfig& rmax_rx_config,
-                                             const RxQueueConfig& q, const MemoryRegion& mr_header,
-                                             const MemoryRegion& mr_payload);
+                                             const RxQueueConfig& q,
+                                             const MemoryRegionConfig& mr_header,
+                                             const MemoryRegionConfig& mr_payload);
   /**
    * @brief Sets the GPU memory configuration if applicable.
    *
@@ -326,7 +328,8 @@ class RxConfigManager : public IRxConfigManager {
    * @param mr The memory region.
    * @return true if the GPU memory configuration is set, false otherwise.
    */
-  bool set_gpu_is_in_use_if_applicable(RmaxRxQueueConfig& rmax_rx_config, const MemoryRegion& mr);
+  bool set_gpu_is_in_use_if_applicable(RmaxRxQueueConfig& rmax_rx_config,
+                                       const MemoryRegionConfig& mr);
 
   /**
    * @brief Sets the CPU memory configuration.
@@ -341,7 +344,7 @@ class RxConfigManager : public IRxConfigManager {
    * @param rmax_rx_config The RMAX RX queue configuration.
    * @param mr The memory region.
    */
-  void set_cpu_allocator_type(RmaxRxQueueConfig& rmax_rx_config, const MemoryRegion& mr);
+  void set_cpu_allocator_type(RmaxRxQueueConfig& rmax_rx_config, const MemoryRegionConfig& mr);
 
   /**
    * @brief Validates the RX queue memory regions configuration.
@@ -363,7 +366,7 @@ class RxConfigManager : public IRxConfigManager {
    */
   bool validate_memory_regions_config_from_single_mrs(const RxQueueConfig& q,
                                                       const RmaxRxQueueConfig& rmax_rx_config,
-                                                      const MemoryRegion& mr);
+                                                      const MemoryRegionConfig& mr);
 
   /**
    * @brief Validates the RX queue memory regions configuration for dual memory regions.
@@ -376,8 +379,8 @@ class RxConfigManager : public IRxConfigManager {
    */
   bool validate_memory_regions_config_from_dual_mrs(const RxQueueConfig& q,
                                                     const RmaxRxQueueConfig& rmax_rx_config,
-                                                    const MemoryRegion& mr_header,
-                                                    const MemoryRegion& mr_payload);
+                                                    const MemoryRegionConfig& mr_header,
+                                                    const MemoryRegionConfig& mr_payload);
 
   /**
    * @brief Sets common application settings for an RX service.
@@ -426,7 +429,7 @@ class RxConfigManager : public IRxConfigManager {
 
  private:
   std::unordered_map<uint32_t, ExtRmaxIPOReceiverConfig> rx_service_configs_;
-  AdvNetConfigYaml cfg_;
+  NetworkConfig cfg_;
   std::shared_ptr<ral::lib::RmaxAppsLibFacade> rmax_apps_lib_ = nullptr;
   bool is_configuration_set_ = false;
 };
@@ -451,7 +454,7 @@ class TxConfigManager : public ITxConfigManager {
    * @param rmax_apps_lib Shared pointer to the RmaxAppsLibFacade.
    * @return True if the configuration was successfully set, false otherwise.
    */
-  bool set_configuration(const AdvNetConfigYaml& cfg,
+  bool set_configuration(const NetworkConfig& cfg,
                          std::shared_ptr<ral::lib::RmaxAppsLibFacade> rmax_apps_lib) override {
     cfg_ = cfg;
     rmax_apps_lib_ = rmax_apps_lib;
@@ -471,7 +474,7 @@ class TxConfigManager : public ITxConfigManager {
 
  private:
   std::unordered_map<uint32_t, RmaxBaseServiceConfig> tx_service_configs_;
-  AdvNetConfigYaml cfg_;
+  NetworkConfig cfg_;
   std::shared_ptr<ral::lib::RmaxAppsLibFacade> rmax_apps_lib_ = nullptr;
   bool is_configuration_set_ = false;
 };
@@ -506,7 +509,7 @@ class RmaxConfigContainer {
    * @param cfg The configuration YAML.
    * @return True if the configuration was successfully parsed, false otherwise.
    */
-  bool parse_configuration(const AdvNetConfigYaml& cfg);
+  bool parse_configuration(const NetworkConfig& cfg);
 
   std::shared_ptr<IConfigManager> get_config_manager(ConfigType type) const {
     auto it = config_managers_.find(type);
@@ -569,7 +572,7 @@ class RmaxConfigContainer {
    *
    * @param level The Ano log level to be converted and set.
    */
-  void set_rmax_log_level(AnoLogLevel::Level level) {
+  void set_rmax_log_level(LogLevel::Level level) {
     rmax_log_level_ = RmaxLogLevel::from_ano_log_level(level);
   }
 
@@ -577,7 +580,7 @@ class RmaxConfigContainer {
   RmaxLogLevel::Level rmax_log_level_ = RmaxLogLevel::OFF;
   std::unordered_map<ConfigType, std::shared_ptr<IConfigManager>> config_managers_;
   std::shared_ptr<ral::lib::RmaxAppsLibFacade> rmax_apps_lib_ = nullptr;
-  AdvNetConfigYaml cfg_;
+  NetworkConfig cfg_;
   bool is_configured_ = false;
 };
 
@@ -596,18 +599,18 @@ class RmaxConfigParser {
    *
    * @param q_item The YAML node containing the RX queue configuration.
    * @param q The RxQueueConfig structure to be populated.
-   * @return AdvNetStatus indicating the success or failure of the operation.
+   * @return Status indicating the success or failure of the operation.
    */
-  static AdvNetStatus parse_rx_queue_rivermax_config(const YAML::Node& q_item, RxQueueConfig& q);
+  static Status parse_rx_queue_rivermax_config(const YAML::Node& q_item, RxQueueConfig& q);
 
   /**
    * @brief Parses the TX queue Rivermax configuration.
    *
    * @param q_item The YAML node containing the queue item.
    * @param q The TX queue configuration to be populated.
-   * @return AdvNetStatus indicating the success or failure of the operation.
+   * @return Status indicating the success or failure of the operation.
    */
-  static AdvNetStatus parse_tx_queue_rivermax_config(const YAML::Node& q_item, TxQueueConfig& q);
+  static Status parse_tx_queue_rivermax_config(const YAML::Node& q_item, TxQueueConfig& q);
 };
 
 }  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/rmax_config_manager.h
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/rmax_config_manager.h
@@ -28,7 +28,7 @@
 #include "rmax_ano_data_types.h"
 #include "rmax_ipo_receiver_service.h"
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 using namespace ral::services::rmax_ipo_receiver;
 
@@ -610,6 +610,6 @@ class RmaxConfigParser {
   static AdvNetStatus parse_tx_queue_rivermax_config(const YAML::Node& q_item, TxQueueConfig& q);
 };
 
-}  // namespace holoscan::ops
+}  // namespace holoscan::advanced_network
 
 #endif  // RMAX_CONFIG_MANAGER_H_

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/stats_printer.h
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/stats_printer.h
@@ -25,7 +25,7 @@
 #include "advanced_network/manager.h"
 #include "rmax_ipo_receiver_service.h"
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 class IpoRxStatsPrinter {
  public:
@@ -98,6 +98,6 @@ class IpoRxStatsPrinter {
   }
 };
 
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network
 
 #endif  // STATS_PRINTER_H

--- a/operators/advanced_network/advanced_network/types.h
+++ b/operators/advanced_network/advanced_network/types.h
@@ -30,7 +30,7 @@
 #include <linux/udp.h>
 #include <cuda_runtime.h>
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 /**
  * @brief Reserved header bytes for burst structure
@@ -422,4 +422,4 @@ auto adv_net_get_rx_tx_cfg_en(const Config& config) {
   return std::make_tuple(rx, tx);
 }
 
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network

--- a/operators/advanced_network/python/adv_network_common_pybind.cpp
+++ b/operators/advanced_network/python/adv_network_common_pybind.cpp
@@ -20,7 +20,7 @@
 
 namespace py = pybind11;
 
-namespace holoscan::ops {
+namespace holoscan::advanced_network {
 
 PYBIND11_MODULE(_advanced_network_common, m) {
   m.doc() = "Advanced networking operator utility functions";
@@ -119,4 +119,4 @@ PYBIND11_MODULE(_advanced_network_common, m) {
   //  py::class_<AdvNetBurstParams, std::shared_ptr<AdvNetBurstParams>>
   //    (m, "AdvNetBurstParams").def(py::init<>());
 }
-};  // namespace holoscan::ops
+};  // namespace holoscan::advanced_network

--- a/operators/advanced_network/python/adv_network_common_pybind.cpp
+++ b/operators/advanced_network/python/adv_network_common_pybind.cpp
@@ -25,98 +25,98 @@ namespace holoscan::advanced_network {
 PYBIND11_MODULE(_advanced_network_common, m) {
   m.doc() = "Advanced networking operator utility functions";
 
-  py::enum_<AdvNetStatus>(m, "AdvNetStatus")
-      .value("SUCCESS", AdvNetStatus::SUCCESS)
-      .value("NULL_PTR", AdvNetStatus::NULL_PTR)
-      .value("NO_FREE_BURST_BUFFERS", AdvNetStatus::NO_FREE_BURST_BUFFERS)
-      .value("NO_FREE_PACKET_BUFFERS", AdvNetStatus::NO_FREE_PACKET_BUFFERS);
+  py::enum_<Status>(m, "Status")
+      .value("SUCCESS", Status::SUCCESS)
+      .value("NULL_PTR", Status::NULL_PTR)
+      .value("NO_FREE_BURST_BUFFERS", Status::NO_FREE_BURST_BUFFERS)
+      .value("NO_FREE_PACKET_BUFFERS", Status::NO_FREE_PACKET_BUFFERS);
 
-  m.def("adv_net_create_tx_burst_params",
-        &adv_net_create_tx_burst_params,
+  m.def("create_tx_burst_params",
+        &create_tx_burst_params,
         py::return_value_policy::reference,
         "Create a shared pointer burst params structure");
-  m.def("adv_net_get_seg_pkt_len",
-        py::overload_cast<AdvNetBurstParams*, int, int>(&adv_net_get_seg_pkt_len),
+  m.def("get_segment_packet_length",
+        py::overload_cast<BurstParams*, int, int>(&get_segment_packet_length),
         "Get length of one segments of the packet");
-  m.def("adv_net_get_pkt_len",
-        py::overload_cast<AdvNetBurstParams*, int>(&adv_net_get_pkt_len),
+  m.def("get_packet_length",
+        py::overload_cast<BurstParams*, int>(&get_packet_length),
         "Get length of the packet");
-  m.def("adv_net_free_all_seg_pkts",
-        py::overload_cast<AdvNetBurstParams*, int>(&adv_net_free_all_seg_pkts),
+  m.def("free_all_segment_packets",
+        py::overload_cast<BurstParams*, int>(&free_all_segment_packets),
         "Free all packets in a burst for one segment");
-  m.def("adv_net_free_all_pkts_and_burst_rx",
-        py::overload_cast<AdvNetBurstParams*>(&adv_net_free_all_pkts_and_burst_rx),
+  m.def("free_all_packets_and_burst_rx",
+        py::overload_cast<BurstParams*>(&free_all_packets_and_burst_rx),
         "Free all packets and burst structure for RX");
-  m.def("adv_net_free_all_pkts_and_burst_tx",
-        py::overload_cast<AdvNetBurstParams*>(&adv_net_free_all_pkts_and_burst_tx),
+  m.def("free_all_packets_and_burst_tx",
+        py::overload_cast<BurstParams*>(&free_all_packets_and_burst_tx),
         "Free all packets and burst structure for TX");
-  m.def("adv_net_free_seg_pkts_and_burst",
-        py::overload_cast<AdvNetBurstParams*, int>(&adv_net_free_seg_pkts_and_burst),
+  m.def("free_segment_packets_and_burst",
+        py::overload_cast<BurstParams*, int>(&free_segment_packets_and_burst),
         "Free all packets and burst structure for one packet segment");
-  m.def("adv_net_tx_burst_available",
-        py::overload_cast<AdvNetBurstParams*>(&adv_net_tx_burst_available),
+  m.def("tx_burst_available",
+        py::overload_cast<BurstParams*>(&is_tx_burst_available),
         "Return true if a TX burst is available for use");
-  m.def("adv_net_get_tx_pkt_burst",
-        py::overload_cast<AdvNetBurstParams*>(&adv_net_get_tx_pkt_burst),
+  m.def("get_tx_packet_burst",
+        py::overload_cast<BurstParams*>(&get_tx_packet_burst),
         "Get TX packet burst");
-  m.def("adv_net_shutdown", (&adv_net_shutdown), "Shut down the ANO manager");
-  m.def("adv_net_print_stats", (&adv_net_print_stats), "Print statistics in in the ANO");
-  // m.def("adv_net_set_cpu_udp_payload",
-  //     [](AdvNetBurstParams *burst, int idx, long int data, int len) {
-  //             return adv_net_set_cpu_udp_payload(burst, idx,
+  m.def("shutdown", (&shutdown), "Shut down the ANO manager");
+  m.def("print_stats", (&print_stats), "Print statistics in in the ANO");
+  // m.def("set_cpu_udp_payload",
+  //     [](BurstParams *burst, int idx, long int data, int len) {
+  //             return set_cpu_udp_payload(burst, idx,
   //                     reinterpret_cast<void*>(data), len); },
   //             "Set UDP header parameters and copy payload");
-  // m.def("adv_net_set_cpu_udp_payload",
-  //     [](std::shared_ptr<AdvNetBurstParams> burst, int idx, long int data, int len) {
-  //         return adv_net_set_cpu_udp_payload(burst, idx,
+  // m.def("set_cpu_udp_payload",
+  //     [](std::shared_ptr<BurstParams> burst, int idx, long int data, int len) {
+  //         return set_cpu_udp_payload(burst, idx,
   //              reinterpret_cast<void*>(data), len); },
   //         "Set UDP header parameters and copy payload");
 
-  m.def("adv_net_get_num_pkts",
-        py::overload_cast<AdvNetBurstParams*>(&adv_net_get_num_pkts),
+  m.def("get_num_packets",
+        py::overload_cast<BurstParams*>(&get_num_packets),
         "Get number of packets in a burst");
-  m.def("adv_net_get_q_id",
-        py::overload_cast<AdvNetBurstParams*>(&adv_net_get_q_id),
+  m.def("get_q_id",
+        py::overload_cast<BurstParams*>(&get_q_id),
         "Get queue ID of a burst");
-  m.def("adv_net_set_num_pkts",
-        py::overload_cast<AdvNetBurstParams*, int64_t>(&adv_net_set_num_pkts),
+  m.def("set_num_packets",
+        py::overload_cast<BurstParams*, int64_t>(&set_num_packets),
         "Set number of packets in a burst");
-  m.def("adv_net_set_hdr",
-        py::overload_cast<AdvNetBurstParams*, uint16_t, uint16_t, int64_t, int>(&adv_net_set_hdr),
+  m.def("set_header",
+        py::overload_cast<BurstParams*, uint16_t, uint16_t, int64_t, int>(&set_header),
         "Set parameters of burst header");
-  m.def("adv_net_free_tx_burst",
-        py::overload_cast<AdvNetBurstParams*>(&adv_net_free_tx_burst),
+  m.def("free_tx_burst",
+        py::overload_cast<BurstParams*>(&free_tx_burst),
         "Free TX burst");
-  m.def("adv_net_free_rx_burst",
-        py::overload_cast<AdvNetBurstParams*>(&adv_net_free_rx_burst),
+  m.def("free_rx_burst",
+        py::overload_cast<BurstParams*>(&free_rx_burst),
         "Free RX burst");
-  m.def("adv_net_get_seg_pkt_ptr",
-        py::overload_cast<AdvNetBurstParams*, int, int>(&adv_net_get_seg_pkt_ptr),
+  m.def("get_segment_packet_ptr",
+        py::overload_cast<BurstParams*, int, int>(&get_segment_packet_ptr),
         "Get packet pointer for one segment");
-  m.def("adv_net_get_pkt_ptr",
-        py::overload_cast<AdvNetBurstParams*, int>(&adv_net_get_pkt_ptr),
+  m.def("get_packet_ptr",
+        py::overload_cast<BurstParams*, int>(&get_packet_ptr),
         "Get packet pointer");
-  m.def("adv_net_get_port_from_ifname",
-        &adv_net_get_port_from_ifname,
+  m.def("get_port_from_ifname",
+        &get_port_from_ifname,
         "Get port number from interface name");
 
-  // py::class_<AdvNetBurstHdrParams>(m, "AdvNetBurstHdrParams").def(py::init<>())
-  //     .def_readwrite("num_pkts",  &AdvNetBurstHdrParams::num_pkts)
-  //     .def_readwrite("port_id",   &AdvNetBurstHdrParams::port_id)
-  //     .def_readwrite("q_id",      &AdvNetBurstHdrParams::q_id);
+  // py::class_<BurstHeaderParams>(m, "BurstHeaderParams").def(py::init<>())
+  //     .def_readwrite("num_pkts",  &BurstHeaderParams::num_pkts)
+  //     .def_readwrite("port_id",   &BurstHeaderParams::port_id)
+  //     .def_readwrite("q_id",      &BurstHeaderParams::q_id);
 
-  // py::class_<AdvNetBurstHdr>(m, "AdvNetBurstHdr").def(py::init<>())
-  //     .def_readwrite("hdr",  &AdvNetBurstHdr::hdr);
+  // py::class_<BurstHeader>(m, "BurstHeader").def(py::init<>())
+  //     .def_readwrite("hdr",  &BurstHeader::hdr);
 
-  // py::class_<AdvNetBurstParams>(m, "AdvNetBurstParams").def(py::init<>())
-  //     .def_readwrite("hdr", &AdvNetBurstParams::hdr)
-  //     .def_readwrite("cpu_pkts", &AdvNetBurstParams::cpu_pkts)
-  //     .def_readwrite("gpu_pkts", &AdvNetBurstParams::gpu_pkts);
+  // py::class_<BurstParams>(m, "BurstParams").def(py::init<>())
+  //     .def_readwrite("hdr", &BurstParams::hdr)
+  //     .def_readwrite("cpu_pkts", &BurstParams::cpu_pkts)
+  //     .def_readwrite("gpu_pkts", &BurstParams::gpu_pkts);
 
-  py::class_<AdvNetBurstHdrParams>(m, "AdvNetBurstHdrParams").def(py::init<>());
-  py::class_<AdvNetBurstHdr>(m, "AdvNetBurstHdr").def(py::init<>());
-  py::class_<AdvNetBurstParams>(m, "AdvNetBurstParams").def(py::init<>());
-  //  py::class_<AdvNetBurstParams, std::shared_ptr<AdvNetBurstParams>>
-  //    (m, "AdvNetBurstParams").def(py::init<>());
+  py::class_<BurstHeaderParams>(m, "BurstHeaderParams").def(py::init<>());
+  py::class_<BurstHeader>(m, "BurstHeader").def(py::init<>());
+  py::class_<BurstParams>(m, "BurstParams").def(py::init<>());
+  //  py::class_<BurstParams, std::shared_ptr<BurstParams>>
+  //    (m, "BurstParams").def(py::init<>());
 }
 };  // namespace holoscan::advanced_network

--- a/operators/advanced_network/python/adv_network_rx_pybind.cpp
+++ b/operators/advanced_network/python/adv_network_rx_pybind.cpp
@@ -71,6 +71,8 @@ class PyAdvNetworkOpRx : public AdvNetworkOpRx {
   }
 };
 
+}  // namespace holoscan::ops
+
 PYBIND11_MODULE(_advanced_network_rx, m) {
   m.doc() = R"pbdoc(
         Holoscan SDK Python Bindings
@@ -88,17 +90,16 @@ PYBIND11_MODULE(_advanced_network_rx, m) {
   m.attr("__version__") = "dev";
 #endif
 
-  py::class_<AdvNetworkOpRx, PyAdvNetworkOpRx, Operator, std::shared_ptr<AdvNetworkOpRx>>(
-      m, "AdvNetworkOpRx", doc::AdvNetworkOpRx::doc_AdvNetworkOpRx)
-      .def(py::init<Fragment*,
+  py::class_<holoscan::ops::AdvNetworkOpRx, holoscan::ops::PyAdvNetworkOpRx, holoscan::Operator, std::shared_ptr<holoscan::ops::AdvNetworkOpRx>>(
+      m, "AdvNetworkOpRx", holoscan::doc::AdvNetworkOpRx::doc_AdvNetworkOpRx)
+      .def(py::init<holoscan::Fragment*,
                     const py::args&,
                     const std::unordered_set<std::string>&,
                     const std::string&>(),
            "fragment"_a,
            "output_ports_list"_a = std::unordered_set<std::string>{},
            "name"_a = "advanced_network_rx"s,
-           doc::AdvNetworkOpRx::doc_AdvNetworkOpRx_python)
-      .def("initialize", &AdvNetworkOpRx::initialize, doc::AdvNetworkOpRx::doc_initialize)
-      .def("setup", &AdvNetworkOpRx::setup, "spec"_a, doc::AdvNetworkOpRx::doc_setup);
+           holoscan::doc::AdvNetworkOpRx::doc_AdvNetworkOpRx_python)
+      .def("initialize", &holoscan::ops::AdvNetworkOpRx::initialize, holoscan::doc::AdvNetworkOpRx::doc_initialize)
+      .def("setup", &holoscan::ops::AdvNetworkOpRx::setup, "spec"_a, holoscan::doc::AdvNetworkOpRx::doc_setup);
 }  // PYBIND11_MODULE NOLINT
-}  // namespace holoscan::ops

--- a/operators/advanced_network/python/adv_network_rx_pybind.cpp
+++ b/operators/advanced_network/python/adv_network_rx_pybind.cpp
@@ -90,7 +90,10 @@ PYBIND11_MODULE(_advanced_network_rx, m) {
   m.attr("__version__") = "dev";
 #endif
 
-  py::class_<holoscan::ops::AdvNetworkOpRx, holoscan::ops::PyAdvNetworkOpRx, holoscan::Operator, std::shared_ptr<holoscan::ops::AdvNetworkOpRx>>(
+  py::class_<holoscan::ops::AdvNetworkOpRx,
+             holoscan::ops::PyAdvNetworkOpRx,
+             holoscan::Operator,
+             std::shared_ptr<holoscan::ops::AdvNetworkOpRx>>(
       m, "AdvNetworkOpRx", holoscan::doc::AdvNetworkOpRx::doc_AdvNetworkOpRx)
       .def(py::init<holoscan::Fragment*,
                     const py::args&,
@@ -100,6 +103,11 @@ PYBIND11_MODULE(_advanced_network_rx, m) {
            "output_ports_list"_a = std::unordered_set<std::string>{},
            "name"_a = "advanced_network_rx"s,
            holoscan::doc::AdvNetworkOpRx::doc_AdvNetworkOpRx_python)
-      .def("initialize", &holoscan::ops::AdvNetworkOpRx::initialize, holoscan::doc::AdvNetworkOpRx::doc_initialize)
-      .def("setup", &holoscan::ops::AdvNetworkOpRx::setup, "spec"_a, holoscan::doc::AdvNetworkOpRx::doc_setup);
+      .def("initialize",
+           &holoscan::ops::AdvNetworkOpRx::initialize,
+           holoscan::doc::AdvNetworkOpRx::doc_initialize)
+      .def("setup",
+           &holoscan::ops::AdvNetworkOpRx::setup,
+           "spec"_a,
+           holoscan::doc::AdvNetworkOpRx::doc_setup);
 }  // PYBIND11_MODULE NOLINT

--- a/operators/advanced_network/python/adv_network_tx_pybind.cpp
+++ b/operators/advanced_network/python/adv_network_tx_pybind.cpp
@@ -87,12 +87,20 @@ PYBIND11_MODULE(_advanced_network_tx, m) {
   m.attr("__version__") = "dev";
 #endif
 
-  py::class_<holoscan::ops::AdvNetworkOpTx, holoscan::ops::PyAdvNetworkOpTx, holoscan::Operator, std::shared_ptr<holoscan::ops::AdvNetworkOpTx>>(
+  py::class_<holoscan::ops::AdvNetworkOpTx,
+             holoscan::ops::PyAdvNetworkOpTx,
+             holoscan::Operator,
+             std::shared_ptr<holoscan::ops::AdvNetworkOpTx>>(
       m, "AdvNetworkOpTx", holoscan::doc::AdvNetworkOpTx::doc_AdvNetworkOpTx)
       .def(py::init<holoscan::Fragment*, const py::args&, const std::string&>(),
            "fragment"_a,
            "name"_a = "advanced_network_tx"s,
            holoscan::doc::AdvNetworkOpTx::doc_AdvNetworkOpTx_python)
-      .def("initialize", &holoscan::ops::AdvNetworkOpTx::initialize, holoscan::doc::AdvNetworkOpTx::doc_initialize)
-      .def("setup", &holoscan::ops::AdvNetworkOpTx::setup, "spec"_a, holoscan::doc::AdvNetworkOpTx::doc_setup);
+      .def("initialize",
+           &holoscan::ops::AdvNetworkOpTx::initialize,
+           holoscan::doc::AdvNetworkOpTx::doc_initialize)
+      .def("setup",
+           &holoscan::ops::AdvNetworkOpTx::setup,
+           "spec"_a,
+           holoscan::doc::AdvNetworkOpTx::doc_setup);
 }  // PYBIND11_MODULE NOLINT

--- a/operators/advanced_network/python/adv_network_tx_pybind.cpp
+++ b/operators/advanced_network/python/adv_network_tx_pybind.cpp
@@ -68,6 +68,8 @@ class PyAdvNetworkOpTx : public AdvNetworkOpTx {
   }
 };
 
+}  // namespace holoscan::ops
+
 PYBIND11_MODULE(_advanced_network_tx, m) {
   m.doc() = R"pbdoc(
         Holoscan SDK Python Bindings
@@ -85,13 +87,12 @@ PYBIND11_MODULE(_advanced_network_tx, m) {
   m.attr("__version__") = "dev";
 #endif
 
-  py::class_<AdvNetworkOpTx, PyAdvNetworkOpTx, Operator, std::shared_ptr<AdvNetworkOpTx>>(
-      m, "AdvNetworkOpTx", doc::AdvNetworkOpTx::doc_AdvNetworkOpTx)
-      .def(py::init<Fragment*, const py::args&, const std::string&>(),
+  py::class_<holoscan::ops::AdvNetworkOpTx, holoscan::ops::PyAdvNetworkOpTx, holoscan::Operator, std::shared_ptr<holoscan::ops::AdvNetworkOpTx>>(
+      m, "AdvNetworkOpTx", holoscan::doc::AdvNetworkOpTx::doc_AdvNetworkOpTx)
+      .def(py::init<holoscan::Fragment*, const py::args&, const std::string&>(),
            "fragment"_a,
            "name"_a = "advanced_network_tx"s,
-           doc::AdvNetworkOpTx::doc_AdvNetworkOpTx_python)
-      .def("initialize", &AdvNetworkOpTx::initialize, doc::AdvNetworkOpTx::doc_initialize)
-      .def("setup", &AdvNetworkOpTx::setup, "spec"_a, doc::AdvNetworkOpTx::doc_setup);
+           holoscan::doc::AdvNetworkOpTx::doc_AdvNetworkOpTx_python)
+      .def("initialize", &holoscan::ops::AdvNetworkOpTx::initialize, holoscan::doc::AdvNetworkOpTx::doc_initialize)
+      .def("setup", &holoscan::ops::AdvNetworkOpTx::setup, "spec"_a, holoscan::doc::AdvNetworkOpTx::doc_setup);
 }  // PYBIND11_MODULE NOLINT
-}  // namespace holoscan::ops

--- a/pkg/holoscan-networking/CMakeLists.txt
+++ b/pkg/holoscan-networking/CMakeLists.txt
@@ -16,7 +16,7 @@
 holohub_configure_deb(
   NAME "holoscan-networking"
   DESCRIPTION "Holoscan Networking"
-  VERSION "0.0.3"
+  VERSION "0.1.0"
   VENDOR "NVIDIA"
   CONTACT "Alexis Girault <agirault@nvidia.com>"
   COMPONENTS

--- a/tutorials/high_performance_networking/metadata.json
+++ b/tutorials/high_performance_networking/metadata.json
@@ -9,7 +9,7 @@
 			}
 		],
 		"language": "C++",
-		"version": "0.0.3",
+		"version": "0.1.0",
 		"changelog": {
 			"0.0.1": "Initial Release",
 			"0.0.3": "Updated for Holoscan 3.0"


### PR DESCRIPTION
- Move namespace from `holoscan::ops` to `holoscan::advanced_network` for the ano lib (not operators)
- Make names more explicit (en -> enabled, pkt -> packet, seg -> segment, hdr -> header)
- Remove prefix in class/type names redundant with namespace (AdvNet, Ano)
- Remove prefix in methods redundant with namespace (adv_net_)