### PR TITLE
Install aja-source op

### DIFF
--- a/operators/aja_source/CMakeLists.txt
+++ b/operators/aja_source/CMakeLists.txt
@@ -64,3 +64,5 @@ target_link_libraries(aja_source
 if(HOLOHUB_BUILD_PYTHON)
     add_subdirectory(python)
 endif()
+
+install(TARGETS aja_source)


### PR DESCRIPTION
The endoscopy tool tracking app and the object detection torch app attempt to load the AJA source operator (`libaja_source.so`), but it is not in the `install/` directory. This issue prevents the Holoscan CLI from executing the application due to the missing `.so` file.


Note: The application runs fine with `build_and_run` because the `libaja_source.so` file is located in the `build/` directory. However, the CLI packages the application from the directory created with `build_and_install`, which is missing `libaja_source.so`.