### PR TITLE
fixes yolo test

### DIFF
--- a/applications/yolo_model_deployment/yolo_detection.py
+++ b/applications/yolo_model_deployment/yolo_detection.py
@@ -298,6 +298,12 @@ if __name__ == "__main__":
     # Argument parser
     parser = ArgumentParser(description="YOLO Detection Demo Application.")
     parser.add_argument(
+        "-c",
+        "--config",
+        default=os.path.join(os.path.dirname(__file__), "yolo_detection.yaml"),
+        help="Path to the configuration file.",
+    )
+    parser.add_argument(
         "-s",
         "--source",
         choices=["v4l2", "replayer"],
@@ -319,7 +325,6 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config_file = os.path.join(os.path.dirname(__file__), "yolo_detection.yaml")
     app = YoloDetApp(video_dir=args.video_dir, data=args.data, source=args.source)
-    app.config(config_file)
+    app.config(args.config)
     app.run()


### PR DESCRIPTION
add the missing support of `--config`
for
https://github.com/nvidia-holoscan/holohub/blob/3b0b6a3108ec67d0e5af213e3c316cb4e3c2e0b3/applications/yolo_model_deployment/CMakeLists.txt#L74