### PR TITLE
Prevent returning multiple IDs from get_group_id()

### DIFF
--- a/dev_container
+++ b/dev_container
@@ -256,7 +256,7 @@ get_group_id() {
     # a single ID. Thus, append a colon to the group name to match the exact
     # group (e.g., video: and not video-users:) and include head -1 to get a
     # single ID if there are still multiple matches.
-    cat /etc/group | grep $group: | cut -d: -f3 | head -1
+    cat /etc/group | grep ^${group}: | cut -d: -f3 | head -1
 }
 
 get_ucx_options() {

--- a/dev_container
+++ b/dev_container
@@ -251,7 +251,12 @@ run_docker() {
 
 get_group_id() {
     local group=$1
-    cat /etc/group | grep $group | cut -d: -f3
+    # It it possible to match multiple lines in /etc/group for a given
+    # search pattern, but the expectation is that this function returns
+    # a single ID. Thus, append a colon to the group name to match the exact
+    # group (e.g., video: and not video-users:) and include head -1 to get a
+    # single ID if there are still multiple matches.
+    cat /etc/group | grep $group: | cut -d: -f3 | head -1
 }
 
 get_ucx_options() {

--- a/dev_container
+++ b/dev_container
@@ -256,7 +256,7 @@ get_group_id() {
     # a single ID. Thus, append a colon to the group name to match the exact
     # group (e.g., video: and not video-users:) and include head -1 to get a
     # single ID if there are still multiple matches.
-    cat /etc/group | grep ^${group}: | cut -d: -f3 | head -1
+    grep "^${group}:" /etc/group | cut -d: -f3 | head -1
 }
 
 get_ucx_options() {


### PR DESCRIPTION
Grepping /etc/group for a group name can match multiple entries. For example, with the following entries in /etc/group:

video:x:GID1:...
video-data:x:GID2:...

`grep video /etc/group` will match both lines. Append a colon to the search group name to prevent these extra matches. In case there are still multiple matches, add head -1 to keep only the first entry.