### PR TITLE
some misc CLI updates

### DIFF
--- a/codespell_ignore_words.txt
+++ b/codespell_ignore_words.txt
@@ -14,4 +14,5 @@ ehr
 Infor
 infor
 INFOR
+assertIn
 

--- a/holohub
+++ b/holohub
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -28,6 +28,7 @@ from typing import List, Optional
 import utilities.cli.util as holohub_cli_util
 import utilities.metadata.gather_metadata as metadata_util
 from utilities.cli.container import HoloHubContainer
+from utilities.cli.util import Color
 
 
 def list_cmake_dir_options(script_dir: Path, cmake_function: str) -> List[str]:
@@ -435,13 +436,13 @@ class HoloHubCLI:
                 if not args.dryrun:
                     os.chdir(project_data.get("source_folder", ""))
                 print(
-                    f"\033[34m{holohub_cli_util.get_timestamp()} \033[37m$ \033[32mcd {project_data.get('source_folder', '')}\033[0m"
+                    f"{Color.blue(holohub_cli_util.get_timestamp())} {Color.white('$')} {Color.green('cd ' + str(project_data.get('source_folder', '')))}"
                 )
             elif workdir == "holohub_bin":
                 if not args.dryrun:
                     os.chdir(build_dir)
                 print(
-                    f"\033[34m{holohub_cli_util.get_timestamp()} \033[37m$ \033[32mcd {build_dir}\033[0m"
+                    f"{Color.blue(holohub_cli_util.get_timestamp())} {Color.white('$')} {Color.green('cd ' + str(build_dir))}"
                 )
             else:  # default to app binary directory
                 target_dir = (
@@ -450,7 +451,7 @@ class HoloHubCLI:
                 if not args.dryrun:
                     os.chdir(target_dir)
                 print(
-                    f"\033[34m{holohub_cli_util.get_timestamp()} \033[37m$ \033[32mcd {target_dir}\033[0m"
+                    f"{Color.blue(holohub_cli_util.get_timestamp())} {Color.white('$')} {Color.green('cd ' + str(target_dir))}"
                 )
 
             # Set up environment
@@ -466,13 +467,13 @@ class HoloHubCLI:
             # Print environment setup
             if args.verbose or args.dryrun:
                 print(
-                    f"\033[34m{holohub_cli_util.get_timestamp()} \033[37m$ \033[32mexport PYTHONPATH={env['PYTHONPATH']}\033[0m"
+                    f"{Color.blue(holohub_cli_util.get_timestamp())} {Color.white('$')} {Color.green('export PYTHONPATH=' + env['PYTHONPATH'])}"
                 )
                 print(
-                    f"\033[34m{holohub_cli_util.get_timestamp()} \033[37m$ \033[32mexport HOLOHUB_DATA_PATH={env['HOLOHUB_DATA_PATH']}\033[0m"
+                    f"{Color.blue(holohub_cli_util.get_timestamp())} {Color.white('$')} {Color.green('export HOLOHUB_DATA_PATH=' + env['HOLOHUB_DATA_PATH'])}"
                 )
                 print(
-                    f"\033[34m{holohub_cli_util.get_timestamp()} \033[37m$ \033[32mexport HOLOSCAN_INPUT_PATH={env['HOLOSCAN_INPUT_PATH']}\033[0m"
+                    f"{Color.blue(holohub_cli_util.get_timestamp())} {Color.white('$')} {Color.green('export HOLOSCAN_INPUT_PATH=' + env['HOLOSCAN_INPUT_PATH'])}"
                 )
 
             # Handle Nsight Systems profiling
@@ -557,13 +558,13 @@ class HoloHubCLI:
         for project_type in LIST_TYPES:
             if project_type not in grouped_metadata:
                 continue
-            print(f"\n\033[1;37m== {project_type.upper()}S =================\033[0m\n")
+            print(f"\n{Color.white(f'== {project_type.upper()}S =================', bold=True)}\n")
             for project in sorted(grouped_metadata[project_type], key=lambda x: x["project_name"]):
                 language = project.get("metadata", {}).get("language", "")
                 language = f"({language})" if language else ""
                 print(f'{project["project_name"]} {language}')
 
-        print("\n\033[1;37m=================================\033[0m\n")
+        print(f"\n{Color.white('=================================', bold=True)}\n")
 
     def handle_lint(self, args: argparse.Namespace) -> None:
         """Handle lint command"""
@@ -645,7 +646,7 @@ class HoloHubCLI:
 
         else:
             # Run linting checks
-            print("Linting Python")
+            print(Color.blue("Linting Python"))
             if (
                 holohub_cli_util.run_command(
                     ["ruff", "check", "--ignore", "E712", args.path],
@@ -670,7 +671,7 @@ class HoloHubCLI:
             ):
                 exit_code = 1
 
-            print("Linting C++")
+            print(Color.blue("Linting C++"))
             if (
                 holohub_cli_util.run_command(
                     [
@@ -699,7 +700,7 @@ class HoloHubCLI:
             ):
                 exit_code = 1
 
-            print("Code spelling")
+            print(Color.blue("Code spelling"))
             if (
                 holohub_cli_util.run_command(
                     [
@@ -718,7 +719,7 @@ class HoloHubCLI:
             ):
                 exit_code = 1
 
-            print("Linting CMake")
+            print(Color.blue("Linting CMake"))
             cmake_files = list(Path(args.path).rglob("CMakeLists.txt"))
             cmake_files.extend(Path(args.path).rglob("*.cmake"))
             if cmake_files:
@@ -737,7 +738,7 @@ class HoloHubCLI:
                     exit_code = 1
 
         if exit_code == 0:
-            print("Everything looks good!")
+            print(Color.green("Everything looks good!"))
         sys.exit(exit_code)
 
     def _install_lint_deps(self, dry_run: bool = False) -> None:
@@ -998,7 +999,7 @@ class HoloHubCLI:
             dry_run=args.dryrun,
         )
 
-        print("Setup for HoloHub is ready. Happy Holocoding!")
+        print(Color.green("Setup for HoloHub is ready. Happy Holocoding!"))
 
     def handle_install(self, args: argparse.Namespace) -> None:
         """Handle install command"""
@@ -1007,13 +1008,13 @@ class HoloHubCLI:
     def handle_clear_cache(self, args: argparse.Namespace) -> None:
         """Handle clear-cache command"""
         if args.dryrun:
-            print("Would clear cache folders:")
+            print(Color.blue("Would clear cache folders:"))
             for pattern in ["build", "build-*", "install"]:
                 for path in HoloHubCLI.HOLOHUB_ROOT.glob(pattern):
                     if path.is_dir():
-                        print(f"  Would remove: {path}")
+                        print(f"  {Color.yellow('Would remove:')} {path}")
         else:
-            print("Clearing cache...")
+            print(Color.blue("Clearing cache..."))
             for pattern in ["build", "build-*", "install"]:
                 for path in HoloHubCLI.HOLOHUB_ROOT.glob(pattern):
                     if path.is_dir():

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -678,6 +678,7 @@ class HoloHubCLI:
                         "python",
                         "-m",
                         "cpplint",
+                        "--quiet",
                         "--exclude",
                         "build",
                         "--exclude",
@@ -737,7 +738,7 @@ class HoloHubCLI:
                 ):
                     exit_code = 1
 
-        if exit_code == 0:
+        if exit_code == 0 and not args.dryrun:
             print(Color.green("Everything looks good!"))
         sys.exit(exit_code)
 

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -254,7 +254,7 @@ class HoloHubCLI:
         ]  # Get the closest match with distance <= 3
         msg = f"Project '{project_name}' not found."
         if closest_matches:
-            msg += f" Did you mean: '{closest_matches[0][0]}' (source: {closest_matches[0][1]})"
+            msg += f"\nDid you mean: '{closest_matches[0][0]}' (source: {closest_matches[0][1]})"
         holohub_cli_util.fatal(msg)
         return None
 
@@ -426,7 +426,7 @@ class HoloHubCLI:
             if language == "cpp":
                 if not build_dir.is_dir() and not args.dryrun:
                     holohub_cli_util.fatal(
-                        f"The build directory for this application does not exist.\n"
+                        f"The build directory {build_dir} for this application does not exist.\n"
                         f"Did you forget to './holohub build {args.project}'?"
                     )
 

--- a/utilities/cli/tests/CMakeLists.txt
+++ b/utilities/cli/tests/CMakeLists.txt
@@ -77,3 +77,10 @@ add_test(
     COMMAND ${Python3_EXECUTABLE} -m unittest discover -s ${CMAKE_CURRENT_SOURCE_DIR} -p "test_container.py"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
+
+# Add test for CLI module
+add_test(
+    NAME test_cli
+    COMMAND ${Python3_EXECUTABLE} -m unittest discover -s ${CMAKE_CURRENT_SOURCE_DIR} -p "test_cli.py"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)

--- a/utilities/cli/tests/test_cli.py
+++ b/utilities/cli/tests/test_cli.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Add the utilities directory to the Python path
+sys.path.append(str(Path(os.getcwd()) / "utilities"))
+
+from utilities.cli.holohub import HoloHubCLI
+
+
+class TestHoloHubCLI(unittest.TestCase):
+    def setUp(self):
+        self.cli = HoloHubCLI()
+        # Mock project data for testing
+        self.mock_project_data = {
+            "project_name": "test_project",
+            "source_folder": Path(os.getcwd()) / "applications" / "test_project",
+            "metadata": {
+                "language": "cpp",
+                "dockerfile": "<holohub_app_source>/Dockerfile",
+                "run": {"command": "./test_project"},
+            },
+        }
+        # Mock project data with some similar names
+        self.cli.projects = [
+            {"project_name": "hello_world", "metadata": {"language": "cpp"}},
+            {
+                "project_name": "hello_world_python",
+                "metadata": {"language": "python"},
+                "source_folder": "applications/hello_world_python",
+            },
+            {"project_name": "hello_world_cpp", "source_folder": "applications/hello_world_cpp"},
+            {
+                "project_name": "hello_world_advanced",
+                "metadata": {"language": "cpp"},
+                "source_folder": "applications/hello_world_advanced",
+            },
+        ]
+
+    def test_parser_creation(self):
+        """Test that the argument parser is created with all required commands"""
+        parser = self.cli.parser
+        self.assertIsNotNone(parser)
+
+        # Check that all main commands are present
+        subparsers = [action for action in parser._actions if action.dest == "command"]
+        self.assertEqual(len(subparsers), 1)
+        # Check for some key commands
+        for x in [
+            "build-container",
+            "run-container",
+            "build",
+            "run",
+            "list",
+            "lint",
+            "setup",
+            "install",
+        ]:
+            self.assertIn(x, subparsers[0].choices)
+
+    @patch("utilities.cli.holohub.HoloHubCLI._find_project")
+    @patch("utilities.cli.holohub.HoloHubContainer")
+    def test_build_container_command(self, mock_container_class, mock_find_project):
+        """Test the build-container command parsing"""
+        mock_find_project.return_value = self.mock_project_data
+        mock_container = MagicMock()
+        mock_container_class.return_value = mock_container
+
+        cmd = "build-container test_project --base_img test_image --verbose --no-cache"
+        args = self.cli.parser.parse_args(cmd.split())
+        self.assertEqual(args.command, "build-container")
+        self.assertEqual(args.project, "test_project")
+        self.assertEqual(args.base_img, "test_image")
+        self.assertTrue(args.verbose)
+        self.assertTrue(args.no_cache)
+
+        # Call the function to verify it's called with correct args
+        args.func(args)
+        mock_find_project.assert_called_once_with(project_name="test_project", language=None)
+        mock_container_class.assert_called_once()
+        mock_container.build.assert_called_once_with(
+            docker_file=None, base_img="test_image", img=None, no_cache=True, build_args=None
+        )
+
+    @patch("utilities.cli.holohub.HoloHubCLI._find_project")
+    @patch("utilities.cli.holohub.HoloHubContainer")
+    @patch("utilities.cli.util.run_command")
+    @patch("shutil.which")
+    def test_run_command(
+        self, mock_which, mock_run_command, mock_container_class, mock_find_project
+    ):
+        """Test the run command parsing"""
+        mock_find_project.return_value = self.mock_project_data
+        mock_container = MagicMock()
+        mock_container_class.return_value = mock_container
+        mock_run_command.return_value = None
+        mock_which.return_value = "/usr/local/bin/nsys"  # Mock nsys being available
+
+        cmd = "run test_project --local --verbose --nsys-profile"
+        args = self.cli.parser.parse_args(cmd.split())
+        self.assertEqual(args.command, "run")
+        self.assertEqual(args.project, "test_project")
+        self.assertTrue(args.local)
+        self.assertTrue(args.verbose)
+        self.assertTrue(args.nsys_profile)
+
+        # Call the function to verify it's called with correct args
+        args.func(args)
+        mock_find_project.assert_called_once_with(project_name="test_project", language=None)
+
+    def test_list_command(self):
+        """Test the list command parsing"""
+        args = self.cli.parser.parse_args(["list"])
+        self.assertEqual(args.command, "list")
+        self.assertEqual(len(vars(args)), 2)  # command and func
+
+    def test_did_you_mean_suggestion(self):
+        """Test the 'did you mean' suggestion functionality"""
+
+        # Test with a misspelled project name
+        with self.assertRaises(SystemExit):
+            with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+                self.cli._find_project("hello_wrld")
+                stderr_output = mock_stderr.getvalue()
+                self.assertIn("Project 'hello_wrld' not found.", stderr_output)
+                self.assertIn(
+                    "Did you mean: 'hello_world' (source: applications/hello_world)", stderr_output
+                )
+
+        # Test with a completely different name
+        with self.assertRaises(SystemExit):
+            with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+                self.cli._find_project("nonexistent")
+                stderr_output = mock_stderr.getvalue()
+                self.assertIn("Project 'nonexistent' not found.", stderr_output)
+                self.assertIn(
+                    "Did you mean: 'hello_world' (source: applications/hello_world)", stderr_output
+                )
+
+    @patch("utilities.cli.util.run_command")
+    def test_lint_command(self, mock_run_command):
+        """Test the lint command parsing"""
+        mock_run_command.return_value = None
+
+        args = self.cli.parser.parse_args("lint test/path --fix --install-dependencies".split())
+        self.assertEqual(args.command, "lint")
+        self.assertEqual(args.path, "test/path")
+        self.assertTrue(args.fix)
+        self.assertTrue(args.install_dependencies)
+
+        # Call the function to verify it's called with correct args
+        args.func(args)
+        # Verify that run_command was called at least once
+        mock_run_command.assert_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utilities/cli/tests/test_cli.py
+++ b/utilities/cli/tests/test_cli.py
@@ -43,11 +43,7 @@ class TestHoloHubCLI(unittest.TestCase):
         # Mock project data with some similar names
         self.cli.projects = [
             {"project_name": "hello_world", "metadata": {"language": "cpp"}},
-            {
-                "project_name": "hello_world_python",
-                "metadata": {"language": "python"},
-                "source_folder": "applications/hello_world_python",
-            },
+            {"project_name": "hello_world_python", "metadata": {"language": "python"}},
             {"project_name": "hello_world_cpp", "source_folder": "applications/hello_world_cpp"},
             {
                 "project_name": "hello_world_advanced",
@@ -65,17 +61,9 @@ class TestHoloHubCLI(unittest.TestCase):
         subparsers = [action for action in parser._actions if action.dest == "command"]
         self.assertEqual(len(subparsers), 1)
         # Check for some key commands
-        for x in [
-            "build-container",
-            "run-container",
-            "build",
-            "run",
-            "list",
-            "lint",
-            "setup",
-            "install",
-        ]:
-            self.assertIn(x, subparsers[0].choices)
+        cmds = "build-container run-container build run list lint setup install"
+        for cmd in cmds.split():
+            self.assertIn(cmd, subparsers[0].choices)
 
     @patch("utilities.cli.holohub.HoloHubCLI._find_project")
     @patch("utilities.cli.holohub.HoloHubContainer")

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -295,6 +295,11 @@ def format_long_command(cmd: List[str], max_line_length: int = 80) -> str:
     if not cmd:
         return ""
 
+    # Check if total command length exceeds max length
+    total_length = sum(len(arg) + 1 for arg in cmd) - 1
+    if total_length <= max_line_length:
+        return " ".join(cmd)
+
     # Start with the first command
     formatted = cmd[0]
     current_line = cmd[0]

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -25,6 +25,48 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 
 
+class Color:
+    """Utility class for terminal color formatting"""
+
+    # ANSI color codes
+    RED = "\033[31m"
+    GREEN = "\033[32m"
+    YELLOW = "\033[33m"
+    BLUE = "\033[34m"
+    CYAN = "\033[36m"
+    WHITE = "\033[37m"
+
+    # Text attributes
+    BOLD = "\033[1m"
+    RESET = "\033[0m"
+
+    @staticmethod
+    def format(text: str, color: str, bold: bool = False) -> str:
+        """Format text with color and optional bold attribute"""
+        result = color
+        if bold:
+            result += Color.BOLD
+        result += text + Color.RESET
+        return result
+
+    @staticmethod
+    def _create_color_method(color_code: str):
+        """Create a color method for the given color code"""
+
+        def color_method(text: str, bold: bool = False) -> str:
+            return Color.format(text, color_code, bold)
+
+        return color_method
+
+    # Create color methods dynamically
+    red = _create_color_method(RED)
+    green = _create_color_method(GREEN)
+    yellow = _create_color_method(YELLOW)
+    blue = _create_color_method(BLUE)
+    cyan = _create_color_method(CYAN)
+    white = _create_color_method(WHITE)
+
+
 # Utility Functions
 def get_timestamp() -> str:
     """Get current timestamp in the format used by the bash script"""
@@ -33,7 +75,9 @@ def get_timestamp() -> str:
 
 def fatal(message: str) -> None:
     """Print fatal error and exit with backtrace"""
-    print(f"\033[31m{get_timestamp()} [FATAL] \033[0m{message}", file=sys.stderr)
+    print(
+        f"{Color.red(get_timestamp())} {Color.red('[FATAL]', bold=True)} {message}", file=sys.stderr
+    )
     print("\nBacktrace: ...", file=sys.stderr)
     traceback.print_list(traceback.extract_stack()[-3:], file=sys.stderr)
     sys.exit(1)
@@ -45,10 +89,12 @@ def run_command(
     """Run a shell command and handle errors"""
     cmd_str = format_long_command(cmd) if dry_run else " ".join(str(x) for x in cmd)
     if dry_run:
-        print(f"\033[34m{get_timestamp()} \033[36m[dryrun] \033[37m$ \033[32m{cmd_str}\033[0m")
+        print(
+            f"{Color.blue(get_timestamp())} {Color.cyan('[dryrun]')} {Color.white('$')} {Color.green(cmd_str)}"
+        )
         return subprocess.CompletedProcess(cmd, 0)
 
-    print(f"\033[34m{get_timestamp()} \033[37m$ \033[32m{cmd_str}\033[0m")
+    print(f"{Color.blue(get_timestamp())} {Color.white('$')} {Color.green(cmd_str)}")
     try:
         return subprocess.run(cmd, check=check, **kwargs)
     except subprocess.CalledProcessError as e:

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -288,3 +288,27 @@ def format_long_command(cmd: List[str], max_line_length: int = 80) -> str:
             current_line += " " + arg
 
     return formatted
+
+
+def levenshtein_distance(s1: str, s2: str) -> int:
+    """Calculate the Levenshtein distance between two strings."""
+    s1 = s1.lower()
+    s2 = s2.lower()
+
+    if len(s1) < len(s2):
+        return levenshtein_distance(s2, s1)
+
+    if len(s2) == 0:
+        return len(s1)
+
+    previous_row = range(len(s2) + 1)
+    for i, c1 in enumerate(s1):
+        current_row = [i + 1]
+        for j, c2 in enumerate(s2):
+            insertions = previous_row[j + 1] + 1
+            deletions = current_row[j] + 1
+            substitutions = previous_row[j] + (c1 != c2)
+            current_row.append(min(insertions, deletions, substitutions))
+        previous_row = current_row
+
+    return previous_row[-1]


### PR DESCRIPTION
- unified the msg color logic
- improved error msg when project name not found:
```bash
./holohub build-container holocht
2025-04-17 12:14:44 [FATAL] Project 'holocht' not found.
Did you mean: 'holochat' (source: /Users/Documents/holohub/applications/holochat)


```
- add some tests for the cli class
- dryrun print command shouldn't break short commands (length <= max allowed)