### PR TITLE
Minor infra fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ and dependencies.
 			]
 		},
 		// Supported platforms
-		"platforms": ["amd64", "arm64"],
+		"platforms": ["x86_64", "aarch64"],
 		// Free-form tags for referencing the contribution
 		"tags": ["Endoscopy", "Video Encoding"],
 		// Ranking of the contribution. See below for ranking meaning

--- a/run
+++ b/run
@@ -247,6 +247,7 @@ get_app_dockerfile() {
   # 4. Use the default Dockerfile provided at the top level of the HoloHub repository.
   # Usage: ./run get_app_dockerfile <app_name> <language>
   local appname="$1"
+  local language="$2"
   local dockerfile_path=""
 
   local app_source_root_path=$(get_app_source_root_dir ${appname})

--- a/run
+++ b/run
@@ -561,11 +561,11 @@ lint() {
     # If we call with --fix
     if [ $FIX == true ]; then
       # Fix python
-      run_command ruff check --fix --ignore E712 ${DIR_TO_RUN} || exit_code=1
+      run_command ${HOLOHUB_PY_EXE} -m ruff check --fix --ignore E712 ${DIR_TO_RUN} || exit_code=1
       # Fix python isort issues, run:
-      run_command isort ${DIR_TO_RUN} || exit_code=1
+      run_command ${HOLOHUB_PY_EXE} -m isort ${DIR_TO_RUN} || exit_code=1
       # Fix python black code formatting issues, run:
-      run_command black ${DIR_TO_RUN} || exit_code=1
+      run_command ${HOLOHUB_PY_EXE} -m black ${DIR_TO_RUN} || exit_code=1
       run_command codespell -w -i 3 ${DIR_TO_RUN} --ignore-words codespell_ignore_words.txt \
                             --skip="*.onnx,*.min.js,*.min.js.map,Contrastive_learning_Notebook.ipynb,./data" || exit_code=1
 
@@ -592,7 +592,7 @@ lint() {
     pushd ${SCRIPT_DIR} > /dev/null
 
     echo "Linting Python"
-    run_command ruff check $DIR_TO_RUN --ignore E712 || exit_code=1
+    run_command ${HOLOHUB_PY_EXE} -m ruff check $DIR_TO_RUN --ignore E712 || exit_code=1
     run_command ${HOLOHUB_PY_EXE} -m isort -c $DIR_TO_RUN || exit_code=1
     run_command ${HOLOHUB_PY_EXE} -m black --check $DIR_TO_RUN || exit_code=1
 


### PR DESCRIPTION
- Fix `run:get_app_dockerfile` to not ignore language parameter (Regression introduced in #712)
- Update `CONTRIBUTING.md` to reflect new platform name conventions
- Call linting tools prefixed with `python3 -m` when appropriate, to circumvent scenarios where tools installation paths are not in the PATH