### PR TITLE
Fixes for `vila_live` build

### DIFF
--- a/applications/vila_live/CMakeLists.txt
+++ b/applications/vila_live/CMakeLists.txt
@@ -27,7 +27,6 @@ add_custom_command(OUTPUT "${HOLOHUB_DATA_DIR}/vila_live/meeting.mp4"
     COMMAND ffmpeg -i "${HOLOHUB_DATA_DIR}/vila_live/video.mp4" -t 6.4
               -c:v libx264 "${HOLOHUB_DATA_DIR}/vila_live/meeting.mp4"
     COMMAND rm -rf "${HOLOHUB_DATA_DIR}/vila_live/video.mp4"
-    BYPRODUCTS "${HOLOHUB_DATA_DIR}/vila_live/meeting.mp4"
     VERBATIM
     )
 
@@ -37,8 +36,6 @@ add_custom_command(OUTPUT "${HOLOHUB_DATA_DIR}/vila_live/meeting.gxf_index"
     COMMAND ffmpeg -i "${HOLOHUB_DATA_DIR}/vila_live/meeting.mp4" -pix_fmt rgb24 -f rawvideo pipe:1 |
             python3 "${CMAKE_SOURCE_DIR}/utilities/convert_video_to_gxf_entities.py"
             --directory "${HOLOHUB_DATA_DIR}/vila_live" --basename meeting --width 1280 --height 720 --framerate 25
-    BYPRODUCTS "${HOLOHUB_DATA_DIR}/vila_live/meeting.gxf_index"
-               "${HOLOHUB_DATA_DIR}/vila_live/meeting.gxf_entities"
     DEPENDS "${HOLOHUB_DATA_DIR}/vila_live/meeting.mp4"
     )
 

--- a/applications/vila_live/Dockerfile
+++ b/applications/vila_live/Dockerfile
@@ -31,7 +31,7 @@ RUN chmod +x /tmp/scripts/run
 RUN /tmp/scripts/run setup
 
 # Install setuptools prior to all other requirements to avoid install errors
-RUN python3 -m pip install --no-cache-dir setuptools && \
+RUN python3 -m pip install --no-cache-dir setuptools packaging && \
     python3 -m pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cu124
 
 # Build/install flash-attention 2 (NOTE: on Arm64 this will take between 1-1.5 hours)

--- a/applications/vila_live/requirements.txt
+++ b/applications/vila_live/requirements.txt
@@ -2,7 +2,7 @@ flask==3.0.2
 websockets==12.0
 asyncio==3.4.3
 pillow==10.3.0
-transformers==4.48.0
+transformers==4.46
 ninja~=1.11
 deepspeed~=0.16
 pydantic~=2.10


### PR DESCRIPTION
Updates to fix `vila_live` build errors following HoloHub default generator update to Ninja.

Addresses errors on x86 platform:

Docker build:
```bash
0.454 Collecting flash-attn~=2.5
0.694   Downloading flash_attn-2.7.4.post1.tar.gz (6.0 MB)
1.893      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.0/6.0 MB 5.3 MB/s eta 0:00:00
2.687   Preparing metadata (setup.py): started
2.746   Preparing metadata (setup.py): finished with status 'error'
2.748   error: subprocess-exited-with-error
2.748
2.748   × python setup.py egg_info did not run successfully.
2.748   │ exit code: 1
2.748   ╰─> [6 lines of output]
2.748       Traceback (most recent call last):
2.748         File "<string>", line 2, in <module>
2.748         File "<pip-setuptools-caller>", line 34, in <module>
2.748         File "/tmp/pip-install-yjwnc8sl/flash-attn_42b07c7ef9e64ab497235f9174b57d88/setup.py", line 12, in <module>
2.748           from packaging.version import parse, Version
2.748       ModuleNotFoundError: No module named 'packaging'
```

CMake build:
```sh
[command] cmake --build build/vila_live -j
ninja: error: build.ninja:1440: multiple rules generate /workspace/holohub/data/vila_live/meeting.gxf_index
```

A runtime error is observed and requires further investigation:
```sh
ImportError: cannot import name 'is_torch_greater_or_equal_than_1_13' from 'transformers.pytorch_utils' (/usr/local/lib/python3.10/dist-packages/transformers/pytorch_utils.py)
```