### PR TITLE
fixes llm-awq <> transformers 4.48

### DIFF
--- a/applications/vila_live/CMakeLists.txt
+++ b/applications/vila_live/CMakeLists.txt
@@ -49,8 +49,8 @@ if(BUILD_TESTING)
   file(READ "${CMAKE_CURRENT_SOURCE_DIR}/vila_live.yaml" CONFIG_FILE)
   string(REPLACE "count: 0" "count: 10" CONFIG_FILE ${CONFIG_FILE})
   # add model path and quant path to the yaml file, see also Dockerfile
-  string(APPEND CONFIG_FILE "\nmodel_path: /workspace/volumes/models/Llama-3-VILA1.5-8b-AWQ/")
-  string(APPEND CONFIG_FILE "\nquant_path: /workspace/volumes/models/Llama-3-VILA1.5-8b-AWQ/llm/llama-3-vila1.5-8b-w4-g128-awq-v2.pt")
+  string(APPEND CONFIG_FILE "\nmodel_path: /workspace/volumes/models/Llama-3-VILA1.5-8b-Fix-AWQ/")
+  string(APPEND CONFIG_FILE "\nquant_path: /workspace/volumes/models/Llama-3-VILA1.5-8b-Fix-AWQ/llm/llama-3-vila1.5-8b-fix-w4-g128-awq-v2.pt")
   file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/tests/vila_live_testing.yaml ${CONFIG_FILE})
 
   add_custom_target(vila_live_test ALL

--- a/applications/vila_live/Dockerfile
+++ b/applications/vila_live/Dockerfile
@@ -39,7 +39,7 @@ RUN python3 -m pip install --no-cache-dir setuptools packaging && \
 RUN MAX_JOBS=4 python3 -m pip install --no-cache-dir --no-build-isolation flash-attn~=2.5
 
 # Copy over app-specific requirements
-COPY applications/vila_live/requirements.txt /tmp/requirements.txt
+COPY applications/vila_live/requirements.txt applications/vila_live/llm-awq.patch /tmp/
 
 # Clone AWQ and VILA repositories and install them based on the GPU's compute capacity
 WORKDIR /workspace
@@ -47,6 +47,7 @@ ARG COMPUTE_CAPACITY
 RUN git clone https://github.com/mit-han-lab/llm-awq \
     && cd llm-awq \
     && git checkout 41d7e704932b7eaf8b3dcfb21e1fe49fd296d894 \
+    && git apply /tmp/llm-awq.patch \
     # Remove torch and transformers from pyproject.toml to avoid conflicts with installed versions
     && sed -i '/torch/d' pyproject.toml \
     && sed -i '/transformers/d' pyproject.toml \

--- a/applications/vila_live/Dockerfile
+++ b/applications/vila_live/Dockerfile
@@ -67,7 +67,7 @@ RUN git clone https://github.com/mit-han-lab/llm-awq \
 
 
 # Download the AWQ-quantized VILA model
-RUN huggingface-cli download Efficient-Large-Model/Llama-3-VILA1.5-8b-AWQ \
-    --local-dir /workspace/volumes/models/Llama-3-VILA1.5-8b-AWQ --cache-dir /workspace/volumes/models/Llama-3-VILA1.5-8b-AWQ
+RUN huggingface-cli download Efficient-Large-Model/Llama-3-VILA1.5-8b-Fix-AWQ \
+    --local-dir /workspace/volumes/models/Llama-3-VILA1.5-8b-Fix-AWQ --cache-dir /workspace/volumes/models/Llama-3-VILA1.5-8b-Fix-AWQ
 
 WORKDIR /workspace/holohub

--- a/applications/vila_live/Dockerfile
+++ b/applications/vila_live/Dockerfile
@@ -47,6 +47,7 @@ ARG COMPUTE_CAPACITY
 RUN git clone https://github.com/mit-han-lab/llm-awq \
     && cd llm-awq \
     && git checkout 41d7e704932b7eaf8b3dcfb21e1fe49fd296d894 \
+    # patching this version of llm-awq so that it works with transformers 4.48
     && git apply /tmp/llm-awq.patch \
     # Remove torch and transformers from pyproject.toml to avoid conflicts with installed versions
     && sed -i '/torch/d' pyproject.toml \

--- a/applications/vila_live/README.md
+++ b/applications/vila_live/README.md
@@ -5,7 +5,7 @@ This application demonstrates how to run [VILA 1.5](https://github.com/Efficient
 VILA 1.5 is a family of Vision Language Models (VLM) created by NVIDIA & MIT. It uses SigLIP to encode images into tokens which are fed into an LLM with an accompanying prompt. This application collects video frames from the V4L2 operator and feeds them to an AWQ-quantized VILA 1.5 for inference using the [TinyChat](https://github.com/mit-han-lab/llm-awq/blob/main/tinychat/README.md) library. This allows users to interact with a Generative AI model that is "watching" a chosen video stream in real-time.
 
 ![Holoscan VILA Live](./screenshot.png)
-Note: This demo currently uses [Llama-3-VILA1.5-8b-AWQ](https://huggingface.co/Efficient-Large-Model/Llama-3-VILA1.5-8b-AWQ), but any of the following AWQ-quantized models from the VILA 1.5 familty should work as long as the file names are changed in the [Dockerfile](./Dockerfile) and [run_vila_live.sh](./run_vila_live.sh):
+Note: This demo currently uses [Llama-3-VILA1.5-8b-AWQ](https://huggingface.co/Efficient-Large-Model/Llama-3-VILA1.5-8b-Fix-AWQ), but any of the following AWQ-quantized models from the VILA 1.5 familty should work as long as the file names are changed in the [Dockerfile](./Dockerfile) and [run_vila_live.sh](./run_vila_live.sh):
 - [VILA1.5-3b-AWQ](https://huggingface.co/Efficient-Large-Model/VILA1.5-3b-AWQ)
 - [VILA1.5-3b-s2-AWQ](https://huggingface.co/Efficient-Large-Model/VILA1.5-3b-s2-AWQ)
 - [Llama-3-VILA1.5-8b-AWQ](https://huggingface.co/Efficient-Large-Model/Llama-3-VILA1.5-8b-AWQ)

--- a/applications/vila_live/README.md
+++ b/applications/vila_live/README.md
@@ -5,7 +5,7 @@ This application demonstrates how to run [VILA 1.5](https://github.com/Efficient
 VILA 1.5 is a family of Vision Language Models (VLM) created by NVIDIA & MIT. It uses SigLIP to encode images into tokens which are fed into an LLM with an accompanying prompt. This application collects video frames from the V4L2 operator and feeds them to an AWQ-quantized VILA 1.5 for inference using the [TinyChat](https://github.com/mit-han-lab/llm-awq/blob/main/tinychat/README.md) library. This allows users to interact with a Generative AI model that is "watching" a chosen video stream in real-time.
 
 ![Holoscan VILA Live](./screenshot.png)
-Note: This demo currently uses [Llama-3-VILA1.5-8b-AWQ](https://huggingface.co/Efficient-Large-Model/Llama-3-VILA1.5-8b-Fix-AWQ), but any of the following AWQ-quantized models from the VILA 1.5 familty should work as long as the file names are changed in the [Dockerfile](./Dockerfile) and [run_vila_live.sh](./run_vila_live.sh):
+Note: This demo currently uses [Llama-3-VILA1.5-8b-AWQ](https://huggingface.co/Efficient-Large-Model/Llama-3-VILA1.5-8b-Fix-AWQ), but any of the following AWQ-quantized models from the VILA 1.5 family should work as long as the file names are changed in the [Dockerfile](./Dockerfile) and [run_vila_live.sh](./run_vila_live.sh):
 - [VILA1.5-3b-AWQ](https://huggingface.co/Efficient-Large-Model/VILA1.5-3b-AWQ)
 - [VILA1.5-3b-s2-AWQ](https://huggingface.co/Efficient-Large-Model/VILA1.5-3b-s2-AWQ)
 - [Llama-3-VILA1.5-8b-AWQ](https://huggingface.co/Efficient-Large-Model/Llama-3-VILA1.5-8b-AWQ)

--- a/applications/vila_live/README.md
+++ b/applications/vila_live/README.md
@@ -43,6 +43,10 @@ From the Holohub main directory run the following command:
 ```bash
 ./dev_container build_and_run vila_live
 ```
+or running with a replayer:
+```bash
+./dev_container build_and_run vila_live --run_args "--source replayer"
+```
 Note: The first build will take **~1.5 hours** if you're on ARM64. This is largely due to building [Flash Attention 2](https://github.com/Dao-AILab/flash-attention) since pre-built wheels are not distributed for ARM64 platforms.
 
 Once the main LMM-based app is running, you will see a link for the app at `http://127.0.0.1:8050`.

--- a/applications/vila_live/llm-awq.patch
+++ b/applications/vila_live/llm-awq.patch
@@ -1,0 +1,17 @@
+diff --git a/tinychat/models/llama.py b/tinychat/models/llama.py
+index a65cbaa..b9d616c 100644
+--- a/tinychat/models/llama.py
++++ b/tinychat/models/llama.py
+@@ -143,9 +143,9 @@ class LlamaAttentionFused(nn.Module):
+         )  # added to half
+ 
+         # dummy
+-        self.rotary_emb = LlamaRotaryEmbedding(
+-            self.head_dim, max_position_embeddings=2048, device="cuda:0"
+-        )
++        from transformers import LlamaConfig
++        c = LlamaConfig(head_dim=self.head_dim, max_position_embeddings=2048)
++        self.rotary_emb = LlamaRotaryEmbedding(c, device="cuda:0")
+ 
+     def forward(
+         self,

--- a/applications/vila_live/requirements.txt
+++ b/applications/vila_live/requirements.txt
@@ -2,7 +2,7 @@ flask==3.0.2
 websockets==12.0
 asyncio==3.4.3
 pillow==10.3.0
-transformers==4.46
+transformers==4.48.3
 ninja~=1.11
 deepspeed~=0.16
 pydantic~=2.10

--- a/applications/vila_live/run_vila_live.sh
+++ b/applications/vila_live/run_vila_live.sh
@@ -39,8 +39,8 @@ trap cleanup SIGINT SIGTERM
 # Run the Llama.cpp LLM server process + main HoloScrub app
 python3 -m tinychat.serve.controller --host 0.0.0.0 --port 10000 & bg_pids+=($!)
 python3 -m tinychat.serve.model_worker_new --host 0.0.0.0 --controller http://localhost:10000 --port 40000 --worker http://localhost:40000 \
-    --model-path /workspace/volumes/models/Llama-3-VILA1.5-8b-AWQ/ \
-    --quant-path /workspace/volumes/models/Llama-3-VILA1.5-8b-AWQ/llm/llama-3-vila1.5-8b-w4-g128-awq-v2.pt & bg_pids+=($!)
+    --model-path /workspace/volumes/models/Llama-3-VILA1.5-8b-Fix-AWQ/ \
+    --quant-path /workspace/volumes/models/Llama-3-VILA1.5-8b-Fix-AWQ/llm/llama-3-vila1.5-8b-fix-w4-g128-awq-v2.pt & bg_pids+=($!)
 python3 /workspace/holohub/applications/vila_live/vila_live.py "$@" & bg_pids+=($!)
 
 # Let the script clean up the server process


### PR DESCRIPTION
follow up of https://github.com/nvidia-holoscan/holohub/pull/734 https://github.com/nvidia-holoscan/holohub/pull/746

update the built-in model to use a more recent version https://huggingface.co/Efficient-Large-Model/Llama-3-VILA1.5-8B-Fix-AWQ instead of the previous https://huggingface.co/Efficient-Large-Model/Llama-3-VILA1.5-8b-AWQ