### PR TITLE
minor fixes CLI

### DIFF
--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -192,13 +192,14 @@ class HoloHubContainer:
         compute_capacity = get_compute_capacity()
 
         # Check if buildx exists
-        try:
-            run_command(["docker", "buildx", "version"], check=True, capture_output=True)
-        except subprocess.CalledProcessError:
-            fatal(
-                "docker buildx plugin is missing. Please install docker-buildx-plugin:\n"
-                "https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository"
-            )
+        if not self.dryrun:
+            try:
+                run_command(["docker", "buildx", "version"], check=True, capture_output=True)
+            except subprocess.CalledProcessError:
+                fatal(
+                    "docker buildx plugin is missing. Please install docker-buildx-plugin:\n"
+                    "https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository"
+                )
 
         # Set DOCKER_BUILDKIT environment variable
         os.environ["DOCKER_BUILDKIT"] = "1"
@@ -244,7 +245,8 @@ class HoloHubContainer:
     ) -> None:
         """Launch the container"""
 
-        check_nvidia_ctk()
+        if not self.dryrun:
+            check_nvidia_ctk()
 
         img = img or self.image_name
         add_volumes = add_volumes or []
@@ -339,7 +341,8 @@ class HoloHubContainer:
         cmd.extend(extra_args)
 
         if verbose:
-            print(f"Launch command: {' '.join(cmd)}")
+            cmd_list = [f'"{arg}"' if " " in str(arg) else str(arg) for arg in cmd]
+            print(f"Launch command: {' '.join(cmd_list)}")
 
         run_command(cmd, dry_run=self.dryrun)
 

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -259,55 +259,35 @@ class HoloHubCLI:
         return None
 
     def _make_project_container(
-        self,
-        project_name: Optional[str] = None,
-        language: Optional[str] = None,
-        dryrun: bool = False,
-        build_args: Optional[dict] = None,
+        self, project_name: Optional[str] = None, language: Optional[str] = None
     ) -> HoloHubContainer:
-        """Define a project container and optionally build it
-
-        Args:
-            project_name: Name of the project
-            language: Language implementation (cpp/python)
-            dryrun: Whether to run in dryrun mode
-            build_args: Optional arguments to pass to container.build()
-        """
+        """Define a project container"""
         if not project_name:
-            container = HoloHubContainer(project_metadata=None)
-        else:
-            project_data = self._find_project(project_name=project_name, language=language)
-            container = HoloHubContainer(project_metadata=project_data)
-
-        container.dryrun = dryrun
-        if build_args is not None:
-            container.build(**build_args)
-
-        return container
+            return HoloHubContainer(project_metadata=None)
+        project_data = self._find_project(project_name=project_name, language=language)
+        return HoloHubContainer(project_metadata=project_data)
 
     def handle_build_container(self, args: argparse.Namespace) -> None:
         """Handle build-container command"""
