### PR TITLE
Minor doc update for `ai_surgical_video` workflow

### DIFF
--- a/workflows/ai_surgical_video/README.md
+++ b/workflows/ai_surgical_video/README.md
@@ -94,10 +94,10 @@ git checkout hsdk-3.0
 
 This will build a docker image called `hololink-demo:2.0.0`.
 
-Once you have built the Holoscan Sensor Bridge container, you can build the Holohub container using the following command:
+Once you have built the Holoscan Sensor Bridge container, you can build the Holohub container and run the workflow using the following command:
 
 ```sh
-./dev_container build_and_run --base_img hololink-demo:2.0.0 --img holohub:link ai_surgical_video
+./dev_container build_and_run --base_img hololink-demo:2.0.0 --img holohub:link ai_surgical_video --run_args " --source hsb"
 ```
 
 ## Advanced Usage


### PR DESCRIPTION
In the Holoscan Sensor Bridge workflow instructions, use `--source hsb` by default to use HSB rather than video replayer input.

Closes #786