### PR TITLE
ANO: fix port id set

### DIFF
--- a/operators/advanced_network/CHANGELOG.md
+++ b/operators/advanced_network/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Breaking
 
--
+- Removed `get_port_from_ifname`. Use `address_to_port` instead.
 
 ### Non-Breaking
 

--- a/operators/advanced_network/adv_network_rx.cpp
+++ b/operators/advanced_network/adv_network_rx.cpp
@@ -69,14 +69,14 @@ int AdvNetworkOpRx::Init() {
 
   for (const auto& intf : impl->cfg.ifs_) {
     const auto& rx = intf.rx_;
-    auto port_opt = impl->mgr->get_port_from_ifname(intf.address_);
-    if (!port_opt.has_value()) {
+    auto port = impl->mgr->address_to_port(intf.address_);
+    if (port < 0) {
       HOLOSCAN_LOG_ERROR("Failed to get port from name {}", intf.address_);
       return -1;
     }
 
     for (const auto& q : rx.queues_) {
-      pq_map_[(port_opt.value() << 16) | q.common_.id_] = q.output_port_;
+      pq_map_[(port << 16) | q.common_.id_] = q.output_port_;
     }
   }
 

--- a/operators/advanced_network/advanced_network/common.cpp
+++ b/operators/advanced_network/advanced_network/common.cpp
@@ -275,11 +275,6 @@ void* get_packet_ptr(BurstParams* burst, int idx) {
   return g_ano_mgr->get_packet_ptr(burst, idx);
 }
 
-std::optional<uint16_t> get_port_from_ifname(const std::string& name) {
-  ASSERT_ANO_MGR_INITIALIZED();
-  return g_ano_mgr->get_port_from_ifname(name);
-}
-
 void shutdown() {
   ASSERT_ANO_MGR_INITIALIZED();
   g_ano_mgr->shutdown();

--- a/operators/advanced_network/advanced_network/common.h
+++ b/operators/advanced_network/advanced_network/common.h
@@ -405,8 +405,6 @@ void set_header(BurstParams* burst, uint16_t port, uint16_t q, int64_t num, int 
  */
 void format_eth_addr(char* dst, std::string addr);
 
-std::optional<uint16_t> get_port_from_ifname(const std::string& name);
-
 /**
  * @brief Shut down ANO and do any cleanup necessary. Freeing memory is done
  * in the manager's destructor.

--- a/operators/advanced_network/advanced_network/common.h
+++ b/operators/advanced_network/advanced_network/common.h
@@ -362,15 +362,15 @@ int64_t get_q_id(BurstParams* burst);
 /**
  * @brief Get mac address of an interface
  *
- * @param addr Address of interface from config file
- * @param port Port ID of interface
+ * @param port Port number of interface
+ * @param mac MAC address of interface
  *
  * @returns Status::SUCCESS on success
  */
 Status get_mac_addr(int port, char* mac);
 
 /**
- * @brief Get mac address of an interface
+ * @brief Get port number from interface name
  *
  * @param addr Address of interface from config file
  *

--- a/operators/advanced_network/advanced_network/manager.cpp
+++ b/operators/advanced_network/advanced_network/manager.cpp
@@ -192,6 +192,22 @@ Status Manager::allocate_memory_regions() {
   return Status::SUCCESS;
 }
 
+/**
+ * @brief Generic implementation of address_to_port that looks up port in config
+ * This is a final method that cannot be overridden by subclasses.
+ *
+ * @param addr Address string to look up
+ * @return int Port ID or -1 if not found
+ */
+int Manager::address_to_port(const std::string& addr) {
+  for (const auto& intf : cfg_.ifs_) {
+    if (intf.address_ == addr) {
+      return intf.port_id_;
+    }
+  }
+  return -1;
+}
+
 bool Manager::validate_config() const {
   bool pass = true;
   std::set<std::string> mr_names;

--- a/operators/advanced_network/advanced_network/manager.h
+++ b/operators/advanced_network/advanced_network/manager.h
@@ -77,7 +77,7 @@ class Manager {
   virtual Status get_tx_metadata_buffer(BurstParams** burst) = 0;
   virtual Status send_tx_burst(BurstParams* burst) = 0;
   virtual Status get_mac_addr(int port, char* mac) = 0;
-  virtual int address_to_port(const std::string& addr) final;
+  virtual int address_to_port(const std::string& addr) final;  // NOLINT(readability/inheritance)
   virtual bool validate_config() const;
 
   virtual ~Manager() = default;

--- a/operators/advanced_network/advanced_network/manager.h
+++ b/operators/advanced_network/advanced_network/manager.h
@@ -71,7 +71,6 @@ class Manager {
   virtual BurstParams* create_tx_burst_params() = 0;
 
   /* Internal functions used by ANO operators */
-  virtual std::optional<uint16_t> get_port_from_ifname(const std::string& name) = 0;
   virtual Status get_rx_burst(BurstParams** burst) = 0;
   virtual void free_rx_metadata(BurstParams* burst) = 0;
   virtual void free_tx_metadata(BurstParams* burst) = 0;

--- a/operators/advanced_network/advanced_network/manager.h
+++ b/operators/advanced_network/advanced_network/manager.h
@@ -78,7 +78,7 @@ class Manager {
   virtual Status get_tx_metadata_buffer(BurstParams** burst) = 0;
   virtual Status send_tx_burst(BurstParams* burst) = 0;
   virtual Status get_mac_addr(int port, char* mac) = 0;
-  virtual int address_to_port(const std::string& addr) = 0;
+  virtual int address_to_port(const std::string& addr) final;
   virtual bool validate_config() const;
 
   virtual ~Manager() = default;

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
@@ -418,11 +418,10 @@ void DpdkMgr::initialize() {
   // Set up the port IDs to map to DPDK port IDs
   for (auto& intf : cfg_.ifs_) {
     if (rte_eth_dev_get_port_by_name(intf.address_.c_str(), &intf.port_id_) < 0) {
-      HOLOSCAN_LOG_CRITICAL("Failed to get port number for {}", intf.name_);
+      HOLOSCAN_LOG_CRITICAL("Failed to get port number for {} ({})", intf.name_, intf.address_);
       return;
-    } else {
-      HOLOSCAN_LOG_INFO("Port {} found for {}", intf.port_id_, intf.name_);
     }
+    HOLOSCAN_LOG_INFO("{} ({}): identified as port {}", intf.name_, intf.address_, intf.port_id_);
   }
 
   for (int i = 0; i < num_ports; i++) {
@@ -456,12 +455,6 @@ void DpdkMgr::initialize() {
   int max_rx_batch_size = 0;
   int max_tx_batch_size = 0;
   for (auto& intf : cfg_.ifs_) {
-    ret = rte_eth_dev_get_port_by_name(intf.address_.c_str(), &intf.port_id_);
-    if (ret < 0) {
-      HOLOSCAN_LOG_CRITICAL("Failed to get port number for {}", intf.name_.c_str());
-      return;
-    }
-
     struct rte_eth_dev_info dev_info;
     int ret = rte_eth_dev_info_get(intf.port_id_, &dev_info);
     if (ret != 0) {

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
@@ -1887,14 +1887,6 @@ void DpdkMgr::free_tx_burst(BurstParams* burst) {
   rte_mempool_put(tx_metadata, burst);
 }
 
-std::optional<uint16_t> DpdkMgr::get_port_from_ifname(const std::string& name) {
-  uint16_t port;
-  auto ret = rte_eth_dev_get_port_by_name(name.c_str(), &port);
-  if (ret < 0) { return {}; }
-
-  return port;
-}
-
 Status DpdkMgr::get_rx_burst(BurstParams** burst) {
   if (rte_ring_dequeue(rx_ring, reinterpret_cast<void**>(burst)) < 0) {
     return Status::NOT_READY;

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
@@ -152,14 +152,6 @@ bool DpdkMgr::set_config_and_initialize(const NetworkConfig& cfg) {
   return true;
 }
 
-int DpdkMgr::address_to_port(const std::string& addr) {
-  for (const auto& intf : cfg_.ifs_) {
-    if (intf.address_ == addr) { return intf.port_id_; }
-  }
-
-  return -1;
-}
-
 Status DpdkMgr::get_mac_addr(int port, char* mac) {
   if (port > mac_addrs.size()) {
     HOLOSCAN_LOG_CRITICAL("Port {} out of range in get_mac_addr() lookup");

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.h
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.h
@@ -185,7 +185,6 @@ class DpdkMgr : public Manager {
   void free_all_packets(BurstParams* burst) override;
   void free_rx_burst(BurstParams* burst) override;
   void free_tx_burst(BurstParams* burst) override;
-  std::optional<uint16_t> get_port_from_ifname(const std::string& name) override;
 
   Status get_rx_burst(BurstParams** burst) override;
   Status set_packet_tx_time(BurstParams* burst, int idx, uint64_t timestamp);
@@ -193,7 +192,7 @@ class DpdkMgr : public Manager {
   void free_tx_metadata(BurstParams* burst) override;
   Status get_tx_metadata_buffer(BurstParams** burst) override;
   Status send_tx_burst(BurstParams* burst) override;
-    Status get_mac_addr(int port, char* mac) override;
+  Status get_mac_addr(int port, char* mac) override;
   void shutdown() override;
   void print_stats() override;
   void adjust_memory_regions() override;

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.h
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.h
@@ -193,8 +193,7 @@ class DpdkMgr : public Manager {
   void free_tx_metadata(BurstParams* burst) override;
   Status get_tx_metadata_buffer(BurstParams** burst) override;
   Status send_tx_burst(BurstParams* burst) override;
-  int address_to_port(const std::string& addr) override;
-  Status get_mac_addr(int port, char* mac) override;
+    Status get_mac_addr(int port, char* mac) override;
   void shutdown() override;
   void print_stats() override;
   void adjust_memory_regions() override;

--- a/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.cpp
@@ -1645,7 +1645,7 @@ Status DocaMgr::get_tx_packet_burst(BurstParams* burst) {
 
     for (auto& q : intf.tx_.queues_) {
       if (q.common_.id_ == burst->hdr.hdr.q_id) {
-        uint32_t key = (cfg_.ifs_[0].port_id_ << 16) | q.common_.id_;
+        uint32_t key = (intf.port_id_ << 16) | q.common_.id_;
         auto txq = tx_q_map_[key];
 
         // Should be thread safe as it's atomic inc
@@ -1696,7 +1696,7 @@ bool DocaMgr::is_tx_burst_available(BurstParams* burst) {
 
     for (auto& q : intf.tx_.queues_) {
       if (q.common_.id_ == burst->hdr.hdr.q_id) {
-        uint32_t key = (cfg_.ifs_[0].port_id_ << 16) | q.common_.id_;
+        uint32_t key = (intf.port_id_ << 16) | q.common_.id_;
         auto txq = tx_q_map_[key];
         doca_pe_progress(txq->pe);
         if (txq->tx_cmp_posted > TX_COMP_THRS) {

--- a/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.cpp
@@ -1631,14 +1631,6 @@ Status DocaMgr::get_mac_addr(int port, char* mac) {
   return Status::SUCCESS;
 }
 
-int DocaMgr::address_to_port(const std::string& addr) {
-  for (const auto& intf : cfg_.ifs_) {
-    if (intf.address_ == addr) { return intf.port_id_; }
-  }
-
-  return -1;
-}
-
 Status DocaMgr::set_packet_tx_time(BurstParams* burst, int idx, uint64_t timestamp) {
   return Status::SUCCESS;
 }

--- a/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.cpp
@@ -1726,15 +1726,6 @@ void DocaMgr::free_tx_burst(BurstParams* burst) {
   return;
 }
 
-std::optional<uint16_t> DocaMgr::get_port_from_ifname(const std::string& name) {
-  HOLOSCAN_LOG_INFO("Port name {}", name);
-  for (const auto& intf : cfg_.ifs_) {
-    if (name == intf.address_) { return intf.port_id_; }
-  }
-
-  return -1;
-}
-
 Status DocaMgr::get_rx_burst(BurstParams** burst) {
   if (rte_ring_dequeue(rx_ring, reinterpret_cast<void**>(burst)) < 0) {
     return Status::NOT_READY;

--- a/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.cpp
@@ -417,16 +417,16 @@ int DocaMgr::setup_pools_and_rings(int max_tx_batch) {
 
   HOLOSCAN_LOG_DEBUG("Setting up RX meta pool");
   rx_metadata = rte_mempool_create("RX_META_POOL",
-                               (1U << 6) - 1U,
-                               sizeof(BurstParams),
-                               0,
-                               0,
-                               nullptr,
-                               nullptr,
-                               nullptr,
-                               nullptr,
-                               rte_socket_id(),
-                               0);
+                                   (1U << 6) - 1U,
+                                   sizeof(BurstParams),
+                                   0,
+                                   0,
+                                   nullptr,
+                                   nullptr,
+                                   nullptr,
+                                   nullptr,
+                                   rte_socket_id(),
+                                   0);
   if (rx_metadata == nullptr) {
     HOLOSCAN_LOG_CRITICAL("Failed to allocate RX meta pool!");
     return -1;
@@ -458,16 +458,16 @@ int DocaMgr::setup_pools_and_rings(int max_tx_batch) {
 
   HOLOSCAN_LOG_INFO("Setting up TX meta pool");
   tx_metadata = rte_mempool_create("TX_META_POOL",
-                               (1U << 7) - 1U,
-                               sizeof(BurstParams),
-                               0,
-                               0,
-                               nullptr,
-                               nullptr,
-                               nullptr,
-                               nullptr,
-                               rte_socket_id(),
-                               0);
+                                   (1U << 7) - 1U,
+                                   sizeof(BurstParams),
+                                   0,
+                                   0,
+                                   nullptr,
+                                   nullptr,
+                                   nullptr,
+                                   nullptr,
+                                   rte_socket_id(),
+                                   0);
   if (tx_metadata == nullptr) {
     HOLOSCAN_LOG_CRITICAL("Failed to allocate TX meta pool!");
     return -1;
@@ -1677,12 +1677,12 @@ Status DocaMgr::set_eth_header(BurstParams* burst, int idx, char* dst_addr) {
 }
 
 Status DocaMgr::set_ipv4_header(BurstParams* burst, int idx, int ip_len, uint8_t proto,
-                                   unsigned int src_host, unsigned int dst_host) {
+                                unsigned int src_host, unsigned int dst_host) {
   return Status::NOT_SUPPORTED;
 }
 
 Status DocaMgr::set_udp_header(BurstParams* burst, int idx, int udp_len, uint16_t src_port,
-                                  uint16_t dst_port) {
+                               uint16_t dst_port) {
   return Status::NOT_SUPPORTED;
 }
 
@@ -1727,9 +1727,7 @@ void DocaMgr::free_tx_burst(BurstParams* burst) {
 }
 
 Status DocaMgr::get_rx_burst(BurstParams** burst) {
-  if (rte_ring_dequeue(rx_ring, reinterpret_cast<void**>(burst)) < 0) {
-    return Status::NOT_READY;
-  }
+  if (rte_ring_dequeue(rx_ring, reinterpret_cast<void**>(burst)) < 0) { return Status::NOT_READY; }
 
   return Status::SUCCESS;
 }
@@ -1744,9 +1742,9 @@ void DocaMgr::free_tx_metadata(BurstParams* burst) {
 
 BurstParams* DocaMgr::create_tx_burst_params() {
   auto burst_idx = burst_tx_idx.fetch_add(1);
-  HOLOSCAN_LOG_DEBUG(
-      "create_tx_burst_params burst_idx {} MAX_TX_BURST {}",
-        burst_idx % MAX_TX_BURST, MAX_TX_BURST);
+  HOLOSCAN_LOG_DEBUG("create_tx_burst_params burst_idx {} MAX_TX_BURST {}",
+                     burst_idx % MAX_TX_BURST,
+                     MAX_TX_BURST);
   return &(burst[burst_idx % MAX_TX_BURST]);
 }
 

--- a/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.h
+++ b/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.h
@@ -217,7 +217,7 @@ class DocaMgr : public Manager {
   void free_all_packets(BurstParams* burst) override{};
   void free_rx_burst(BurstParams* burst) override;
   void free_tx_burst(BurstParams* burst) override;
-  
+
   Status get_rx_burst(BurstParams** burst) override;
   Status set_packet_tx_time(BurstParams* burst, int idx, uint64_t timestamp);
   void free_rx_metadata(BurstParams* burst) override;
@@ -225,7 +225,7 @@ class DocaMgr : public Manager {
   Status get_tx_metadata_buffer(BurstParams** burst) override;
   Status send_tx_burst(BurstParams* burst) override;
   Status get_mac_addr(int port, char* mac) override;
-    void shutdown() override;
+  void shutdown() override;
   void print_stats() override;
   bool validate_config() const override;
 

--- a/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.h
+++ b/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.h
@@ -226,8 +226,7 @@ class DocaMgr : public Manager {
   Status get_tx_metadata_buffer(BurstParams** burst) override;
   Status send_tx_burst(BurstParams* burst) override;
   Status get_mac_addr(int port, char* mac) override;
-  int address_to_port(const std::string& addr) override;
-  void shutdown() override;
+    void shutdown() override;
   void print_stats() override;
   bool validate_config() const override;
 

--- a/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.h
+++ b/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.h
@@ -217,8 +217,7 @@ class DocaMgr : public Manager {
   void free_all_packets(BurstParams* burst) override{};
   void free_rx_burst(BurstParams* burst) override;
   void free_tx_burst(BurstParams* burst) override;
-  std::optional<uint16_t> get_port_from_ifname(const std::string& name) override;
-
+  
   Status get_rx_burst(BurstParams** burst) override;
   Status set_packet_tx_time(BurstParams* burst, int idx, uint64_t timestamp);
   void free_rx_metadata(BurstParams* burst) override;

--- a/operators/advanced_network/advanced_network/managers/rivermax/adv_network_rmax_mgr.h
+++ b/operators/advanced_network/advanced_network/managers/rivermax/adv_network_rmax_mgr.h
@@ -72,8 +72,7 @@ class RmaxMgr : public Manager {
   uint64_t get_burst_tot_byte(BurstParams* burst) override;
   BurstParams* create_tx_burst_params() override;
   Status get_mac_addr(int port, char* mac) override;
-  int address_to_port(const std::string& addr) override;
-
+  
  private:
   class RmaxMgrImpl;
   std::unique_ptr<RmaxMgr::RmaxMgrImpl> pImpl;

--- a/operators/advanced_network/advanced_network/managers/rivermax/adv_network_rmax_mgr.h
+++ b/operators/advanced_network/advanced_network/managers/rivermax/adv_network_rmax_mgr.h
@@ -59,8 +59,6 @@ class RmaxMgr : public Manager {
   void free_rx_burst(BurstParams* burst) override;
   void free_tx_burst(BurstParams* burst) override;
 
-  std::optional<uint16_t> get_port_from_ifname(const std::string& name) override;
-
   Status get_rx_burst(BurstParams** burst) override;
   Status set_packet_tx_time(BurstParams* burst, int idx, uint64_t timestamp);
   void free_rx_metadata(BurstParams* burst) override;
@@ -72,7 +70,7 @@ class RmaxMgr : public Manager {
   uint64_t get_burst_tot_byte(BurstParams* burst) override;
   BurstParams* create_tx_burst_params() override;
   Status get_mac_addr(int port, char* mac) override;
-  
+
  private:
   class RmaxMgrImpl;
   std::unique_ptr<RmaxMgr::RmaxMgrImpl> pImpl;

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/adv_network_rmax_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/adv_network_rmax_mgr.cpp
@@ -110,8 +110,7 @@ class RmaxMgr::RmaxMgrImpl {
   void free_rx_burst(BurstParams* burst);
   void free_tx_burst(BurstParams* burst);
   void format_eth_addr(char* dst, std::string addr);
-  std::optional<uint16_t> get_port_from_ifname(const std::string& name);
-  Status get_rx_burst(BurstParams** burst);
+    Status get_rx_burst(BurstParams** burst);
   Status set_packet_tx_time(BurstParams* burst, int idx, uint64_t timestamp);
   void free_rx_metadata(BurstParams* burst);
   void free_tx_metadata(BurstParams* burst);
@@ -603,23 +602,6 @@ void RmaxMgr::RmaxMgrImpl::free_rx_burst(BurstParams* burst) {
 void RmaxMgr::RmaxMgrImpl::free_tx_burst(BurstParams* burst) {}
 
 /**
- * @brief Gets the port number from an interface name.
- *
- * @param name The interface name.
- * @return Optional containing the port number if found, otherwise empty.
- */
-std::optional<uint16_t> RmaxMgr::RmaxMgrImpl::get_port_from_ifname(const std::string& name) {
-  HOLOSCAN_LOG_INFO("Port name {}", name);
-  auto it = std::find_if(cfg_.ifs_.begin(), cfg_.ifs_.end(), [&name](const auto& intf) {
-    return name == intf.address_;
-  });
-
-  if (it != cfg_.ifs_.end()) { return it->port_id_; }
-
-  return -1;
-}
-
-/**
  * @brief Dequeues an RX burst.
  *
  * @param burst Pointer to the burst parameters.
@@ -993,16 +975,6 @@ void RmaxMgr::free_rx_burst(BurstParams* burst) {
  */
 void RmaxMgr::free_tx_burst(BurstParams* burst) {
   pImpl->free_tx_burst(burst);
-}
-
-/**
- * @brief Gets the port number from an interface name.
- *
- * @param name The interface name.
- * @return Optional containing the port number if found, otherwise empty.
- */
-std::optional<uint16_t> RmaxMgr::get_port_from_ifname(const std::string& name) {
-  return pImpl->get_port_from_ifname(name);
 }
 
 /**

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/adv_network_rmax_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/adv_network_rmax_mgr.cpp
@@ -183,6 +183,12 @@ bool RmaxMgr::RmaxMgrImpl::set_config_and_initialize(const NetworkConfig& cfg) {
  * and initializing the RX services and chunk consumers.
  */
 void RmaxMgr::RmaxMgrImpl::initialize() {
+  int port_id = 0;
+  for (auto& intf : cfg_.ifs_) {
+    intf.port_id_ = port_id++;
+    HOLOSCAN_LOG_INFO("{} ({}): assigned port ID {}", intf.name_, intf.address_, intf.port_id_);
+  }
+
   rx_bursts_out_queue = std::make_shared<AnoBurstsQueue>();
 
   rmax_apps_lib = std::make_shared<ral::lib::RmaxAppsLibFacade>();

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/adv_network_rmax_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/adv_network_rmax_mgr.cpp
@@ -122,8 +122,7 @@ class RmaxMgr::RmaxMgrImpl {
   uint64_t get_burst_tot_byte(BurstParams* burst);
   BurstParams* create_tx_burst_params();
   Status get_mac_addr(int port, char* mac);
-  int address_to_port(const std::string& addr);
-
+  
  private:
   static void flush_packets(int port);
   void setup_accurate_send_scheduling_mask();
@@ -718,21 +717,6 @@ Status RmaxMgr::RmaxMgrImpl::get_mac_addr(int port, char* mac) {
 }
 
 /**
- * @brief Converts an address to a port number.
- *
- * @param addr The address.
- * @return The port number.
- */
-int RmaxMgr::RmaxMgrImpl::address_to_port(const std::string& addr) {
-  auto it = std::find_if(cfg_.ifs_.begin(), cfg_.ifs_.end(), [&addr](const auto& intf) {
-    return intf.address_ == addr;
-  });
-
-  if (it != cfg_.ifs_.end()) { return it->port_id_; }
-  return -1;
-}
-
-/**
  * @brief Constructor for RmaxMgr.
  */
 RmaxMgr::RmaxMgr() : pImpl(std::make_unique<RmaxMgrImpl>()) {}
@@ -1123,16 +1107,6 @@ BurstParams* RmaxMgr::create_tx_burst_params() {
  */
 Status RmaxMgr::get_mac_addr(int port, char* mac) {
   return pImpl->get_mac_addr(port, mac);
-}
-
-/**
- * @brief Converts an address to a port number.
- *
- * @param addr The address.
- * @return The port number.
- */
-int RmaxMgr::address_to_port(const std::string& addr) {
-  return pImpl->address_to_port(addr);
 }
 
 };  // namespace holoscan::advanced_network

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/adv_network_rmax_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/adv_network_rmax_mgr.cpp
@@ -110,7 +110,7 @@ class RmaxMgr::RmaxMgrImpl {
   void free_rx_burst(BurstParams* burst);
   void free_tx_burst(BurstParams* burst);
   void format_eth_addr(char* dst, std::string addr);
-    Status get_rx_burst(BurstParams** burst);
+  Status get_rx_burst(BurstParams** burst);
   Status set_packet_tx_time(BurstParams* burst, int idx, uint64_t timestamp);
   void free_rx_metadata(BurstParams* burst);
   void free_tx_metadata(BurstParams* burst);
@@ -121,7 +121,7 @@ class RmaxMgr::RmaxMgrImpl {
   uint64_t get_burst_tot_byte(BurstParams* burst);
   BurstParams* create_tx_burst_params();
   Status get_mac_addr(int port, char* mac);
-  
+
  private:
   static void flush_packets(int port);
   void setup_accurate_send_scheduling_mask();

--- a/operators/advanced_network/python/adv_network_common_pybind.cpp
+++ b/operators/advanced_network/python/adv_network_common_pybind.cpp
@@ -96,9 +96,6 @@ PYBIND11_MODULE(_advanced_network_common, m) {
   m.def("get_packet_ptr",
         py::overload_cast<BurstParams*, int>(&get_packet_ptr),
         "Get packet pointer");
-  m.def("get_port_from_ifname",
-        &get_port_from_ifname,
-        "Get port number from interface name");
 
   // py::class_<BurstHeaderParams>(m, "BurstHeaderParams").def(py::init<>())
   //     .def_readwrite("num_pkts",  &BurstHeaderParams::num_pkts)


### PR DESCRIPTION
# Context

Port Id logic was changed in #715. Some issues came up:
- dpdk checks port ids twice with `rte_eth_dev_get_port_by_name`
- gpunetio and rivermax backends don't have initialized port ids
- identified redundancy between `address_to_port` and `get_port_from_ifname`
- `address_to_port` is generic to all managers and shouldntt get overriden


# Changes

- [x] DPDK: remove duplicated `rte_eth_dev_get_port_by_name`
- [x] Rivermax: initialize port IDs
- [x] GPUNetIO: initialize port IDs
- [x] Consolidate `address_to_port` in base class
- [x] Remove `get_port_from_ifname` 

# Results

- [x] DPDK tests still pass (apart from jumbo frames, failing already on `main`)

```bash
./dev_container launch \
  --img holohub:adv_networking_bench \
  --docker_opts "-u 0 --privileged" \
  -- bash -c "cd build/adv_networking_bench/applications/adv_networking_bench/cpp/ && python3 -m pytest -v -k 'dpdk' "
```
```pytest
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /workspace/holohub
configfile: pyproject.toml
collected 10 items / 6 deselected / 4 selected        

testing/test_ano_bench.py::test_multi_if_loopback[dpdk-64-6.0-0.1-0.0] PASSED                                                                                                          [ 25%]
testing/test_ano_bench.py::test_multi_if_loopback[dpdk-512-55.0-0.1-0.0] PASSED                                                                                                        [ 50%]
testing/test_ano_bench.py::test_multi_if_loopback[dpdk-1500-94.0-0.1-0.0] PASSED                                                                                                       [ 75%]
testing/test_ano_bench.py::test_multi_if_loopback[dpdk-9000-96.0-0.1-0.0] FAILED                                                                                                       [100%]
```