### PR TITLE
bump application `cvcuda_basic` to the latest CV-CUDA version (For NumPy 2.x compatibility)

### DIFF
--- a/applications/cvcuda_basic/Dockerfile
+++ b/applications/cvcuda_basic/Dockerfile
@@ -26,51 +26,39 @@ ARG GPU_TYPE
 ############################################################
 # CV-CUDA Downloader
 ############################################################
-FROM ${BASE_IMAGE} as cvcuda-downloader
+FROM ${BASE_IMAGE} as cvcuda-install
 
-ARG GCC_VERSION=11
-ARG CVCUDA_TAG=v0.7.0-beta
 ARG DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /opt/nvidia
 
-# install gcc-11, g++-11
-# proper checkout of CV-CUDA stubs also requires git-lfs
-RUN apt update \
-    && apt install --no-install-recommends -y \
-      software-properties-common="0.99.*" \
-      git-lfs
-
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y
-RUN apt install -y gcc-${GCC_VERSION} g++-${GCC_VERSION}
-
-# download CV-CUDA
-RUN git clone --branch ${CVCUDA_TAG} --depth 1 https://github.com/CVCUDA/CV-CUDA \
-    && cd CV-CUDA \
-    && git submodule update --init
-
-############################################################
-# CV-CUDA Builder
-############################################################
-
-FROM cvcuda-downloader as cvcuda-builder
-WORKDIR /opt/nvidia/CV-CUDA
-
-# compile CV-CUDA
-RUN bash ./ci/build.sh
-
-# create and install the Debian packages
-# (skip cvcuda-tests as it requires an additional python3-pytest dependency)
-RUN cd build-rel \
-    && cpack -G DEB . \
-    && rm cvcuda-tests*.deb \
-    && dpkg -i cvcuda*.deb \
-    && find . -name "*.whl" -exec pip install {} \;
+# Detect architecture and install appropriate CV-CUDA wheel
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        # install Python package for x86_64
+        pip install https://github.com/CVCUDA/CV-CUDA/releases/download/v0.14.0-beta/cvcuda_cu12-0.14.0-cp310.cp311.cp38.cp39-cp310.cp311.cp38.cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl && \
+        # Download and install C++ library for x86_64
+        curl -LO https://github.com/CVCUDA/CV-CUDA/releases/download/v0.14.0-beta/cvcuda-lib-0.14.0-cuda12-x86_64-linux.deb && curl -LO https://github.com/CVCUDA/CV-CUDA/releases/download/v0.14.0-beta/cvcuda-dev-0.14.0-cuda12-x86_64-linux.deb && \
+        dpkg -i cvcuda-lib-0.14.0-cuda12-x86_64-linux.deb && \
+        dpkg -i cvcuda-dev-0.14.0-cuda12-x86_64-linux.deb && \
+        rm cvcuda-lib-0.14.0-cuda12-x86_64-linux.deb && \
+        rm cvcuda-dev-0.14.0-cuda12-x86_64-linux.deb; \
+    else \
+        # install Python package for aarch64
+        pip install https://github.com/CVCUDA/CV-CUDA/releases/download/v0.14.0-beta/cvcuda_cu12-0.14.0-cp310.cp311.cp38.cp39-cp310.cp311.cp38.cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl && \
+        # Download and install C++ library for aarch64
+        curl -LO https://github.com/CVCUDA/CV-CUDA/releases/download/v0.14.0-beta/cvcuda-lib-0.14.0-cuda12-aarch64-linux.deb && \
+        curl -LO https://github.com/CVCUDA/CV-CUDA/releases/download/v0.14.0-beta/cvcuda-dev-0.14.0-cuda12-aarch64-linux.deb && \
+        dpkg -i cvcuda-lib-0.14.0-cuda12-aarch64-linux.deb && \
+        dpkg -i cvcuda-dev-0.14.0-cuda12-aarch64-linux.deb && \
+        rm cvcuda-lib-0.14.0-cuda12-aarch64-linux.deb && \
+        rm cvcuda-dev-0.14.0-cuda12-aarch64-linux.deb; \
+    fi
 
 ############################################################
 # Base (final)
 ############################################################
-FROM cvcuda-builder as base
+FROM cvcuda-install
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
This MR updates CV-CUDA in the `cvcuda_basic` example from 0.7.0 to the latest 0.14.0 release.

We are now able to install the C++ libs via .deb packages and Python packages via pre-built wheels from the release page. 

The CV-CUDA example started failing with nightly testing of the upcoming Holscan SDK release. This was tracked down to incompatibility with CV-CUDA<0.11 with NumPy>=2.0 due to an older version of pybind11 used for CV-CUDA at that time. For this current release of CV-CUDA, I verified that the Python app runs when NumPy 2.2.4 is installed in the environment.


