### PR TITLE
Add tests for gpunetio in ano

### DIFF
--- a/applications/adv_networking_bench/README.md
+++ b/applications/adv_networking_bench/README.md
@@ -87,5 +87,3 @@ With RIVERMAX RX:
 ```bash
 ./build/applications/adv_networking_bench/cpp/adv_networking_bench adv_networking_bench_rmax_rx.yaml
 ```
-
-<mark>For Holoscan internal reasons (not related to the DOCA library), build the Advanced Network Operator with `RX_PERSISTENT_ENABLED` set to 1 MAY cause problems to this application on the receive (process) side (receive hangs). If you experience any issue on the receive side, please read carefully in the Advanced Network Operator README how to solve this problem.</mark>

--- a/applications/adv_networking_bench/adv_networking_bench_gpunetio_tx_rx.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_gpunetio_tx_rx.yaml
@@ -40,7 +40,7 @@ advanced_network:
       buf_size: 1064
 
     interfaces:
-    - name: "tx_port"
+    - name: "single_port"
       address: 0000:ca:00.0
       tx:
         queues:

--- a/applications/network_radar_pipeline/README.md
+++ b/applications/network_radar_pipeline/README.md
@@ -26,8 +26,6 @@ To run with DOCA GPUNetIO as ANO transport layer:
 - On Tx machine: `./build/applications/network_radar_pipeline/cpp/network_radar_pipeline source_doca.yaml`
 - On Rx machine: `./build/applications/network_radar_pipeline/cpp/network_radar_pipeline process_doca.yaml`
 
-<mark>For Holoscan internal reasons (not related to the DOCA library), build the Advanced Network Operator with `RX_PERSISTENT_ENABLED` set to 1 MAY cause problems to this application on the receive (process) side (receive hangs in process.cu file). If you experience any issue on the receive side, please read carefully in the Advanced Network Operator README about how to solve this problem.</mark>
-
 ## Network Operator Connectors
 See each operators' README before using / for more detailed information.
 ### Basic Network Operator Connector

--- a/operators/advanced_network/README.md
+++ b/operators/advanced_network/README.md
@@ -97,19 +97,6 @@ To build and run the ANO Dockerfile with DOCA support, please follow the steps b
 ./build/adv_networking_bench/applications/adv_networking_bench/cpp/adv_networking_bench adv_networking_bench_gpunetio_tx_rx.yaml
 ```
 
-<mark>Receiver side, CUDA Persistent kernel note</mark>
-To get the best performance on the receive side, the Advanced Network Operator must be built with with `RX_PERSISTENT_ENABLED` set to 1 which enables the CUDA receiver kernel to run persistently for the whole execution. For Holoscan internal reasons (not related to the DOCA library), a persistent CUDA kernel may cause issues on some applications on the receive side. This issue is still under investigation.
-If this happens, there are two options:
-- build the Advanced Network Operator with `RX_PERSISTENT_ENABLED` set to 0
-- keep the `RX_PERSISTENT_ENABLED` set to 1 and enable also MPS setting `MPS_ENABLED` to 1. Then, MPS should be enabled on the system:
-```
-export CUDA_MPS_PIPE_DIRECTORY=/var
-export CUDA_MPS_LOG_DIRECTORY=/var
-sudo -E nvidia-cuda-mps-control -d
-sudo -E echo start_server -uid 0 | sudo -E nvidia-cuda-mps-control
-```
-
-This should solve all problems. Both `RX_PERSISTENT_ENABLED` and `MPS_ENABLED` are defined in `operators/advanced_network/managers/doca/adv_network_doca_mgr.h`.
 ##### RIVERMAX
 NVIDIA Rivermax SDK
 Optimized networking SDK for media and data streaming applications.

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
@@ -1937,10 +1937,7 @@ void DpdkMgr::shutdown() {
   HOLOSCAN_LOG_INFO("DPDK ANO shutdown called {}", num_init);
 
   if (--num_init == 0) {
-    int portid;
-    RTE_ETH_FOREACH_DEV(portid) {
-      PrintDpdkStats(portid);
-    }
+    print_stats();
 
     HOLOSCAN_LOG_INFO("ANO DPDK manager shutting down");
     force_quit.store(true);

--- a/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.cpp
@@ -1785,6 +1785,8 @@ void DocaMgr::shutdown() {
   HOLOSCAN_LOG_INFO("ANO DOCA manager shutting down");
 
   if (force_quit_doca.load() == false) {
+    print_stats();
+
     HOLOSCAN_LOG_INFO("ANO DOCA manager stopping cores");
     force_quit_doca.store(true);
     for (int i = 0; i < worker_th_idx; i++) {

--- a/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.h
+++ b/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.h
@@ -61,7 +61,7 @@
 #define THRESHOLD_BUF_NUM 32768
 
 #define MPS_ENABLED 0
-#define RX_PERSISTENT_ENABLED 0
+#define RX_PERSISTENT_ENABLED 1
 
 struct adv_doca_rx_gpu_info {
   uint32_t num_pkts;

--- a/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/adv_network_rmax_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/rivermax/rmax_mgr_impl/adv_network_rmax_mgr.cpp
@@ -659,6 +659,8 @@ Status RmaxMgr::RmaxMgrImpl::send_tx_burst(BurstParams* burst) {
  */
 void RmaxMgr::RmaxMgrImpl::shutdown() {
   if (!force_quit.load()) {
+    print_stats();
+
     HOLOSCAN_LOG_INFO("ANO Rivermax manager shutting down");
     force_quit.store(false);
     std::raise(SIGINT);


### PR DESCRIPTION
Not validated, couldn't do rx on IGX. Can iterate on the parser once we diagnose and address the issue.

New test names:
```
-- Adding CTest: pytest.test_ano_bench.test_multi_if_loopback_dpdk-64-6.0-0.1-0.0
-- Adding CTest: pytest.test_ano_bench.test_multi_if_loopback_dpdk-512-55.0-0.1-0.0
-- Adding CTest: pytest.test_ano_bench.test_multi_if_loopback_dpdk-1500-94.0-0.1-0.0
-- Adding CTest: pytest.test_ano_bench.test_multi_if_loopback_dpdk-9000-96.0-0.1-0.0
-- Adding CTest: pytest.test_ano_bench.test_multi_if_loopback_gpunetio-64-6.0-0.1-0.0
-- Adding CTest: pytest.test_ano_bench.test_multi_if_loopback_gpunetio-512-55.0-0.1-0.0
-- Adding CTest: pytest.test_ano_bench.test_multi_if_loopback_gpunetio-1500-94.0-0.1-0.0
-- Adding CTest: pytest.test_ano_bench.test_multi_if_loopback_gpunetio-9000-96.0-0.1-0.0
-- Adding CTest: pytest.test_ano_bench.test_multi_rx_q
-- Adding CTest: pytest.test_ano_bench.test_hds_rx
-- Adding CTest: pytest.test_ano_bench.test_gpunetio_single_if_loopback
```

Example to build and run `test_gpunetio_single_if_loopback`:

```
./dev_container build_and_run adv_networking_bench --no_run --build_args "-DBUILD_TESTING:BOOL=ON"
```

```bash
./dev_container launch \
          --img holohub:adv_networking_bench \
          --docker_opts " \
        -u 0 \
        --privileged \
        -w /workspace/holohub/build/adv_networking_bench/applications/adv_networking_bench/cpp/ \
        " \
          -- pytest -s -v --log-cli-level=DEBUG --show-capture=no -k single
```



Also switch to persistent kernel