### PR TITLE
Fixes for `yolo_model_deployment` build

### DIFF
--- a/applications/yolo_model_deployment/CMakeLists.txt
+++ b/applications/yolo_model_deployment/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(holoscan 1.0 REQUIRED CONFIG
 
 # Download the yolov8 model, exporting ONNX model, apply graph surgery for input size conversion
 add_custom_command(OUTPUT "${HOLOHUB_DATA_DIR}/yolo_model_deployment/yolov8s.onnx"
-    COMMAND git clone https://github.com/triple-Mu/YOLOv8-TensorRT.git
+    COMMAND git clone https://github.com/triple-Mu/YOLOv8-TensorRT.git || true
     COMMAND wget https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8s.pt
     COMMAND mv yolov8s.pt YOLOv8-TensorRT
     COMMAND python3 YOLOv8-TensorRT/export-det.py --weights yolov8s.pt --iou-thres 0.65 --conf-thres 0.25 --topk 100 --opset 11 --sim --input-shape 1 3 640 640 --device cuda:0
@@ -29,9 +29,6 @@ add_custom_command(OUTPUT "${HOLOHUB_DATA_DIR}/yolo_model_deployment/yolov8s.onn
     COMMAND python ./graph_surgeon.py yolov8s.onnx yolov8s.onnx
     COMMAND mkdir -p "${HOLOHUB_DATA_DIR}/yolo_model_deployment"
     COMMAND mv yolov8s.onnx "${HOLOHUB_DATA_DIR}/yolo_model_deployment"
-    COMMAND rm -rf YOLOv8-TensorRT
-    COMMAND rm graph_surgeon.py
-    BYPRODUCTS "${HOLOHUB_DATA_DIR}/yolo_model_deployment/yolov8s.onnx"
     )
 
 
@@ -43,7 +40,6 @@ add_custom_command(OUTPUT "${HOLOHUB_DATA_DIR}/yolo_model_deployment/meeting.mp4
     COMMAND ffmpeg -i "${HOLOHUB_DATA_DIR}/yolo_model_deployment/video.mp4" -t 6.4
               -c:v libx264 "${HOLOHUB_DATA_DIR}/yolo_model_deployment/meeting.mp4"
     COMMAND rm -rf "${HOLOHUB_DATA_DIR}/yolo_model_deployment/video.mp4"
-    BYPRODUCTS "${HOLOHUB_DATA_DIR}/yolo_model_deployment/meeting.mp4"
     VERBATIM
     )
 
@@ -53,8 +49,6 @@ add_custom_command(OUTPUT "${HOLOHUB_DATA_DIR}/yolo_model_deployment/meeting.gxf
     COMMAND ffmpeg -i "${HOLOHUB_DATA_DIR}/yolo_model_deployment/meeting.mp4" -pix_fmt rgb24 -f rawvideo pipe:1 |
             python3 "${CMAKE_SOURCE_DIR}/utilities/convert_video_to_gxf_entities.py"
             --directory "${HOLOHUB_DATA_DIR}/yolo_model_deployment" --basename meeting --width 1280 --height 720 --framerate 25
-    BYPRODUCTS "${HOLOHUB_DATA_DIR}/yolo_model_deployment/meeting.gxf_index"
-               "${HOLOHUB_DATA_DIR}/yolo_model_deployment/meeting.gxf_entities"
     DEPENDS "${HOLOHUB_DATA_DIR}/yolo_model_deployment/meeting.mp4"
     )
 


### PR DESCRIPTION
Addresses observed issues:
- Build failure due to both BYPRODUCTS and OUTPUT generating data files, possibly observed now with switch to Ninja build system in a734ed58a. Resolves error message:
```
ninja: error: build.ninja:1440: multiple rules generate /workspace/holohub/data/yolo_model_deployment/meeting.gxf_index [-w dupbuild=err]
```

- Persist YOLOv8-TensorRT repo to avoid error where ONNX generation failure could leave the build folder in a bad state with fail on the next `git clone YOLOv8-TensorRT`