### PR TITLE
Permit CMake application dependencies on other applications

### DIFF
--- a/cmake/HoloHubConfigHelpers.cmake
+++ b/cmake/HoloHubConfigHelpers.cmake
@@ -56,7 +56,14 @@ function(add_holohub_application NAME)
 
     # If we have dependencies make sure they are built
     if(APP_DEPENDS)
-      cmake_parse_arguments(DEPS "" "" "EXTENSIONS;OPERATORS" ${APP_DEPENDS})
+      cmake_parse_arguments(DEPS "" "" "EXTENSIONS;OPERATORS;APPLICATIONS" ${APP_DEPENDS})
+      message(DEBUG "${pkgname} exts = ${DEPS_EXTENSIONS}")
+      message(DEBUG "${pkgname} ops = ${DEPS_OPERATORS}")
+      message(DEBUG "${pkgname} apps = ${DEPS_APPLICATIONS}")
+
+      foreach(dependency IN LISTS DEPS_APPLICATIONS)
+        set("APP_${dependency}" ON CACHE BOOL "Build the ${dependency} application" FORCE)
+      endforeach()
 
       foreach(dependency IN LISTS DEPS_EXTENSIONS)
         set("EXT_${dependency}" ON CACHE BOOL "Build the ${dependency}" FORCE)


### PR DESCRIPTION
Extend `add_holohub_application` to allow applications to specify dependencies on other applications.

Intended to support LIMITED dependencies among applications. For instance, `volume_rendering_xr` may define operators tightly coupled with that app, while `xr_hello_holoscan` may at first depend on those tightly coupled components and then refine by forking components or consolidating in a reusable module. Prior to this change there is no mechanism to allow one application to enable another application to be built in the same build tree.

Note that the order of `add_holohub_application` calls matters, dependent applications much be listed first in order to enable subsequent dependency applications.

Intended to help mitigate operator code duplication among two related applications in https://github.com/nvidia-holoscan/holohub/pull/764. For instance, `xr_hello_holoscan` may be updated as follows to access XR volume rendering components:
```
add_holohub_application(xr_hello_holoscan DEPENDS
                        APPLICATIONS volume_rendering_xr)
```