### PR TITLE
fixes vila_live test data location

### DIFF
--- a/applications/vila_live/tests/CMakeLists.txt
+++ b/applications/vila_live/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_test(NAME vila_live_tinychat_test
 # Set test properties
 set_tests_properties(vila_live_vlm_test
   PROPERTIES
+  ENVIRONMENT "HOLOHUB_DATA_DIR=${HOLOHUB_DATA_DIR}"
   PASS_REGULAR_EXPRESSION "Scheduler finished"
   FAIL_REGULAR_EXPRESSION "FAILED")
 

--- a/applications/vila_live/vila_live.py
+++ b/applications/vila_live/vila_live.py
@@ -97,7 +97,7 @@ class V4L2toVLM(Application):
 
         if data == "none":
             data = os.path.join(
-                os.environ.get("HOLOHUB_DATA_PATH", "/workspace/holohub/data"), "vila_live"
+                os.environ.get("HOLOHUB_DATA_DIR", "/workspace/holohub/data"), "vila_live"
             )
 
         self.sample_data_path = data


### PR DESCRIPTION
change the default env to `HOLOHUB_DATA_DIR` and add it during test