### PR TITLE
Fix nvclip sample application error

### DIFF
--- a/applications/nvidia_nim/nvidia_nim_chat/requirements.txt
+++ b/applications/nvidia_nim/nvidia_nim_chat/requirements.txt
@@ -1,3 +1,3 @@
 halo==0.0.31
 holoscan==2.1.0
-openai==1.30.1
+openai==1.72.0

--- a/applications/nvidia_nim/nvidia_nim_nvclip/nvidia_nim.yaml
+++ b/applications/nvidia_nim/nvidia_nim_nvclip/nvidia_nim.yaml
@@ -18,7 +18,7 @@
 # NVIDIA-hosted NIMs running on build.nvidia.com.
 nim:
   base_url: https://integrate.api.nvidia.com/v1
-  api_key: aa
+  api_key: 
   model: nvidia/nvclip
   encoding_format: float
 

--- a/applications/nvidia_nim/nvidia_nim_nvclip/requirements.txt
+++ b/applications/nvidia_nim/nvidia_nim_nvclip/requirements.txt
@@ -1,4 +1,4 @@
 halo==0.0.31
 holoscan==2.1.0
-openai==1.30.1
+openai==1.72.0
 torch==2.5.0


### PR DESCRIPTION
Update OpenAI version to fix the "unexpected keyword argument 'proxies' " error:

The existing version of OpenAI contains additional parameters that may no longer be acceptable by the latest service version
```
# /usr/local/lib/python3.10/dist-packages/openai/_base_client.py:825

        self._client = http_client or SyncHttpxClientWrapper(
            base_url=base_url,
            # cast to a valid type because mypy doesn't understand our type narrowing
            timeout=cast(Timeout, timeout),
            proxies=proxies,
            transport=transport,
            limits=limits,
            follow_redirects=True,
        )
```

With the updated version:
```
# /usr/local/lib/python3.10/dist-packages/openai/_base_client.py:825

        self._client = http_client or SyncHttpxClientWrapper(
            base_url=base_url,
            # cast to a valid type because mypy doesn't understand our type narrowing
            timeout=cast(Timeout, timeout),
        )
```