-        self._make_project_container(
-            project_name=args.project,
-            language=args.language if hasattr(args, "language") else None,
-            dryrun=args.dryrun,
-            build_args={
-                "docker_file": args.docker_file,
-                "base_img": args.base_img,
-                "img": args.img,
-                "no_cache": args.no_cache,
-                "build_args": args.build_args,
-            },
+        container = self._make_project_container(
+            project_name=args.project, language=args.language if hasattr(args, "language") else None
+        )
+        container.dryrun = args.dryrun
+        container.build(
+            docker_file=args.docker_file,
+            base_img=args.base_img,
+            img=args.img,
+            no_cache=args.no_cache,
+            build_args=args.build_args,
         )
 
     def handle_run_container(self, args: argparse.Namespace) -> None:
         """Handle run-container command"""
         container = self._make_project_container(
-            project_name=args.project,
-            language=args.language if hasattr(args, "language") else None,
-            dryrun=args.dryrun,
-            build_args={},  # Empty dict to trigger build but with no special args
+            project_name=args.project, language=args.language if hasattr(args, "language") else None
         )
+        container.dryrun = args.dryrun
+        container.build()
         container.run(
             img=args.img,
             local_sdk_root=args.local_sdk_root,
@@ -382,9 +362,10 @@ class HoloHubCLI:
             container = self._make_project_container(
                 project_name=args.project,
                 language=args.language if hasattr(args, "language") else None,
-                dryrun=args.dryrun,
-                build_args={},  # Empty dict to trigger build but with no special args
             )
+            container.dryrun = args.dryrun
+            container.build()
+
             container.run(
                 docker_opts="--entrypoint=bash",
                 extra_args=["-c", f"./holohub build {args.project} --local"],
@@ -506,10 +487,9 @@ class HoloHubCLI:
             container = self._make_project_container(
                 project_name=args.project,
                 language=args.language if hasattr(args, "language") else None,
-                dryrun=args.dryrun,
-                build_args={},  # Empty dict to trigger build but with no special args
             )
-
+            container.dryrun = args.dryrun
+            container.build()
             # Get language before launching container
             language = holohub_cli_util.normalize_language(
                 container.project_metadata.get("metadata", {}).get("language", None)

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -517,8 +517,6 @@ class HoloHubCLI:
 
             # Build command with all necessary arguments
             run_cmd = f"./holohub run {args.project} --language {language} --local"
-            if args.dryrun:
-                run_cmd += " --dryrun"
             if args.verbose:
                 run_cmd += " --verbose"
             if args.nsys_profile:

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -1021,15 +1021,14 @@ class HoloHubCLI:
         """Handle clear-cache command"""
         if args.dryrun:
             print(Color.blue("Would clear cache folders:"))
-            for pattern in ["build", "build-*", "install"]:
-                for path in HoloHubCLI.HOLOHUB_ROOT.glob(pattern):
-                    if path.is_dir():
-                        print(f"  {Color.yellow('Would remove:')} {path}")
         else:
             print(Color.blue("Clearing cache..."))
-            for pattern in ["build", "build-*", "install"]:
-                for path in HoloHubCLI.HOLOHUB_ROOT.glob(pattern):
-                    if path.is_dir():
+        for pattern in ["build", "build-*", "install"]:
+            for path in HoloHubCLI.HOLOHUB_ROOT.glob(pattern):
+                if path.is_dir():
+                    if args.dryrun:
+                        print(f"  {Color.yellow('Would remove:')} {path}")
+                    else:
                         shutil.rmtree(path)
 
     def run(self) -> None:

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -277,10 +277,6 @@ class HoloHubCLI:
             container = HoloHubContainer(project_metadata=None)
         else:
             project_data = self._find_project(project_name=project_name, language=language)
-            if not project_data:
-                holohub_cli_util.fatal(
-                    f"Project '{project_name}' {f'({language})' if language else ''} not found"
-                )
             container = HoloHubContainer(project_metadata=project_data)
 
         container.dryrun = dryrun
@@ -346,11 +342,6 @@ class HoloHubCLI:
     ) -> tuple[Path, dict]:
         """Helper method to build a project locally"""
         project_data = self._find_project(project_name=project_name, language=language)
-        if not project_data:
-            holohub_cli_util.fatal(
-                f"Project '{project_name}' {f'({language})' if language else ''} not found"
-            )
-
         build_type = self.get_buildtype_str(build_type)
         build_dir = HoloHubCLI.DEFAULT_BUILD_PARENT_DIR / project_name
         build_dir.mkdir(parents=True, exist_ok=True)

--- a/utilities/cli/tests/test_container.py
+++ b/utilities/cli/tests/test_container.py
@@ -85,6 +85,16 @@ class TestHoloHubContainer(unittest.TestCase):
         self.assertTrue("--runtime=nvidia" in cmd)
         self.assertTrue(self.container.image_name in cmd)
 
+    @patch("subprocess.CompletedProcess")
+    def test_dry_run(self, mock_completed_process):
+        """Test container dry run command"""
+        self.container.dryrun = True
+        self.container.run()
+        cmd = mock_completed_process.call_args[0][0]
+        self.assertTrue(self.container.image_name in cmd)
+        self.assertIn('"c 81:* rmw"', cmd)
+        self.container.dryrun = False
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -87,12 +87,13 @@ def run_command(
     cmd: List[str], dry_run: bool = False, check: bool = True, **kwargs
 ) -> subprocess.CompletedProcess:
     """Run a shell command and handle errors"""
-    cmd_str = format_long_command(cmd) if dry_run else " ".join(str(x) for x in cmd)
+    cmd_list = [f'"{x}"' if " " in str(x) else str(x) for x in cmd]
+    cmd_str = format_long_command(cmd_list) if dry_run else " ".join(cmd_list)
     if dry_run:
         print(
             f"{Color.blue(get_timestamp())} {Color.cyan('[dryrun]')} {Color.white('$')} {Color.green(cmd_str)}"
         )
-        return subprocess.CompletedProcess(cmd, 0)
+        return subprocess.CompletedProcess(cmd_list, 0)
 
     print(f"{Color.blue(get_timestamp())} {Color.white('$')} {Color.green(cmd_str)}")
     try:


### PR DESCRIPTION
collection of some minor CLI fixes during development:
- dryrun broken commands e.g. `--device-cgroup-rule c 81:* rmw` to `--device-cgroup-rule "c 81:* rmw"`
- remove strict deps check when `dryrun` is true
- docs: run is actually build+run, removed some duplicated code
- _find_project internally handle the case of not found and exit, so no need to check it after _find_project 
- `run_cmd += " --dryrun"` not needed as `container.run` is already in dryrun mode: https://github.com/nvidia-holoscan/holohub/blob/965fa6604dfa65afbde86471edff0af6899c47ff/utilities/cli/holohub.py#L522-L523