### PR TITLE
Fix body pose app and upgrade from yolov8 to yolo11

### DIFF
--- a/applications/body_pose_estimation/CMakeLists.txt
+++ b/applications/body_pose_estimation/CMakeLists.txt
@@ -18,11 +18,10 @@ find_package(holoscan 1.0 REQUIRED CONFIG
              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
 # Download the yolov8 pose model if it doesn't exist
-add_custom_command(OUTPUT "${HOLOHUB_DATA_DIR}/body_pose_estimation/yolov8l-pose.onnx"
-    COMMAND "PATH=${PATH}:/workspace/holohub/.local/bin" /usr/local/bin/yolo export model=yolov8l-pose.pt format=onnx
+add_custom_command(OUTPUT "${HOLOHUB_DATA_DIR}/body_pose_estimation/yolov11l-pose.onnx"
+    COMMAND "PATH=${PATH}:/workspace/holohub/.local/bin" /usr/local/bin/yolo export model=yolo11l-pose.pt format=onnx
     COMMAND mkdir -p "${HOLOHUB_DATA_DIR}/body_pose_estimation"
-    COMMAND mv yolov8l-pose.onnx "${HOLOHUB_DATA_DIR}/body_pose_estimation"
-    BYPRODUCTS "${HOLOHUB_DATA_DIR}/body_pose_estimation/yolov8l-pose.onnx"
+    COMMAND mv yolo11l-pose.onnx "${HOLOHUB_DATA_DIR}/body_pose_estimation/"
     )
 
 # Download the testing video
@@ -30,7 +29,6 @@ add_custom_command(OUTPUT "${HOLOHUB_DATA_DIR}/body_pose_estimation/twirl.mp4"
     COMMAND mkdir -p "${HOLOHUB_DATA_DIR}/body_pose_estimation"
     COMMAND curl -S -o "${HOLOHUB_DATA_DIR}/body_pose_estimation/twirl.mp4"
               -L "https://www.pexels.com/download/video/5385885/?fps=25.0&h=1920&w=1080"
-    BYPRODUCTS "${HOLOHUB_DATA_DIR}/body_pose_estimation/twirl.mp4"
     VERBATIM
     )
 
@@ -40,14 +38,12 @@ add_custom_command(OUTPUT "${HOLOHUB_DATA_DIR}/body_pose_estimation/twirl.gxf_in
     COMMAND ffmpeg -i "${HOLOHUB_DATA_DIR}/body_pose_estimation/twirl.mp4" -pix_fmt rgb24 -f rawvideo pipe:1 |
             python3 "${CMAKE_SOURCE_DIR}/utilities/convert_video_to_gxf_entities.py"
             --directory "${HOLOHUB_DATA_DIR}/body_pose_estimation" --basename twirl --width 1080 --height 1920 --framerate 25
-    BYPRODUCTS "${HOLOHUB_DATA_DIR}/body_pose_estimation/twirl.gxf_index"
-               "${HOLOHUB_DATA_DIR}/body_pose_estimation/twirl.gxf_entities"
     DEPENDS "${HOLOHUB_DATA_DIR}/body_pose_estimation/twirl.mp4"
     )
 
 add_custom_target(body_pose_estimation_data ALL
                   DEPENDS
-                  "${HOLOHUB_DATA_DIR}/body_pose_estimation/yolov8l-pose.onnx"
+                  "${HOLOHUB_DATA_DIR}/body_pose_estimation/yolov11l-pose.onnx"
                   "${HOLOHUB_DATA_DIR}/body_pose_estimation/twirl.gxf_index")
 
 

--- a/applications/body_pose_estimation/Dockerfile
+++ b/applications/body_pose_estimation/Dockerfile
@@ -27,7 +27,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install required apt packages and python modules
 #
 RUN apt-get update \
-    && apt-get install -y libgl1
+    && apt-get install -y libgl1 curl
 
 RUN pip3 install \
     ultralytics \

--- a/applications/body_pose_estimation/README.md
+++ b/applications/body_pose_estimation/README.md
@@ -10,7 +10,7 @@ A model is used to infer the locations of keypoints from the source video which 
 
 ## Model
 
-This application uses YOLOv8 pose model from [Ultralytics](https://docs.ultralytics.com/tasks/pose/) for body pose estimation.
+This application uses YOLO11 pose model from [Ultralytics](https://docs.ultralytics.com/tasks/pose/) for body pose estimation.
 The model is downloaded when building the application.
 
 ## Data

--- a/applications/body_pose_estimation/body_pose_estimation.py
+++ b/applications/body_pose_estimation/body_pose_estimation.py
@@ -416,7 +416,7 @@ class BodyPoseEstimationApp(Application):
 
         inference_args = self.kwargs("inference")
         inference_args["model_path_map"] = {
-            "yolo_pose": os.path.join(self.sample_data_path, "yolov8l-pose.onnx")
+            "yolo_pose": os.path.join(self.sample_data_path, "yolo11l-pose.onnx")
         }
 
         inference = InferenceOp(

--- a/applications/body_pose_estimation/body_pose_estimation.py
+++ b/applications/body_pose_estimation/body_pose_estimation.py
@@ -510,4 +510,5 @@ if __name__ == "__main__":
 
     app = BodyPoseEstimationApp(args.data, args.source, args.video_device)
     app.config(config_file)
+    app.enable_metadata(False)
     app.run()


### PR DESCRIPTION
This pull request includes several changes to update the body pose estimation application to use the YOLO11 pose model instead of the YOLOv8 pose model.  

Additionally, updates were made to fix:
* Build error by removing BYPRODUCTS lines in CMakeLists.txt file which the ninja generator doesn't like
* Disable meta data which was causing a runtime error


Updates to use YOLO11 model:

* [`applications/body_pose_estimation/CMakeLists.txt`](diffhunk://#diff-8702cf208f6d613526bad1291f7b39ce1c0d140c787649982408c9d5d34e8708L21-L33): Updated the model file name and paths from `yolov8l-pose.onnx` to `yolo11l-pose.onnx` and removed unnecessary `BYPRODUCTS` lines. [[1]](diffhunk://#diff-8702cf208f6d613526bad1291f7b39ce1c0d140c787649982408c9d5d34e8708L21-L33) [[2]](diffhunk://#diff-8702cf208f6d613526bad1291f7b39ce1c0d140c787649982408c9d5d34e8708L43-R46)
* [`applications/body_pose_estimation/README.md`](diffhunk://#diff-313c601048240b061718112cdd391e5136b3a8a8f6b0051f0864a96e819d251eL13-R13): Updated the model name in the documentation from YOLOv8 to YOLO11.
* [`applications/body_pose_estimation/body_pose_estimation.py`](diffhunk://#diff-1b2c92ef104552423b5a041bb33143e9f63791541ff05bce5e360eeb291e231eL419-R419): Updated the model path in the `compose` method to use `yolo11l-pose.onnx`.

Other changes:

* [`applications/body_pose_estimation/Dockerfile`](diffhunk://#diff-8f86b55896ba6b147ef52c92e6f8265e26680ffb3d6e9c86ea985e7699bf7f21L30-R30): Added `curl` to the list of installed packages.
* [`applications/body_pose_estimation/body_pose_estimation.py`](diffhunk://#diff-1b2c92ef104552423b5a041bb33143e9f63791541ff05bce5e360eeb291e231eR513): Added a call to `app.enable_metadata(False)` in the `compose` method.