### PR TITLE
Consistent Application Naming

### DIFF
--- a/applications/asr_to_llm/README.md
+++ b/applications/asr_to_llm/README.md
@@ -1,4 +1,4 @@
-# Real-time ASR to local-LLM
+# Real-time Riva ASR to local-LLM
 
 This application streams microphone input to [NVIDIA Riva](https://www.nvidia.com/en-us/ai-data-science/products/riva/) Automatic Speech Recognition (ASR), which once the user specifies they are done speaking, passes the transcribed text to an LLM running locally that then summarizes this text.
 

--- a/applications/asr_to_llm/metadata.json
+++ b/applications/asr_to_llm/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Riva ASR to local-LLM",
+		"name": "Real-time Riva ASR to local-LLM",
 		"authors": [
 			{
 				"name": "Nigel Nelson",

--- a/applications/body_pose_estimation/README.md
+++ b/applications/body_pose_estimation/README.md
@@ -1,4 +1,5 @@
-# Body Pose Estimation App
+# Body Pose Estimation
+
 <div align="center">
     <img src="./docs/1.png" width="300" height="375">
     <img src="./docs/2.png" width="300" height="375">

--- a/applications/colonoscopy_segmentation/metadata.json
+++ b/applications/colonoscopy_segmentation/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Colonoscopy segmentation",
+		"name": "Colonoscopy Polyp Segmentation",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/cuda_quantum/README.md
+++ b/applications/cuda_quantum/README.md
@@ -1,4 +1,4 @@
-# Hybrid-Computing Sample App - CUDA Quantum Variational Quantum Eigensolver (VQE) Application
+# CUDA Quantum Variational Quantum Eigensolver (VQE)
 
 ## Variational Quantum Eigensolver (VQE)
 The Variational Quantum Eigensolver (VQE) is a quantum algorithm designed to approximate the ground state energy of quantum systems. This energy, represented by what is called the Hamiltonian of the system, is central to multiple disciplines, including drug discovery, material science, and condensed matter physics. The goal of VQE is to find the state that minimizes the expectation value of this Hamiltonian, which corresponds to the ground state energy.

--- a/applications/cuda_quantum/metadata.json
+++ b/applications/cuda_quantum/metadata.json
@@ -1,6 +1,6 @@
 {
     "application": {
-        "name": "Cuda Quantum",
+        "name": "CUDA Quantum Variational Quantum Eigensolver (VQE)",
         "authors": [
             {
                 "name": "Sean Huver",

--- a/applications/cunumeric_integration/README.md
+++ b/applications/cunumeric_integration/README.md
@@ -1,4 +1,4 @@
-# Calculate Power Spectral Density with Holoscan and cuNumeric
+#  Power Spectral Density with cuNumeric
 
 [cuNumeric](https://github.com/nv-legate/cunumeric) is an drop-in replacement for NumPy that aims to provide a distributed and accelerated drop-in replacement for the NumPy API on top of the [Legion](https://legion.stanford.edu/) runtime. It works best for programs that have very large arrays of data that can't fit in the the memory of a single GPU or node.
 

--- a/applications/cvcuda_basic/README.md
+++ b/applications/cvcuda_basic/README.md
@@ -1,4 +1,4 @@
-# Simple CV-CUDA application
+# Simple CV-CUDA
 
 This application demonstrates seamless interoperability between Holoscan tensors and CV-CUDA tensors. The image processing pipeline is just a simple flip of the video orientation.
 

--- a/applications/cvcuda_basic/cpp/metadata.json
+++ b/applications/cvcuda_basic/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "CV-CUDA: Basic Interoperability",
+		"name": "Simple CV-CUDA",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/cvcuda_basic/python/metadata.json
+++ b/applications/cvcuda_basic/python/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "CV-CUDA: Basic Interoperability",
+		"name": "Simple CV-CUDA",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/dds/dds_video/README.md
+++ b/applications/dds/dds_video/README.md
@@ -1,4 +1,4 @@
-# DDS Video Application
+# DDS Video: Real-time Video Streaming with RTI Connext
 
 The DDS Video application demonstrates how video frames can be written to or
 read from a DDS databus in order to provide flexible integration between

--- a/applications/dds/dds_video/metadata.json
+++ b/applications/dds/dds_video/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "DDS Video",
+		"name": "DDS Video: Real-time Video Streaming with RTI Connext",
 		"authors": [
 			{
 				"name": "Ian Stewart",

--- a/applications/deltacast_transmitter/README.md
+++ b/applications/deltacast_transmitter/README.md
@@ -1,4 +1,4 @@
-# Deltacast transmitter
+# Deltacast Videomaster Transmitter
 
 This application demonstrates the use of videomaster_transmitter to transmit a video stream through a dedicated IO device.
 

--- a/applications/deltacast_transmitter/cpp/metadata.json
+++ b/applications/deltacast_transmitter/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Videomaster transmitter example",
+		"name": "Deltacast Videomaster Transmitter",
 		"authors": [
 			{
 				"name": "Laurent Radoux",

--- a/applications/deltacast_transmitter/python/metadata.json
+++ b/applications/deltacast_transmitter/python/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Videomaster transmitter example",
+		"name": "Deltacast Videomaster Transmitter",
 		"authors": [
 			{
 				"name": "Pierre PERICK",

--- a/applications/depth_anything_v2/README.md
+++ b/applications/depth_anything_v2/README.md
@@ -1,4 +1,5 @@
 # Depth Anything V2
+
 <div align="center">
     <img src="./docs/depth.gif" width="500" height="363">
 </div>

--- a/applications/distributed/grpc/grpc_endoscopy_tool_tracking/README.md
+++ b/applications/distributed/grpc/grpc_endoscopy_tool_tracking/README.md
@@ -1,4 +1,4 @@
-# Endoscopy Tool Tracking Application with gRPC
+# Distributed Endoscopy Tool Tracking with gRPC Streaming
 
 This application demonstrates how to offload heavy workloads to a remote Holoscan application using gRPC.
 

--- a/applications/distributed/grpc/grpc_endoscopy_tool_tracking/cpp/metadata.json
+++ b/applications/distributed/grpc/grpc_endoscopy_tool_tracking/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "gRPC-streaming Endoscopy Tool Tracking",
+		"name": "Distributed Endoscopy Tool Tracking with gRPC Streaming",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/distributed/grpc/grpc_endoscopy_tool_tracking/python/metadata.json
+++ b/applications/distributed/grpc/grpc_endoscopy_tool_tracking/python/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "gRPC-streaming Endoscopy Tool Tracking",
+		"name": "Distributed Endoscopy Tool Tracking with gRPC Streaming",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/distributed/grpc/grpc_h264_endoscopy_tool_tracking/README.md
+++ b/applications/distributed/grpc/grpc_h264_endoscopy_tool_tracking/README.md
@@ -1,4 +1,4 @@
-# H.264 Endoscopy Tool Tracking Application with gRPC
+# Distributed H.264 Endoscopy Tool Tracking with gRPC Streaming
 
 This application demonstrates how to offload heavy workloads to a remote Holoscan application using gRPC.
 

--- a/applications/distributed/grpc/grpc_h264_endoscopy_tool_tracking/cpp/metadata.json
+++ b/applications/distributed/grpc/grpc_h264_endoscopy_tool_tracking/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "gRPC-streaming H.264 Endoscopy Tool Tracking Distributed",
+		"name": "Distributed H.264 Endoscopy Tool Tracking with gRPC Streaming",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/distributed/ucx/ucx_endoscopy_tool_tracking/README.md
+++ b/applications/distributed/ucx/ucx_endoscopy_tool_tracking/README.md
@@ -1,4 +1,4 @@
-## Distributed Endoscopy Tool Tracking Application
+# UCX-based Distributed Endoscopy Tool Tracking 
 
 Digital endoscopy is a key technology for medical screenings and minimally invasive surgeries. Using real-time AI workflows to process and analyze the video signal produced by the endoscopic camera, this technology helps medical professionals with anomaly detection and measurements, image enhancements, alerts, and analytics.
 
@@ -13,7 +13,7 @@ The Distributed Endoscopy Tool Tracking application provides an example of how a
 The Distributed Endoscopy Tool Tracking application is very similar to the [Endoscopy Tool Tracking application](../../../endoscopy_tool_tracking/) but divides all operators into three fragments as depicted below.
 This allows fragments to run on different systems. For example, one can run the *Video Input Fragment* and the *Visualization Fragment* on a radiology workstation while the *Inference Fragment* runs on a more powerful system with multiple GPUs. Refer to the [Holoscan SDK User Guide](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_core.html) for more information on distributed applications.
 
-### Video Stream Replayer Input
+## Video Stream Replayer Input
 ![](docs/workflow_tool_tracking_replayer.png)<br>
 Fig. 2 Tool tracking application workflow with replay from file
 
@@ -31,9 +31,9 @@ To start the the Dev Container, run the following command from the root director
 ./dev_container vscode
 ```
 
-### VS Code Launch Profiles
+## VS Code Launch Profiles
 
-#### C++
+### C++
 
 There are several launch profiles configured for the C++ version of this application:
 
@@ -44,7 +44,7 @@ There are several launch profiles configured for the C++ version of this applica
 5. **(compound) ucx_endoscopy_tool_tracking/cpp**: Starts #2, #3, #4 in sequence.
 
 
-#### Python
+### Python
 
 There are several launch profiles configured for this application:
 

--- a/applications/distributed/ucx/ucx_endoscopy_tool_tracking/cpp/README.md
+++ b/applications/distributed/ucx/ucx_endoscopy_tool_tracking/cpp/README.md
@@ -1,4 +1,4 @@
-# Distributed Endoscopy Tool Tracking
+# UCX-based Distributed Endoscopy Tool Tracking (C++)
 
 This application is similar to the Endoscopy Tool Tracking application, but the distributed version divides the application into three fragments:
 
@@ -8,18 +8,18 @@ This application is similar to the Endoscopy Tool Tracking application, but the 
 
 Based on an LSTM (long-short term memory) stateful model, these applications demonstrate the use of custom components for tool tracking, including composition and rendering of text, tool position, and mask (as heatmap) combined with the original video stream.
 
-### Requirements
+## Requirements
 
 The provided applications are configured to use a pre-recorded endoscopy video (replayer).
 
-### Data
+## Data
 
 [📦️ (NGC) Sample App Data for AI-based Endoscopy Tool Tracking](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/clara-holoscan/resources/holoscan_endoscopy_sample_data)
 
 The data is automatically downloaded and converted to the correct format when building the application.
 If you want to manually convert the video data, please refer to the instructions for using the [convert_video_to_gxf_entities](https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/scripts#convert_video_to_gxf_entitiespy) script.
 
-### Run Instructions
+## Run Instructions
 
 
 ```sh

--- a/applications/distributed/ucx/ucx_endoscopy_tool_tracking/cpp/metadata.json
+++ b/applications/distributed/ucx/ucx_endoscopy_tool_tracking/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Endoscopy Tool Tracking Distributed",
+		"name": "UCX-based Distributed Endoscopy Tool Tracking",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/distributed/ucx/ucx_endoscopy_tool_tracking/python/README.md
+++ b/applications/distributed/ucx/ucx_endoscopy_tool_tracking/python/README.md
@@ -1,4 +1,4 @@
-# Distributed Endoscopy Tool Tracking
+# UCX-based Distributed Endoscopy Tool Tracking (Python)
 
 This application is similar to the Endoscopy Tool Tracking application, but the distributed version divides the application into three fragments:
 
@@ -8,19 +8,19 @@ This application is similar to the Endoscopy Tool Tracking application, but the 
 
 Based on an LSTM (long-short term memory) stateful model, these applications demonstrate the use of custom components for tool tracking, including composition and rendering of text, tool position, and mask (as heatmap) combined with the original video stream.
 
-### Requirements
+## Requirements
 
 - Python 3.8+
 - The provided applications are configured to use a pre-recorded endoscopy video (replayer). 
 
-### Data
+## Data
 
 [📦️ (NGC) Sample App Data for AI-based Endoscopy Tool Tracking](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/clara-holoscan/resources/holoscan_endoscopy_sample_data)
 
 The data is automatically downloaded and converted to the correct format when building the application.
 If you want to manually convert the video data, please refer to the instructions for using the [convert_video_to_gxf_entities](https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/scripts#convert_video_to_gxf_entitiespy) script.
 
-### Run Instructions
+## Run Instructions
 
 ```sh
 # Start the application with all three fragments

--- a/applications/distributed/ucx/ucx_endoscopy_tool_tracking/python/metadata.json
+++ b/applications/distributed/ucx/ucx_endoscopy_tool_tracking/python/metadata.json
@@ -1,7 +1,7 @@
 {
 	"application": {
-		"name": "Endoscopy Tool Tracking Distributed",
-		"authors": [
+			"name": "Endoscopy Tool Tracking Distributed",
+			"authors": [
 			{
 				"name": "Holoscan Team",
 				"affiliation": "NVIDIA"

--- a/applications/ehr_query_llm/fhir/README.md
+++ b/applications/ehr_query_llm/fhir/README.md
@@ -1,4 +1,4 @@
-# FHIR Client Application for Retrieving and posting FHIR Resources
+# FHIR Client for Retrieving and Posting FHIR Resources
 
 This is an application to interface with a FHIR server to retrieve or post FHIR resources.
 

--- a/applications/ehr_query_llm/fhir/metadata.json
+++ b/applications/ehr_query_llm/fhir/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "FHIR Client App",
+		"name": "FHIR Client for Retrieving and Posting FHIR Resources",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/ehr_query_llm/lmm/README.md
+++ b/applications/ehr_query_llm/lmm/README.md
@@ -1,9 +1,9 @@
-## EHR Agent Framework 
+# EHR Agent Framework
 
 The EHR Agent Framework is designed to handle and interact with EHR (Electronic Health Records) and it provides a modular and extensible system for handling various types of queries through specialized agents, with robust error handling and performance optimization features.
 
 
-### Table of Contents
+## Table of Contents
 
 - [Agent Framework overview](#agent-framework-overview)
 - [Setup Instructions](#setup-instructions)

--- a/applications/endoscopy_out_of_body_detection/README.md
+++ b/applications/endoscopy_out_of_body_detection/README.md
@@ -1,4 +1,4 @@
-# Endoscopy Out of Body Detection Application
+# Endoscopy Out of Body Detection
 
 ![Endoscopy Out of Body Detection Workflow](./endoscopy_out_of_body_detection.png)
 

--- a/applications/endoscopy_out_of_body_detection/cpp/metadata.json
+++ b/applications/endoscopy_out_of_body_detection/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Endoscopy Out of Body Detection Pipeline",
+		"name": "Endoscopy Out of Body Detection",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/endoscopy_out_of_body_detection/python/metadata.json
+++ b/applications/endoscopy_out_of_body_detection/python/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Endoscopy Out of Body Detection Pipeline",
+		"name": "Endoscopy Out of Body Detection",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/endoscopy_tool_tracking/README.md
+++ b/applications/endoscopy_tool_tracking/README.md
@@ -1,4 +1,4 @@
-## Endoscopy Tool Tracking Application
+# Endoscopy Tool Tracking
 
 Digital endoscopy is a key technology for medical screenings and minimally invasive surgeries. Using real-time AI workflows to process and analyze the video signal produced by the endoscopic camera, this technology helps medical professionals with anomaly detection and measurements, image enhancements, alerts, and analytics.
 

--- a/applications/florence-2-vision/README.md
+++ b/applications/florence-2-vision/README.md
@@ -1,4 +1,4 @@
-# 📷🤖 Florence-2
+# Florence-2: Advancing a Unified Representation for a Variety of Vision Tasks
 
 This application demonstrates how to run the [Florence-2](https://arxiv.org/abs/2311.06242) models on a live video feed with the possibility of changing the task and optional prompt via a QT UI.
 

--- a/applications/florence-2-vision/metadata.json
+++ b/applications/florence-2-vision/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Florence-2",
+		"name": "Florence-2: Advancing a Unified Representation for a Variety of Vision Tasks",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/fm_asr/README.md
+++ b/applications/fm_asr/README.md
@@ -1,4 +1,5 @@
-# FM ASR
+# FM Radio Automatic Speech Recognition
+
 This project is proof-of-concept demo featuring the combination of real-time, low-level signal processing and deep learning inference. It currently supports the [RTL-SDR](https://www.rtl-sdr.com/). Specifically, this project demonstrates the demodulation, downsampling, and automatic transcription of live, civilian FM radio broadcasts. The pipeline architecture is shown in the figure below. 
 
 ![Pipeline Architecture](docs/images/pipeline_arch.png)
@@ -8,19 +9,19 @@ The primary pipeline segments are written in Python. Future improvements will in
 This project leverages NVIDIA's [Holoscan SDK](https://github.com/nvidia-holoscan/holoscan-sdk) for performant GPU pipelines, cuSignal package for GPU-accelerated signal processing, and the [RIVA SDK](https://docs.nvidia.com/deeplearning/riva/user-guide/docs/overview.html) for high accuracy automatic speech recognition (ASR).
 
 ## Table of Contents
-- [Install](#install)    
-    - [Local Sensor](#local-sensor---basic-configuration)
-        - [x86](#local-sensor---basic-configuration)
-        - [Jetson - TODO](#local-jetson-container)
-    - [Remote Sensor - TODO](#remote-sensor---network-in-the-loop)
-        - [x86](#remote-sensor---network-in-the-loop)
-        - [Jetson](#remote-jetson-containers)  
-    - [Bare Metal - TODO](#bare-metal-install)  
-- [Startup](#startup)
+- [FM ASR](#fm-asr)
+  - [Table of Contents](#table-of-contents)
+  - [Install](#install)
+    - [Local Sensor - Basic Configuration](#local-sensor---basic-configuration)
+      - [Local Jetson Container](#local-jetson-container)
+    - [Remote Sensor - Network in the Loop](#remote-sensor---network-in-the-loop)
+    - [Bare Metal Install](#bare-metal-install)
+  - [Startup](#startup)
     - [Scripted Launch](#scripted-launch)
     - [Manual Launch](#manual-launch)
-- [Configuration Parameters](#configuration-parameters)
-- [Known Issues](#known-issues)
+    - [Initialize and Start the Riva Service](#initialize-and-start-the-riva-service)
+  - [Configuration Parameters](#configuration-parameters)
+      - [Known Issues](#known-issues)
 
 ## Install
 To begin installation, clone this repository using the following:

--- a/applications/fm_asr/metadata.json
+++ b/applications/fm_asr/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "FM-ASR",
+		"name": "FM Radio Automatic Speech Recognition",
 		"authors": [
 			{
 				"name": "Joshua Martinez",

--- a/applications/h264/h264_endoscopy_tool_tracking/README.md
+++ b/applications/h264/h264_endoscopy_tool_tracking/README.md
@@ -1,4 +1,4 @@
-# H.264 Endoscopy Tool Tracking Application
+# H.264 Endoscopy Tool Tracking
 
 The application showcases how to use H.264 video source as input to and output
 from the Holoscan pipeline. This application is a modified version of Endoscopy

--- a/applications/h264/h264_video_decode/README.md
+++ b/applications/h264/h264_video_decode/README.md
@@ -1,4 +1,4 @@
-# H.264 Video Decode Reference Application
+# H.264 Video Decode
 
 This is a minimal reference application demonstrating usage of H.264 video
 decode operators. This application makes use of H.264 elementary stream reader

--- a/applications/h264/h264_video_decode/cpp/metadata.json
+++ b/applications/h264/h264_video_decode/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
   "application": {
-    "name": "H.264 Video Decode Reference Application",
+    "name": "H.264 Video Decode",
     "authors": [
       {
         "name": "Holoscan Team",

--- a/applications/h264/h264_video_decode/python/metadata.json
+++ b/applications/h264/h264_video_decode/python/metadata.json
@@ -1,6 +1,6 @@
 {
   "application": {
-    "name": "H.264 Video Decode Reference Application",
+    "name": "H.264 Video Decode",
     "authors": [
       {
         "name": "Holoscan Team",

--- a/applications/high_speed_endoscopy/README.md
+++ b/applications/high_speed_endoscopy/README.md
@@ -1,4 +1,4 @@
-## High Speed Endoscopy Application
+# High Speed Endoscopy
 
 The high speed endoscopy application showcases how high resolution cameras can be used to capture the scene, post-processed on GPU, and displayed at high frame rate.
 

--- a/applications/hyperspectral_segmentation/metadata.json
+++ b/applications/hyperspectral_segmentation/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Hyperspectral image segmentation",
+		"name": "Hyperspectral Image Segmentation",
 		"authors": [
 			{
 				"name": "Lars Doorenbos",

--- a/applications/imaging_ai_segmentator/README.md
+++ b/applications/imaging_ai_segmentator/README.md
@@ -1,4 +1,4 @@
-# AI Segmentation using MONAI re-trained TotalSegmentator model and CT DICOM images as input
+# Imaging AI Whole Body Segmentation
 
 This application uses MONAI re-trained TotalSegmentator model to segment 104 body parts from a DICOM series of a CT scan. It is implemented using Holohub DICOM processing operators and PyTorch inference operators.
 

--- a/applications/matlab_gpu_coder/matlab_beamform/metadata.json
+++ b/applications/matlab_gpu_coder/matlab_beamform/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "matlab_beamform",
+		"name": "Ultrasound Beamforming with MATLAB GPU Coder",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/matlab_gpu_coder/matlab_image_processing/metadata.json
+++ b/applications/matlab_gpu_coder/matlab_image_processing/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "matlab_image_processing",
+		"name": "Image Processing with MATLAB GPU Coder",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/monai_endoscopic_tool_seg/README.md
+++ b/applications/monai_endoscopic_tool_seg/README.md
@@ -1,4 +1,5 @@
-# Endoscopic Tool Segmentation from MONAI Model Zoo
+# Endoscopy Tool Segmentation from MONAI Model Zoo
+
 This endoscopy tool segmentation application runs the MONAI Endoscopic Tool Segmentation from [MONAI Model Zoo](https://github.com/Project-MONAI/model-zoo/tree/dev/models/endoscopic_tool_segmentation).
 
 

--- a/applications/monai_endoscopic_tool_seg/metadata.json
+++ b/applications/monai_endoscopic_tool_seg/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Endoscopy Tool Segmentation from MONAI Model Zoo Application",
+		"name": "Endoscopy Tool Segmentation from MONAI Model Zoo",
 		"authors": [
 			{
 				"name": "Jin Li",

--- a/applications/multiai_endoscopy/README.md
+++ b/applications/multiai_endoscopy/README.md
@@ -1,4 +1,5 @@
-# Multi AI Application with SSD Detection and MONAI Endoscopic Tool Segmentation 
+# Multi AI SSD Detection and MONAI Endoscopic Tool Segmentation
+
 In this application, we show how to build a Multi AI application with detection and segmentation models, write postprocessing operators using CuPy and NumPy in Python tensor interop and [MatX library (An efficient C++17 GPU numerical computing library with Python-like syntax)](https://github.com/NVIDIA/MatX) in C++ tensor interop, and pass multiple tensors from postprocessing to Holoviz.
 
 ![](images/app_multiai_endoscopy.png)<br>

--- a/applications/multiai_endoscopy/cpp/metadata.json
+++ b/applications/multiai_endoscopy/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Multi AI SSD Detection MONAI Endoscopic Tool Segmentation Application",
+		"name": "Multi AI SSD Detection and MONAI Endoscopic Tool Segmentation",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/multiai_endoscopy/python/metadata.json
+++ b/applications/multiai_endoscopy/python/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Multi AI SSD Detection MONAI Endoscopic Tool Segmentation Application",
+		"name": "Multi AI SSD Detection and MONAI Endoscopic Tool Segmentation",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/multiai_ultrasound/README.md
+++ b/applications/multiai_ultrasound/README.md
@@ -1,4 +1,4 @@
-## Multi AI Ultrasound Application
+# Multi AI Ultrasound
 
 To run multiple inference pipelines in a single application, the Multi AI operators (inference and postprocessor) use APIs from the Holoscan Inference module to extract data, initialize and execute the inference workflow, process, and transmit data for visualization.
 

--- a/applications/multiai_ultrasound/cpp/metadata.json
+++ b/applications/multiai_ultrasound/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "MultiAI Ultrasound",
+		"name": "Multi-AI Ultrasound",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/multiai_ultrasound/python/metadata.json
+++ b/applications/multiai_ultrasound/python/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "MultiAI Ultrasound",
+		"name": "Multi-AI Ultrasound",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/network_radar_pipeline/README.md
+++ b/applications/network_radar_pipeline/README.md
@@ -1,5 +1,6 @@
-# Network Radar Pipeline
-The Network Radar Pipeline demonstrates signal processing on data streamed via packets over a network. It showcases the use of both the Advanced Network Operator and Basic Network Operator to send or receive data, combined with the signal processing operators implemented in the Simple Radar Pipeline application.
+# Radar Signal Processing over Network
+
+The Network Radar application demonstrates signal processing on data streamed via packets over a network. It showcases the use of both the Advanced Network Operator and Basic Network Operator to send or receive data, combined with the signal processing operators implemented in the Simple Radar Pipeline application.
 
 Using the GPUDirect capabilities afforded by the Advanced Network Operator, this pipeline has been tested up to 100 Gbps (Tx/Rx) using a ConnectX-7 NIC and A30 GPU.
 

--- a/applications/network_radar_pipeline/cpp/metadata.json
+++ b/applications/network_radar_pipeline/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Networked Radar Pipeline",
+		"name": "Radar Signal Processing over Network",
 		"authors": [
 			{
 				"name": "Dylan Eustice",

--- a/applications/nvidia_nim/nvidia_nim_chat/metadata.json
+++ b/applications/nvidia_nim/nvidia_nim_chat/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Chat with NVIDIA Inference Microservice (NIM)",
+		"name": "Chat with NVIDIA NIM",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/nvidia_nim/nvidia_nim_imaging/README.md
+++ b/applications/nvidia_nim/nvidia_nim_imaging/README.md
@@ -1,4 +1,4 @@
-# NVIDIA NIM Imaging with Vista-3D
+# Medical Imaging Segmentation with NVIDIA Vista-3D NIM
 
 [Vista-3D](https://build.nvidia.com/nvidia/vista-3d) is a specialized interactive foundation model for segmenting and annotating human anatomies.
 This sample application demonstrates using the Vista-3D NVIDIA Inference Microservice (NIM) in a Holoscan pipeline.

--- a/applications/nvidia_nim/nvidia_nim_imaging/metadata.json
+++ b/applications/nvidia_nim/nvidia_nim_imaging/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Imaging using NVIDIA Inference Microservice (NIM)",
+		"name": "Medical Imaging Segmentation with NVIDIA Vista-3D NIM",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/nvidia_nim/nvidia_nim_nvclip/README.md
+++ b/applications/nvidia_nim/nvidia_nim_nvclip/README.md
@@ -1,4 +1,4 @@
-# NVIDIA NV-CLIP
+# NVIDIA NV-CLIP NIM
 
 NV-CLIP is a multimodal embeddings model for image and text, and this is a sample application that shows how to use the OpenAI SDK with NVIDIA Inference Microservice (NIM). Whether you are using a NIM from [build.nvidia.com/](https://build.nvidia.com/) or [a self-hosted NIM](https://docs.nvidia.com/nim/nvclip/latest/getting-started.html#option-2-from-ngc), this sample application will work for both.
 

--- a/applications/nvidia_nim/nvidia_nim_nvclip/metadata.json
+++ b/applications/nvidia_nim/nvidia_nim_nvclip/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "NV-CLIP NIM",
+		"name": "NVIDIA NV-CLIP NIM",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/object_detection_torch/README.md
+++ b/applications/object_detection_torch/README.md
@@ -1,4 +1,4 @@
-# Object Detection Application
+# Object Detection using PyTorch Faster R-CNN
 
 This application performs object detection using frcnn resnet50 model from torchvision.
 The inference is executed using `torch` backend in `holoinfer` module in Holoscan SDK.

--- a/applications/object_detection_torch/metadata.json
+++ b/applications/object_detection_torch/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Object detection using frcnn based pytorch model in C++",
+		"name": "Object Detection using PyTorch Faster R-CNN",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/openigtlink_3dslicer/README.md
+++ b/applications/openigtlink_3dslicer/README.md
@@ -1,4 +1,4 @@
-# Holoscan SDK as an Inference Backend for 3D Slicer
+# OpenIGTLink 3D Slicer: Bidirectional Video Streaming with AI Segmentation
 
 This application demonstrates how to interface Holoscan SDK with [3D Slicer](https://www.slicer.org/), using the [OpenIGTLink protocol](http://openigtlink.org/). The application is shown in the application graph below.
 

--- a/applications/openigtlink_3dslicer/cpp/metadata.json
+++ b/applications/openigtlink_3dslicer/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "OpenIGTLink 3D Slicer",
+		"name": "OpenIGTLink 3D Slicer: Bidirectional Video Streaming with AI Segmentation",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/openigtlink_3dslicer/python/metadata.json
+++ b/applications/openigtlink_3dslicer/python/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "OpenIGTLink 3D Slicer",
+		"name": "OpenIGTLink 3D Slicer: Bidirectional Video Streaming with AI Segmentation",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/orsi/orsi_in_out_body/README.md
+++ b/applications/orsi/orsi_in_out_body/README.md
@@ -1,4 +1,4 @@
-# Orsi In - Out - Body Detection sample app
+# Orsi Academy In-Out Body Detection and Surgical Video Anonymization
 
 
 <center> <img src="./docs/anonymization.png" ></center>

--- a/applications/orsi/orsi_in_out_body/cpp/metadata.json
+++ b/applications/orsi/orsi_in_out_body/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
     "application": {
-        "name": "ORSI Academy Anonymization",
+        "name": "Orsi Academy In-Out Body Detection and Surgical Video Anonymization",
         "authors": [
             {
                 "name": "Jasper Hofman",

--- a/applications/orsi/orsi_in_out_body/python/metadata.json
+++ b/applications/orsi/orsi_in_out_body/python/metadata.json
@@ -1,6 +1,6 @@
 {
     "application": {
-        "name": "ORSI Academy Surgical Tool Segmentation, Anonymization and AR Overlay",
+        "name": "Orsi Academy In-Out Body Detection and Surgical Video Anonymization",
         "authors": [
             {
                 "name": "Jasper Hofman",

--- a/applications/orsi/orsi_multi_ai_ar/README.md
+++ b/applications/orsi/orsi_multi_ai_ar/README.md
@@ -1,6 +1,4 @@
-# Orsi Multi AI and AR sample app
-
-
+# Orsi Academy Multi AI and AR Visualization
 
 <center> <img src="./docs/multi_ai_1.png" width="650" height="400"> <img src="./docs/multi_ai_2.png" width="650" height="400"></center>
 <center> Fig. 1: Application screenshots  </center><br>

--- a/applications/orsi/orsi_multi_ai_ar/cpp/metadata.json
+++ b/applications/orsi/orsi_multi_ai_ar/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
     "application": {
-        "name": "ORSI Academy Surgical Tool Segmentation, Anonymization and AR Overlay",
+        "name": "Orsi Academy Multi AI and AR Visualization",
         "authors": [
             {
                 "name": "Jasper Hofman",

--- a/applications/orsi/orsi_multi_ai_ar/python/metadata.json
+++ b/applications/orsi/orsi_multi_ai_ar/python/metadata.json
@@ -1,6 +1,6 @@
 {
     "application": {
-        "name": "ORSI Academy Surgical Tool Segmentation, Anonymization and AR Overlay",
+        "name": "Orsi Academy Multi AI and AR Visualization",
         "authors": [
             {
                 "name": "Jasper Hofman",

--- a/applications/orsi/orsi_segmentation_ar/README.md
+++ b/applications/orsi/orsi_segmentation_ar/README.md
@@ -1,4 +1,4 @@
-# Orsi Non Organic Structure Segmentation and AR sample app
+# Orsi Academy Surgical Tool Segmentation and AR Overlay
 
 
 <center> <img src="./docs/orsi_segmentation.png" ></center>

--- a/applications/orsi/orsi_segmentation_ar/cpp/metadata.json
+++ b/applications/orsi/orsi_segmentation_ar/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
     "application": {
-        "name": "ORSI Academy Surgical Tool Segmentation and AR Overlay",
+        "name": "Orsi Academy Surgical Tool Segmentation and AR Overlay",
         "authors": [
             {
                 "name": "Jasper Hofman",

--- a/applications/orsi/orsi_segmentation_ar/python/metadata.json
+++ b/applications/orsi/orsi_segmentation_ar/python/metadata.json
@@ -1,6 +1,6 @@
 {
     "application": {
-        "name": "ORSI Academy Surgical Tool Segmentation, Anonymization and AR Overlay",
+        "name": "Orsi Academy Surgical Tool Segmentation and AR Overlay",
         "authors": [
             {
                 "name": "Jasper Hofman",

--- a/applications/orthorectification_with_optix/README.md
+++ b/applications/orthorectification_with_optix/README.md
@@ -1,4 +1,4 @@
-# HoloHub Orthorectification Application
+# GPU-Accelerated Orthorectification with NVIDIA OptiX
 
 This application is an example of utilizing the nvidia OptiX SDK via the PyOptix bindings to create per-frame orthorectified imagery. In this example, one can create a visualization of mapping frames from a drone mapping mission processed with [Open Drone Map](https://opendronemap.org/). A typical output of a mapping mission is a single merged mosaic. While this product is useful for GIS applications, it is difficult to apply algorithms on a such a large single image without incurring additional steps like image chipping. Additionally, the mosaic process introduces image artifacts which can negativley impact algorithm performance. 
 

--- a/applications/orthorectification_with_optix/python/metadata.json
+++ b/applications/orthorectification_with_optix/python/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Orthorectification with OptiX",
+		"name": "GPU-Accelerated Orthorectification with NVIDIA OptiX",
 		"authors": [
 			{
 				"name": "Brent Bartlett",

--- a/applications/prohawk_video_replayer/README.md
+++ b/applications/prohawk_video_replayer/README.md
@@ -1,4 +1,4 @@
-# Prohawk video replayer
+# ProHawk Video Replayer
 
 This application utilizes the ProHawk restoration operator along with Holoscan's Video Replayer and Holoviz operators to enhance and restore medical imagery in real-time, offering superior image quality. The user-friendly interface of the application provides a range of filter options, enabling users to dynamically select the most suitable filter for optimal results.
 

--- a/applications/prohawk_video_replayer/cpp/metadata.json
+++ b/applications/prohawk_video_replayer/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "prohawk_video_replayer",
+		"name": "ProHawk Video Replayer",
 		"authors": [
 			{
 				"name": "Tim Wooldridge",

--- a/applications/prohawk_video_replayer/python/metadata.json
+++ b/applications/prohawk_video_replayer/python/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "prohawk_video_replayer_py",
+		"name": "ProHawk Video Replayer",
 		"authors": [
 			{
 				"name": "Nigel Nelson",

--- a/applications/psd_pipeline/README.md
+++ b/applications/psd_pipeline/README.md
@@ -3,10 +3,11 @@ SPDX-FileCopyrightText: 2024 Valley Tech Systems, Inc.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-# PSD Pipeline
+# VITA 49 Power Spectral Density (PSD)
 
 ## Overview
-The PSD pipeline takes in a VITA49 data stream from the advanced network
+
+The VITA 49 Power Spectral Density (PSD) application takes in a VITA49 data stream from the advanced network
 operator, then performs an FFT, PSD, and averaging operation before
 generating a VITA 49.2 spectral data packet which gets sent to a
 destination UDP socket.

--- a/applications/psd_pipeline/metadata.json
+++ b/applications/psd_pipeline/metadata.json
@@ -1,6 +1,6 @@
 {
     "application": {
-        "name": "PSD pipeline",
+        "name": "VITA 49 Power Spectral Density (PSD)",
         "authors": [
             {
                 "name": "John Moon <john.moon@vts-i.com>",

--- a/applications/pva_video_filter/README.md
+++ b/applications/pva_video_filter/README.md
@@ -1,4 +1,4 @@
-# PVA-Accelerated Image Sharpening Application
+# PVA-Accelerated Image Sharpening
 
 This application demonstrates the usage of [Programmable Vision Accelerator (PVA)](#about-pva) within a Holoscan
 application. It reads a video stream, applies a 2D unsharp mask filter and renders it via the

--- a/applications/pva_video_filter/cpp/metadata.json
+++ b/applications/pva_video_filter/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
     "application": {
-        "name": "PVA Video Filter (Unsharp Mask) Example",
+        "name": "PVA-Accelerated Image Sharpening",
         "authors": [
             {
                 "name": "Soham Sinha",

--- a/applications/realsense_visualizer/README.md
+++ b/applications/realsense_visualizer/README.md
@@ -1,4 +1,4 @@
-# RealSense Visualizer
+# Intel RealSense Camera Visualizer
 
 Visualizes frames captured from an Intel RealSense camera.
 ![](screenshot.png)<br>

--- a/applications/sam2/README.md
+++ b/applications/sam2/README.md
@@ -1,4 +1,4 @@
-# 📷 Holoscan SAM2
+# SAM 2: Segment Anything in Images and Videos
 
 This application demonstrates how to run [SAM2](https://github.com/facebookresearch/segment-anything-2) models on live video feed with the possibility of changing query points in real-time.
 

--- a/applications/sam2/metadata.json
+++ b/applications/sam2/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "sam2",
+		"name": "SAM 2: Segment Anything in Images and Videos",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/sdr_fm_demodulation/README.md
+++ b/applications/sdr_fm_demodulation/README.md
@@ -1,4 +1,4 @@
-# SDR FM Demodulation Application
+# Software Defined Radio FM Demodulation
 
 As the "Hello World" application of software defined radio developers, this demonstration highlights real-time FM demodulation, resampling, and playback on GPU with NVIDIA's Holoscan SDK. In this example, we are using an inexpensive USB-based [RTL-SDR](https://www.rtl-sdr.com/) dongle to feed complex valued Radio Frequency (RF) samples into GPU memory and use [cuSignal](https://github.com/rapidsai/cusignal) functions to perform the relevant signal processing. The main objectives of this demonstration are to:
 - Highlight developer productivity in building an end-to-end streaming application with Holoscan and existing GPU-Accelerated Python libraries

--- a/applications/simple_pdw_pipeline/README.md
+++ b/applications/simple_pdw_pipeline/README.md
@@ -1,5 +1,4 @@
-Simple PDW Pipeline
-==================================
+# Basic Pulse Description Word (PDW) Generator
 
 This is a Holoscan pipeline that shows the possibility of using Holoscan as a
 Pulse Description Word (PDW) generator. This is a process that takes in IQ
@@ -9,16 +8,14 @@ processors are used to see what is transmitting in your area, be they radio
 towers or radars.
 
 siggen.c a signal generator written in C that will transmit
-the input to this pipeline. 
+the input to this pipeline.
 
-BasicNetworkOpRx
---------------------------
+## BasicNetworkOpRx
 
 This uses the Basic Network Operator to read udp packets this operator is
-documented elsewhere. 
+documented elsewhere.
 
-PacketToTensorOp
--------------------------
+## PacketToTensorOp
 
 This converts the bytes from the Basic Network Operator into the packets used
 in the rest of the pipeline. The format of the incoming packets is a 16-bit id
@@ -26,27 +23,24 @@ followed by 8192 IQ samples each sample has the following format:
 16 bits (I)
 16 bits (Q)
 
-FFTOp
-------------------------
+## FFTOp
+
 Does what it says on the tin. Takes an FFT of the input data. Also shifts data
 so that 0 Hz is centered.
 
+## ThresholdingOp
 
-ThresholdingOp:
-------------------------
 Detects samples over a threshold and then packetizes the runs of samples that
-are above the threshold as a “pulse”.
+are above the threshold as a "pulse".
 
+## PulseDescriptiorOp
 
-PulseDescriptiorOp
-------------------------
 Takes simple statistics of input pulses. This is where I am most excited for
 future work, but that is not the point of this particular project.
 
+## PulsePrinterOp
 
-PulsePrinterOp
-----------------------
-Prints the pulse to screen. Also optionally sends packets to a BasicNetworkOpTx. 
+Prints the pulse to screen. Also optionally sends packets to a BasicNetworkOpTx.
 The transmitted network packets have the following format:
 Each of the following fields are 16bit unsigned integers
   id

--- a/applications/simple_pdw_pipeline/metadata.json
+++ b/applications/simple_pdw_pipeline/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Basic PDW Pipeline",
+		"name": "Basic Pulse Description Word (PDW) Generator",
 		"authors": [
 			{
 				"name": "Joshua Anderson",

--- a/applications/simple_radar_pipeline/cpp/README.md
+++ b/applications/simple_radar_pipeline/cpp/README.md
@@ -1,4 +1,4 @@
-# Simple Radar Pipeline Application
+# Simple Radar Pipeline
 
 This demonstration walks the developer through building a simple radar signal processing pipeline, targeted towards detecting objects, with Holoscan. In this example, we generate random radar and waveform data, passing both through:
 1. Pulse Compression

--- a/applications/simple_radar_pipeline/cpp/metadata.json
+++ b/applications/simple_radar_pipeline/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Simple Radar Pipeline in C++",
+		"name": "Simple Radar Pipeline",
 		"authors": [
 			{
 				"name": "Cliff Burdick",

--- a/applications/simple_radar_pipeline/python/README.md
+++ b/applications/simple_radar_pipeline/python/README.md
@@ -1,4 +1,4 @@
-# Simple Radar Pipeline Application
+# Simple Radar Pipeline
 
 This demonstration walks the developer through building a simple radar signal processing pipeline, targeted towards detecting objects, with Holoscan. In this example, we generate random radar and waveform data, passing both through:
 1. Pulse Compression

--- a/applications/simple_radar_pipeline/python/metadata.json
+++ b/applications/simple_radar_pipeline/python/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Simple Classical Radar Pipeline",
+		"name": "Simple Radar Pipeline",
 		"authors": [
 			{
 				"name": "Cliff Burdick",

--- a/applications/speech_to_text_llm/README.md
+++ b/applications/speech_to_text_llm/README.md
@@ -1,12 +1,12 @@
-## Speech-to-text + Large Language Model
+# Speech-to-text + Large Language Model
 
-This application transcribes an audio file using a speech-to-text model (STT), then uses a large language model (LLM) to summarize and generate new relevant information. 
+This application transcribes an audio file using a speech-to-text model (STT), then uses a large language model (LLM) to summarize and generate new relevant information.
 
-While this workflow in principle could be used for a number of domains, here we provide a healthcare specific example. A `sample.wav` file is provided which is an example of a radiology interpretation. An OpenAI whisper model is used to transform the audio into text, then an API call is made to either the GPT3.5-turbo or GPT4 LLM. 
+While this workflow in principle could be used for a number of domains, here we provide a healthcare specific example. A `sample.wav` file is provided which is an example of a radiology interpretation. An OpenAI whisper model is used to transform the audio into text, then an API call is made to either the GPT3.5-turbo or GPT4 LLM.
 
-### YAML Configuration
+## YAML Configuration
 
-The input (either audio or video file), specific Whisper model (tiny, small, medium, or large), LLM model, and directions for the LLM are all determined by the `stt_to_nlp.yaml` file. As you see from our example, the directions for the LLM are made via natural language, and can result in very different applications. 
+The input (either audio or video file), specific Whisper model (tiny, small, medium, or large), LLM model, and directions for the LLM are all determined by the `stt_to_nlp.yaml` file. As you see from our example, the directions for the LLM are made via natural language, and can result in very different applications.
 
 For our purposes we specify the directions as:
 
@@ -44,7 +44,7 @@ Suggested Follow-up Steps:
 2. For the gallbladder polyps, the patient should consult with a gastroenterologist to determine the need for further evaluation, monitoring, or possible surgical intervention. Regular ultrasound examinations may be recommended to monitor the growth of the polyps.
 ```
 
-### Run Instructions
+## Run Instructions
 
 Note: To run this application you will need to [create an OpenAI account](https://platform.openai.com/signup) and obtain your own [API key](https://platform.openai.com/account/api-keys) with active credits.
 
@@ -52,14 +52,14 @@ You should refer to the [glossary](../../README.md#Glossary) for the terms defin
 
 * (Optional) Create and use a virtual environment:
 
-  ```
+  ```bash
   python3 -m venv .venv
   source .venv/bin/activate
   ```
 
 * Install the python packages
 
-  ```
+  ```bash
   pip install -r applications/speech_to_text_llm/requirements.txt
   ```
 
@@ -70,6 +70,7 @@ You should refer to the [glossary](../../README.md#Glossary) for the terms defin
   cd applications/speech_to_text_llm 
   python3 stt_to_nlp.py
   ```
-### Sample Audio File
+  
+## Sample Audio File
 
-Please note the sample audio file included is licensed as CC-BY-4.0 International, copyright NVIDIA 2023. 
+Please note the sample audio file included is licensed as CC-BY-4.0 International, copyright NVIDIA 2023.

--- a/applications/ssd_detection_endoscopy_tools/README.md
+++ b/applications/ssd_detection_endoscopy_tools/README.md
@@ -1,4 +1,5 @@
-# SSD Detection Application
+# SSD Detection for Endoscopy Tools
+
 ## Model
 We can train the [SSD model from NVIDIA DeepLearningExamples repo]((https://github.com/NVIDIA/DeepLearningExamples/tree/master/PyTorch/Detection/SSD)) with any data of our choosing. Here for the purpose of demonstrating the deployment process, we will use a SSD model checkpoint that is only trained for the [demo video clip](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/clara-holoscan/resources/holoscan_endoscopy_sample_data). 
 

--- a/applications/ssd_detection_endoscopy_tools/metadata.json
+++ b/applications/ssd_detection_endoscopy_tools/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "SSD Detection Application",
+		"name": "SSD Detection for Endoscopy Tools",
 		"authors": [
 			{
 				"name": "Jin Li",

--- a/applications/synthetic_aperture_radar/README.md
+++ b/applications/synthetic_aperture_radar/README.md
@@ -1,6 +1,7 @@
-# Holoscan SAR
+# Streaming Synthetic Aperture Radar
 
 ## Description
+
 This application is a demonstration of using Holoscan to construct Synthetic Aperture Radar (SAR) imagery from a data collection.  In current form, the data is assumed to be precollected and contained in a particular binary format.  It has been tested with 2 versions of the publicly available GOTCHA volumetric SAR data collection.  Python-based converters are included to manipulate the public datasets into the binary format expected by the application.  The application implements Backprojection for image formation.
 <!-- , in both Python and C++.  The Python implementation is accelerated via CuPy, and is backwardly compatible with Numpy.  The C++ implementation is accelerated with MatX.
 -->

--- a/applications/tao_peoplenet/README.md
+++ b/applications/tao_peoplenet/README.md
@@ -1,4 +1,5 @@
 # TAO PeopleNet Detection Model on V4L2 Video Stream
+
 <center> <img src="./docs/meeting.gif" ></center>
 
 Use the TAO PeopleNet available on [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tao/models/peoplenet) to detect faces and people in a V4L2 supported video stream. HoloViz is used to draw bounding boxes around the detections.

--- a/applications/tao_peoplenet/metadata.json
+++ b/applications/tao_peoplenet/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "TAO PeopleNet Detection Model on Video Stream",
+		"name": "TAO PeopleNet Detection Model on V4L2 Video Stream",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/ultrasound_segmentation/cpp/metadata.json
+++ b/applications/ultrasound_segmentation/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Ultrasound Segmentation",
+		"name": "Ultrasound Bone Scoliosis Segmentation",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/ultrasound_segmentation/python/metadata.json
+++ b/applications/ultrasound_segmentation/python/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Ultrasound Segmentation",
+		"name": "Ultrasound Bone Scoliosis Segmentation",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/velodyne_lidar_app/README.md
+++ b/applications/velodyne_lidar_app/README.md
@@ -1,4 +1,4 @@
-# Velodyne VLP-16 Lidar Viewer Application
+# Velodyne VLP-16 Lidar Viewer
 
 ![HoloViz Visual of Highway Sample Lidar Data](./doc/VLP10HzMontereyHighway.gif)
 

--- a/applications/velodyne_lidar_app/cpp/metadata.json
+++ b/applications/velodyne_lidar_app/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Velodyne Lidar Viewer",
+		"name": "Velodyne VLP-16 Lidar Viewer",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/video_deidentification/README.md
+++ b/applications/video_deidentification/README.md
@@ -1,4 +1,5 @@
 # Real-Time Face and Text Deidentification
+
 <center> <img src="./docs/video_deid.gif" ></center>
 
 This sample application demonstrates the use of face and text detection models to do real-time video deidentification.

--- a/applications/video_deidentification/metadata.json
+++ b/applications/video_deidentification/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Real-Time Face and Text Deidentification App",
+		"name": "Real-Time Face and Text Deidentification",
 		"authors": [
 			{
 				"name": "Wendell Hom",

--- a/applications/vila_live/README.md
+++ b/applications/vila_live/README.md
@@ -1,4 +1,4 @@
-# 📷🤖 Holoscan VILA Live
+# VILA Live
 
 This application demonstrates how to run [VILA 1.5](https://github.com/Efficient-Large-Model/VILA) models on live video feed with the possibility of changing the prompt in real time.
 

--- a/applications/volume_rendering/cpp/metadata.json
+++ b/applications/volume_rendering/cpp/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Volume Rendering",
+		"name": "Volume rendering using ClaraViz",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/volume_rendering/python/metadata.json
+++ b/applications/volume_rendering/python/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Volume Rendering",
+		"name": "Volume rendering using ClaraViz",
 		"authors": [
 			{
 				"name": "Holoscan Team",

--- a/applications/volume_rendering_xr/metadata.json
+++ b/applications/volume_rendering_xr/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Medical Image viewer in XR",
+		"name": "Medical Image Viewer in XR",
 		"authors": [
 			{
 				"name": "Andreas Heumann",

--- a/applications/yolo_model_deployment/README.md
+++ b/applications/yolo_model_deployment/README.md
@@ -1,4 +1,5 @@
-# Holoscan-Yolo
+# Yolo Object Detection
+
 This project is aiming to provide basic guidance to deploy Yolo-based model to Holoscan SDK as "Bring Your Own Model"
 
 <div align="center">

--- a/applications/yolo_model_deployment/metadata.json
+++ b/applications/yolo_model_deployment/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Yolo Detection",
+		"name": "Yolo Object Detection",
 		"authors": [
 			{
 				"name": "Holoscan Team",


### PR DESCRIPTION
This PR 
- makes the naming of all the Holohub applications consistent across `metadata.json` ("name" field) and `README.md` (title), 
- improve the naming of some applications to be more descriptive,
- remove redundant words from application names, such as "application", "holoscan", "holohub", etc.
- fix README titles that does not starts with `#`.