### PR TITLE
Fixing multi-q and improving receive functions

### DIFF
--- a/applications/adv_networking_bench/adv_networking_bench_default_tx_rx_multi_q_hds.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx_rx_multi_q_hds.yaml
@@ -1,0 +1,334 @@
+scheduler:
+  check_recession_period_ms: 0
+  worker_thread_number: 5
+  stop_on_deadlock: true
+  stop_on_deadlock_timeout: 500
+  max_duration_ms: 10000
+advanced_network:
+  cfg:
+    version: 1
+    manager: dpdk
+    master_core: 3
+    debug: false
+    log_level: info
+    tx_meta_buffers: 4096
+    rx_meta_buffers: 4096
+    memory_regions:
+    - name: Headers_RX_CPU
+      kind: huge
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 42
+    - name: Context_RX_CPU
+      kind: huge
+      affinity: 0
+      access:
+      - local
+      num_bufs: 10240
+      buf_size: 64
+    - name: CH1_Data_RX_GPU
+      kind: device
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 4100
+    - name: CH1_VRT_Headers_RX_CPU
+      kind: huge
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 20
+    - name: CH2_Data_RX_GPU
+      kind: device
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 4100
+    - name: CH2_VRT_Headers_RX_CPU
+      kind: huge
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 20
+    - name: CH3_Data_RX_GPU
+      kind: device
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 4100
+    - name: CH3_VRT_Headers_RX_CPU
+      kind: huge
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 20
+    - name: CH4_Data_RX_GPU
+      kind: device
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 4100
+    - name: CH4_VRT_Headers_RX_CPU
+      kind: huge
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 20
+    - name: CH5_Data_RX_GPU
+      kind: device
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 4100
+    - name: CH5_VRT_Headers_RX_CPU
+      kind: huge
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 20
+    - name: CH6_Data_RX_GPU
+      kind: device
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 4100
+    - name: CH6_VRT_Headers_RX_CPU
+      kind: huge
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 20
+    - name: CH7_Data_RX_GPU
+      kind: device
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 4100
+    - name: CH7_VRT_Headers_RX_CPU
+      kind: huge
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 20
+    - name: CH8_Data_RX_GPU
+      kind: device
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 4100
+    - name: CH8_VRT_Headers_RX_CPU
+      kind: huge
+      affinity: 0
+      access:
+      - local
+      num_bufs: 51200
+      buf_size: 20
+    - name: Data_TX_GPU
+      kind: device
+      affinity: 0
+      num_bufs: 51200
+      buf_size: 1064
+    - name: Data_TX_CPU
+      kind: huge
+      affinity: 0
+      num_bufs: 51200
+      buf_size: 8000
+    interfaces:
+    - name: tx_port
+      address: '0005:03:00.0'
+      tx:
+        queues:
+        - name: tx_q_0
+          id: 0
+          batch_size: 10240
+          cpu_core: 11
+          memory_regions:
+          - Data_TX_CPU
+          offloads:
+          - tx_eth_src
+    - name: rx_port
+      address: '0005:03:00.1'
+      rx:
+        flow_isolation: true
+        queues:
+        - name: rx_q_0
+          id: 0
+          cpu_core: 8
+          batch_size: 256
+          memory_regions:
+          - Headers_RX_CPU
+          - Context_RX_CPU
+        - name: rx_q_1
+          id: 1
+          cpu_core: 9
+          batch_size: 256
+          memory_regions:
+          - Headers_RX_CPU
+          - CH1_VRT_Headers_RX_CPU
+          - CH1_Data_RX_GPU
+        - name: rx_q_2
+          id: 2
+          cpu_core: 9
+          batch_size: 256
+          memory_regions:
+          - Headers_RX_CPU
+          - CH2_VRT_Headers_RX_CPU
+          - CH2_Data_RX_GPU
+        - name: rx_q_3
+          id: 3
+          cpu_core: 9
+          batch_size: 256
+          memory_regions:
+          - Headers_RX_CPU
+          - CH3_VRT_Headers_RX_CPU
+          - CH3_Data_RX_GPU
+        - name: rx_q_4
+          id: 4
+          cpu_core: 9
+          batch_size: 256
+          memory_regions:
+          - Headers_RX_CPU
+          - CH4_VRT_Headers_RX_CPU
+          - CH4_Data_RX_GPU
+        - name: rx_q_5
+          id: 5
+          cpu_core: 9
+          batch_size: 256
+          memory_regions:
+          - Headers_RX_CPU
+          - CH5_VRT_Headers_RX_CPU
+          - CH5_Data_RX_GPU
+        - name: rx_q_6
+          id: 6
+          cpu_core: 9
+          batch_size: 256
+          memory_regions:
+          - Headers_RX_CPU
+          - CH6_VRT_Headers_RX_CPU
+          - CH6_Data_RX_GPU
+        - name: rx_q_7
+          id: 7
+          cpu_core: 9
+          batch_size: 256
+          memory_regions:
+          - Headers_RX_CPU
+          - CH7_VRT_Headers_RX_CPU
+          - CH7_Data_RX_GPU
+        - name: rx_q_8
+          id: 8
+          cpu_core: 9
+          batch_size: 256
+          memory_regions:
+          - Headers_RX_CPU
+          - CH8_VRT_Headers_RX_CPU
+          - CH8_Data_RX_GPU
+        flows:
+        - name: flow_4097
+          id: 0
+          action:
+            type: queue
+            id: 0
+          match:
+            udp_src: 4097
+            udp_dst: 4097
+        - name: flow_4096
+          id: 1
+          action:
+            type: queue
+            id: 1
+          match:
+            udp_src: 4096
+            udp_dst: 4096
+        - name: flow_4095
+          id: 2
+          action:
+            type: queue
+            id: 2
+          match:
+            udp_src: 4095
+            udp_dst: 4095
+        - name: flow_4094
+          id: 3
+          action:
+            type: queue
+            id: 3
+          match:
+            udp_src: 4094
+            udp_dst: 4094
+        - name: flow_4093
+          id: 4
+          action:
+            type: queue
+            id: 4
+          match:
+            udp_src: 4093
+            udp_dst: 4093
+        - name: flow_4092
+          id: 5
+          action:
+            type: queue
+            id: 5
+          match:
+            udp_src: 4092
+            udp_dst: 4092
+        - name: flow_4091
+          id: 6
+          action:
+            type: queue
+            id: 6
+          match:
+            udp_src: 4091
+            udp_dst: 4091
+        - name: flow_4090
+          id: 7
+          action:
+            type: queue
+            id: 7
+          match:
+            udp_src: 4090
+            udp_dst: 4090
+        - name: flow_4089
+          id: 8
+          action:
+            type: queue
+            id: 8
+          match:
+            udp_src: 4089
+            udp_dst: 4089
+bench_rx:
+  interface_name: rx_port
+  gpu_direct: true
+  split_boundary: true
+  batch_size: 1
+  max_packet_size: 1064
+  header_size: 170
+  reorder_kernel: false
+bench_tx:
+  interface_name: tx_port
+  gpu_direct: false
+  split_boundary: 0
+  batch_size: 10240
+  payload_size: 1000
+  header_size: 64
+  eth_dst_addr: 48:b0:2d:f4:04:48
+  ip_src_addr: <1.2.3.4>
+  ip_dst_addr: <5.6.7.8>
+  udp_src_port: 4089-4097
+  udp_dst_port: 4089-4097

--- a/applications/adv_networking_bench/adv_networking_bench_default_tx_rx_multi_q_hds.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx_rx_multi_q_hds.yaml
@@ -327,7 +327,7 @@ bench_tx:
   batch_size: 10240
   payload_size: 1000
   header_size: 64
-  eth_dst_addr: 48:b0:2d:f4:04:48
+  eth_dst_addr: <00:00:00:00:00:00>
   ip_src_addr: <1.2.3.4>
   ip_dst_addr: <5.6.7.8>
   udp_src_port: 4089-4097

--- a/applications/adv_networking_bench/adv_networking_bench_default_tx_rx_multi_q_hds.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx_rx_multi_q_hds.yaml
@@ -1,3 +1,19 @@
+%YAML 1.2
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
 scheduler:
   check_recession_period_ms: 0
   worker_thread_number: 5

--- a/applications/adv_networking_bench/adv_networking_bench_default_tx_rx_multi_q_hds.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx_rx_multi_q_hds.yaml
@@ -164,7 +164,7 @@ advanced_network:
           offloads:
           - tx_eth_src
     - name: rx_port
-      address: '0005:03:00.1'
+      address: <0000:00:00.0>       # The BUS address of the interface doing Rx
       rx:
         flow_isolation: true
         queues:

--- a/applications/adv_networking_bench/adv_networking_bench_default_tx_rx_multi_q_hds.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx_rx_multi_q_hds.yaml
@@ -152,7 +152,7 @@ advanced_network:
       buf_size: 8000
     interfaces:
     - name: tx_port
-      address: '0005:03:00.0'
+      address: <0000:00:00.0>       # The BUS address of the interface doing Tx
       tx:
         queues:
         - name: tx_q_0

--- a/applications/adv_networking_bench/adv_networking_bench_default_tx_rx_multi_q_hds.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_default_tx_rx_multi_q_hds.yaml
@@ -171,7 +171,7 @@ advanced_network:
         - name: rx_q_0
           id: 0
           cpu_core: 8
-          batch_size: 256
+          batch_size: 1
           memory_regions:
           - Headers_RX_CPU
           - Context_RX_CPU

--- a/applications/adv_networking_bench/cpp/CMakeLists.txt
+++ b/applications/adv_networking_bench/cpp/CMakeLists.txt
@@ -67,6 +67,12 @@ add_custom_target(adv_networking_bench_default_rx_multi_q_yaml
 )
 add_dependencies(adv_networking_bench adv_networking_bench_default_rx_multi_q_yaml)
 
+add_custom_target(adv_networking_bench_default_tx_rx_multi_q_hds_yaml
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/../adv_networking_bench_default_tx_rx_multi_q_hds.yaml" ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../adv_networking_bench_default_tx_rx_multi_q_hds.yaml"
+)
+add_dependencies(adv_networking_bench adv_networking_bench_default_tx_rx_multi_q_hds_yaml)
+
 add_custom_target(adv_networking_bench_default_tx_rx_hds_yaml
   COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/../adv_networking_bench_default_tx_rx_hds.yaml" ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../adv_networking_bench_default_tx_rx_hds.yaml"

--- a/applications/adv_networking_bench/cpp/default_bench_op_rx.h
+++ b/applications/adv_networking_bench/cpp/default_bench_op_rx.h
@@ -155,6 +155,11 @@ class AdvNetworkingBenchDefaultRxOp : public Operator {
                          "Header size",
                          "Header size on each packet from L4 and below",
                          42);
+    spec.param<bool>(reorder_kernel_,
+                     "reorder_kernel",
+                     "Reorder kernel enabled",
+                     "Enable reorder kernel",
+                     true);
   }
 
   // Free buffers if CUDA processing/copy is complete
@@ -325,11 +330,13 @@ class AdvNetworkingBenchDefaultRxOp : public Operator {
           // to a contiguous memory buffer (full_batch_data_d_)
           // NOTE: there is no actual reordering since we use the same order as packets came in,
           //   but they would be reordered if h_dev_ptrs_ was filled based on packet sequence id.
-          simple_packet_reorder(static_cast<uint8_t*>(full_batch_data_d_[cur_batch_idx_]),
-                                h_dev_ptrs_[cur_batch_idx_],
-                                nom_payload_size_,
-                                batch_size_.get(),
-                                streams_[cur_batch_idx_]);
+          if (reorder_kernel_.get()) {
+            simple_packet_reorder(static_cast<uint8_t*>(full_batch_data_d_[cur_batch_idx_]),
+                                  h_dev_ptrs_[cur_batch_idx_],
+                                  nom_payload_size_,
+                                  batch_size_.get(),
+                                  streams_[cur_batch_idx_]);
+          }
 
         } else {
           // Non GPUDirect mode: we copy the payload on host-pinned memory (in full_batch_data_h_)
@@ -406,6 +413,7 @@ class AdvNetworkingBenchDefaultRxOp : public Operator {
   Parameter<uint32_t> batch_size_;                       // Batch size for one processing block
   Parameter<uint16_t> max_packet_size_;                  // Maximum size of a single packet
   Parameter<uint16_t> header_size_;                      // Header size of packet
+  Parameter<bool> reorder_kernel_;                        // Reorder kernel enabled
 
   std::array<cudaStream_t, num_concurrent> streams_;
   std::array<cudaEvent_t, num_concurrent> events_;

--- a/applications/adv_networking_bench/cpp/default_bench_op_rx.h
+++ b/applications/adv_networking_bench/cpp/default_bench_op_rx.h
@@ -330,7 +330,7 @@ class AdvNetworkingBenchDefaultRxOp : public Operator {
           // to a contiguous memory buffer (full_batch_data_d_)
           // NOTE: there is no actual reordering since we use the same order as packets came in,
           //   but they would be reordered if h_dev_ptrs_ was filled based on packet sequence id.
-          // We also allow disabling the reorder kernel if alignment and memory types are not 
+          // We also allow disabling the reorder kernel if alignment and memory types are not
           // supported. Currently the reorder kernel expects the packets to be 16B-aligned, and
           // anything that's not will cause an access error on the GPU
           if (reorder_kernel_.get()) {

--- a/applications/adv_networking_bench/cpp/default_bench_op_rx.h
+++ b/applications/adv_networking_bench/cpp/default_bench_op_rx.h
@@ -413,7 +413,7 @@ class AdvNetworkingBenchDefaultRxOp : public Operator {
   Parameter<uint32_t> batch_size_;                       // Batch size for one processing block
   Parameter<uint16_t> max_packet_size_;                  // Maximum size of a single packet
   Parameter<uint16_t> header_size_;                      // Header size of packet
-  Parameter<bool> reorder_kernel_;                        // Reorder kernel enabled
+  Parameter<bool> reorder_kernel_;                       // Reorder kernel enabled
 
   std::array<cudaStream_t, num_concurrent> streams_;
   std::array<cudaEvent_t, num_concurrent> events_;

--- a/applications/adv_networking_bench/cpp/default_bench_op_rx.h
+++ b/applications/adv_networking_bench/cpp/default_bench_op_rx.h
@@ -158,7 +158,7 @@ class AdvNetworkingBenchDefaultRxOp : public Operator {
     spec.param<bool>(reorder_kernel_,
                      "reorder_kernel",
                      "Reorder kernel enabled",
-                     "Enable reorder kernel",
+                     "Enable reorder kernel if alignment and memory types are supported",
                      true);
   }
 
@@ -330,6 +330,9 @@ class AdvNetworkingBenchDefaultRxOp : public Operator {
           // to a contiguous memory buffer (full_batch_data_d_)
           // NOTE: there is no actual reordering since we use the same order as packets came in,
           //   but they would be reordered if h_dev_ptrs_ was filled based on packet sequence id.
+          // We also allow disabling the reorder kernel if alignment and memory types are not 
+          // supported. Currently the reorder kernel expects the packets to be 16B-aligned, and
+          // anything that's not will cause an access error on the GPU
           if (reorder_kernel_.get()) {
             simple_packet_reorder(static_cast<uint8_t*>(full_batch_data_d_[cur_batch_idx_]),
                                   h_dev_ptrs_[cur_batch_idx_],

--- a/applications/adv_networking_bench/cpp/default_bench_op_tx.h
+++ b/applications/adv_networking_bench/cpp/default_bench_op_tx.h
@@ -139,7 +139,7 @@ class AdvNetworkingBenchDefaultTxOp : public Operator {
     } else {
       udp_dst_ports_.push_back(static_cast<uint16_t>(std::stoul(udp_dst_port_str_.get())));
     }
-    
+
     // TX GPU-only mode
     // This section simply serves as an example to get an Eth+IP+UDP header onto the GPU,
     // but this header will not be correct without modification of the IP and MAC. In a

--- a/applications/adv_networking_bench/cpp/default_bench_op_tx.h
+++ b/applications/adv_networking_bench/cpp/default_bench_op_tx.h
@@ -72,6 +72,8 @@ class AdvNetworkingBenchDefaultTxOp : public Operator {
     pkt.ip.tot_len = htons(ip_len);
 
     pkt.udp.check = 0;
+    // Since device-only mode doesn't support updating the GPU memory with different ports we just
+    // use the first one here.
     pkt.udp.dest = htons(udp_dst_ports_[0]);
     pkt.udp.source = htons(udp_src_ports_[0]);
     pkt.udp.len = htons(ip_len - sizeof(pkt.ip));
@@ -177,9 +179,11 @@ class AdvNetworkingBenchDefaultTxOp : public Operator {
                      "Byte boundary where header and data is split",
                      false);
     spec.param<std::string>(udp_src_port_str_,
-          "udp_src_port", "UDP source port", "UDP source port");
+          "udp_src_port", "UDP source port", 
+          "UDP source port or a range of ports (e.g. 1000-1010)");
     spec.param<std::string>(
-        udp_dst_port_str_, "udp_dst_port", "UDP destination port", "UDP destination port");
+        udp_dst_port_str_, "udp_dst_port", "UDP destination port", 
+        "UDP destination port or a range of ports (e.g. 1000-1010)");
     spec.param<std::string>(ip_src_addr_, "ip_src_addr", "IP source address", "IP source address");
     spec.param<std::string>(
         ip_dst_addr_, "ip_dst_addr", "IP destination address", "IP destination address");

--- a/applications/adv_networking_bench/cpp/default_bench_op_tx.h
+++ b/applications/adv_networking_bench/cpp/default_bench_op_tx.h
@@ -179,10 +179,10 @@ class AdvNetworkingBenchDefaultTxOp : public Operator {
                      "Byte boundary where header and data is split",
                      false);
     spec.param<std::string>(udp_src_port_str_,
-          "udp_src_port", "UDP source port", 
+          "udp_src_port", "UDP source port",
           "UDP source port or a range of ports (e.g. 1000-1010)");
     spec.param<std::string>(
-        udp_dst_port_str_, "udp_dst_port", "UDP destination port", 
+        udp_dst_port_str_, "udp_dst_port", "UDP destination port",
         "UDP destination port or a range of ports (e.g. 1000-1010)");
     spec.param<std::string>(ip_src_addr_, "ip_src_addr", "IP source address", "IP source address");
     spec.param<std::string>(

--- a/applications/adv_networking_bench/cpp/testing/benchmark_utils.py
+++ b/applications/adv_networking_bench/cpp/testing/benchmark_utils.py
@@ -184,7 +184,9 @@ class BenchmarkResults:
         # Check each expected queue
         for queue_str, expected_count in expected_str_dict.items():
             actual_count = self.q_rx_pkts[port_str].get(queue_str, 0)
-            success = actual_count > expected_count if allow_greater else actual_count == expected_count
+            success = (
+                actual_count > expected_count if allow_greater else actual_count == expected_count
+            )
 
             # Log
             expect_symbol = ">=" if allow_greater else "="

--- a/applications/adv_networking_bench/cpp/testing/benchmark_utils.py
+++ b/applications/adv_networking_bench/cpp/testing/benchmark_utils.py
@@ -184,31 +184,16 @@ class BenchmarkResults:
         # Check each expected queue
         for queue_str, expected_count in expected_str_dict.items():
             actual_count = self.q_rx_pkts[port_str].get(queue_str, 0)
+            success = actual_count > expected_count if allow_greater else actual_count == expected_count
 
-            if gt:
-                if actual_count <= expected_count:
-                    logger.error(
-                        f"Port {port} Queue {queue_str} packet count mismatch: "
-                        f"expected (at least) ={expected_count}, actual={actual_count} ❌"
-                    )
-                    success = False
-                else:
-                    logger.info(
-                        f"Port {port} Queue {queue_str} packet count match: "
-                        f"expected (at least) {expected_count}, actual={actual_count} ✅"
-                    )
+            # Log
+            expect_symbol = ">=" if allow_greater else "="
+            queue_info = f"Port {port_str} Queue {queue_str} packet count"
+            count_info = f"expected{expect_symbol}{expected_count}, actual={actual_count}"
+            if not success:
+                logger.error(f"{queue_info} mismatch: {count_info} ❌")
             else:
-                if actual_count != expected_count:
-                    logger.error(
-                        f"Port {port} Queue {queue_str} packet count mismatch: "
-                        f"expected={expected_count}, actual={actual_count} ❌"
-                    )
-                    success = False
-                else:
-                    logger.info(
-                        f"Port {port} Queue {queue_str} packet count match: "
-                        f"expected={expected_count}, actual={actual_count} ✅"
-                    )
+                logger.info(f"{queue_info} match: {count_info} ✅")
 
         # Check for unexpected queues with packets
         for queue_str, actual_count in self.q_rx_pkts[port_str].items():

--- a/applications/adv_networking_bench/cpp/testing/benchmark_utils.py
+++ b/applications/adv_networking_bench/cpp/testing/benchmark_utils.py
@@ -157,7 +157,7 @@ class BenchmarkResults:
         return (tx_bytes * 8) / (self.exec_time / 1000) / 1e9
 
     def validate_rx_queue_packets(
-        self, port: int, expected_packets: Dict[int, int], gt: bool = False
+        self, port: int, expected_packets: Dict[int, int], allow_greater: bool = False
     ) -> bool:
         """
         Validate that RX queues on a specific port received the expected number of packets.
@@ -165,7 +165,7 @@ class BenchmarkResults:
         Args:
             port: Port number to validate
             expected_packets: Dictionary mapping queue numbers to expected packet counts {queue: count}
-            gt: If True, validate that the actual packet count is greater than the expected count
+            allow_greater: If True, validate that the actual packet count is greater than the expected count
 
         Returns:
             bool: True if validation passed, False otherwise

--- a/applications/adv_networking_bench/cpp/testing/test_ano_bench.py
+++ b/applications/adv_networking_bench/cpp/testing/test_ano_bench.py
@@ -271,8 +271,7 @@ def test_multi_q_hds_tx_rx(executable, work_dir, nvidia_nics):
     results = parse_benchmark_results(result.stdout + result.stderr, "dpdk")
 
     # Validate some expected metrics
-    # We only check that every queue got at least 100 packets here
-    rx_queue_pkts_check = results.validate_rx_queue_packets(
-        1, {0: 100, 1: 100, 2: 100, 3: 100, 4: 100, 5: 100, 6: 100, 7: 100, 8: 100}, gt=True
-    )
+    # We only check that every rx queue got at least 1 packet here on port 1
+    expected_q_pkts = {i: 1 for i in range(9)}
+    rx_queue_pkts_check = results.validate_rx_queue_packets(1, expected_q_pkts, allow_greater=True)
     assert rx_queue_pkts_check, "RX queue packet distribution validation failed"

--- a/operators/advanced_network/CHANGELOG.md
+++ b/operators/advanced_network/CHANGELOG.md
@@ -18,6 +18,15 @@ Common:
 - Added `get_port_id` to get the port ID for a given PCIe address or config name.
 - Added `get_num_rx_queues` to get the number of RX queues for a given port.
 
+-   **Enhanced Network Benchmarking:**
+    -   The Advanced Networking Benchmark application now supports UDP port ranges (e.g., "5000-5010") for more flexible traffic distribution across queues.
+    -   Added a new configuration (`adv_networking_bench_default_tx_rx_multi_q_hds.yaml`) for benchmarking multi-queue transmit/receive scenarios with Header-Data Split.
+    -   Added option to disable the internal packet reordering kernel (`reorder_kernel: false`).
+-   **Improved Advanced Network Core:**
+    -   Fix crash when using a batch_size smaller than 128
+    -   Support with per-queue timeouts, ensuring balanced processing even with uneven packet distribution or bursty traffic.
+    -   Added configurable metadata buffer pools (`tx_meta_buffers`, `rx_meta_buffers`) for better resource tuning in high-rate scenarios.
+
 
 ## 🚀 holoscan-networking 0.1
 

--- a/operators/advanced_network/README.md
+++ b/operators/advanced_network/README.md
@@ -162,6 +162,10 @@ bound to a non-isolated core. Should differ from isolated cores in queues below.
   - type: `string`
 - **`log_level`**: Backend log level. default: `warn`. Other: `trace` , `debug`, `info`, `error`, `critical`, `off`
   - type: `string`
+- **`tx_meta_buffers`**: Metadata buffers for transmit. One buffer is used for each burst of packets (default: 4096)
+  - type: `integer`
+- **`rx_meta_buffers`**: Metadata buffers for receive. One buffer is used for each burst of packets (default: 4096)
+  - type: `integer`
 
 ##### Memory regions
 
@@ -211,6 +215,27 @@ Too low means risk of dropped packets from NIC having nowhere to write (Rx) or h
 		type: `list`
 	- **`timeout_us`**: Timeout value that a batch will be sent on even if not enough packets to fill a batch were received
   		- type: `integer`
+
+##### Transmit Configuration (tx)
+
+- **`queues`**: List of queues on NIC
+	type: `list`
+	full path: `cfg\interfaces\rx\queues`
+	- **`name`**: Name of queue
+  		- type: `string`
+	- **`id`**: Integer ID used for flow connection or lookup in operator compute method
+  		- type: `integer`
+	- **`cpu_core`**: CPU core ID. Should be isolated when CPU polls the NIC for best performance.. <mark>Not in use for Doca GPUNetIO</mark>
+		Rivermax manager can accept coma separated list of CPU IDs
+  		- type: `string`
+	- **`batch_size`**: Number of packets in a batch passed from the NIC to the downstream operator. A
+	larger number increases throughput but reduces end-to-end latency, as it takes longer to populate a single
+	buffer. A smaller number reduces end-to-end latency but can also reduce throughput.
+  		- type: `integer`
+	- **`memory_regions`**: List of memory regions where buffers are stored. memory regions names are configured in the [Memory Regions](#memory-regions) section
+		type: `list`
+	- **`accurate_send`**: Accurate TX sending enabled for sending packets at a specific PTP timestamp
+  		- type: `boolean`
 
 - **`flows`**: List of flows - rules to apply to packets, mostly to divert to the right queue. (<mark>Not in use for Rivermax manager</mark>)
   type: `list`

--- a/operators/advanced_network/README.md
+++ b/operators/advanced_network/README.md
@@ -227,9 +227,9 @@ Too low means risk of dropped packets from NIC having nowhere to write (Rx) or h
 	  		- type: `integer`
 	- **`match`**: Match section of flow
 	  - type: `sequence`
-		- **`udp_src`**: UDP source port
+		- **`udp_src`**: UDP source port or a range of ports (eg 1000-1010)
 	  	- type: `integer`
-		- **`udp_dst`**: UDP destination port
+		- **`udp_dst`**: UDP destination port or a range of ports (eg 1000-1010)
 	  	- type: `integer`
 		- **`ipv4_len`**: IPv4 payload length
 	  	- type: `integer`

--- a/operators/advanced_network/advanced_network/common.h
+++ b/operators/advanced_network/advanced_network/common.h
@@ -41,6 +41,8 @@ enum class ErrorGlobalStats {
   SENTINEL = 3,
 };
 
+static constexpr uint32_t DEFAULT_TX_META_BUFFERS = 1UL << 8;
+static constexpr uint32_t DEFAULT_RX_META_BUFFERS = 1UL << 8;
 namespace detail {
 inline Direction DirectionStringToType(const std::string& dir) {
   if (dir == "rx") {
@@ -601,6 +603,20 @@ struct YAML::convert<holoscan::advanced_network::NetworkConfig> {
                 holoscan::advanced_network::LogLevel::WARN)));
       } catch (const std::exception& e) {
         input_spec.log_level_ = holoscan::advanced_network::LogLevel::WARN;
+      }
+
+      try {
+        input_spec.tx_meta_buffers_ =
+          node["tx_meta_buffers"].as<uint32_t>(holoscan::advanced_network::DEFAULT_TX_META_BUFFERS);
+      } catch (const std::exception& e) { input_spec.tx_meta_buffers_ =
+        holoscan::advanced_network::DEFAULT_TX_META_BUFFERS;
+      }
+
+      try {
+        input_spec.rx_meta_buffers_ =
+          node["rx_meta_buffers"].as<uint32_t>(holoscan::advanced_network::DEFAULT_RX_META_BUFFERS);
+      } catch (const std::exception& e) {
+        input_spec.rx_meta_buffers_ = holoscan::advanced_network::DEFAULT_RX_META_BUFFERS;
       }
 
       try {

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
@@ -899,9 +899,9 @@ int DpdkMgr::setup_pools_and_rings(int max_rx_batch, int max_tx_batch) {
     return -1;
   }
 
-  HOLOSCAN_LOG_DEBUG("Setting up RX meta pool");
+  HOLOSCAN_LOG_INFO("Setting up RX meta pool with {} buffers", cfg_.rx_meta_buffers_);
   rx_metadata = rte_mempool_create("RX_META_POOL",
-                               (1U << 8) - 1U,
+                               cfg_.rx_meta_buffers_ - 1U,
                                sizeof(BurstParams),
                                0,
                                0,
@@ -955,9 +955,9 @@ int DpdkMgr::setup_pools_and_rings(int max_rx_batch, int max_tx_batch) {
     }
   }
 
-  HOLOSCAN_LOG_DEBUG("Setting up TX meta pool");
+  HOLOSCAN_LOG_INFO("Setting up TX meta pool with {} buffers", cfg_.tx_meta_buffers_);
   tx_metadata = rte_mempool_create("TX_META_POOL",
-                               (1U << 8) - 1U,
+                               cfg_.tx_meta_buffers_ - 1U,
                                sizeof(BurstParams),
                                0,
                                0,

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
@@ -1757,7 +1757,7 @@ Status DpdkMgr::set_packet_tx_time(BurstParams* burst, int idx, uint64_t timesta
 }
 
 //  The number of RX can differ from the configured queues in TX-only mode where we need to create
-//  fake RX queues. 
+//  fake RX queues.
 uint16_t DpdkMgr::get_num_rx_queues(int port_id) const {
   return port_q_num.at(static_cast<uint16_t>(port_id)).first;
 }

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
@@ -91,6 +91,7 @@ struct RxWorkerMultiQPerQParams {
   int queue;
   int num_segs;
   int batch_size;
+  uint64_t timeout_us;
   struct rte_ring* ring;
 };
 
@@ -382,7 +383,7 @@ void DpdkMgr::initialize() {
   int arg = 0;
   std::string cores = std::to_string(cfg_.common_.master_core_) + ",";  // Master core must be first
   std::set<std::string> ifs;
-  std::unordered_map<uint16_t, std::pair<uint16_t, uint16_t>> port_q_num;
+
   std::unordered_map<uint16_t, std::string> port_id_to_name;
 
   // Get GPU PCIe BDFs since they're needed to pass to DPDK
@@ -1286,6 +1287,7 @@ void DpdkMgr::run() {
       params->flowid_pool = rx_flow_id_buffer;
       params->meta_pool = rx_metadata;
       params->batch_size = q->common_.batch_size_;
+      params->timeout_us = q->timeout_us_;
       rte_eal_remote_launch(
           rx_core_worker, (void*)params, strtol(q->common_.cpu_core_.c_str(), NULL, 10));
     } else {
@@ -1299,7 +1301,7 @@ void DpdkMgr::run() {
         struct rte_ring* ring_ptr = rx_rings[key];
 
         params->q_params.push_back({port_id, q_id,
-                    (int)q->common_.mrs_.size(), q->common_.batch_size_, ring_ptr});
+                    (int)q->common_.mrs_.size(), q->common_.batch_size_, q->timeout_us_, ring_ptr});
       }
 
       params->burst_pool = rx_burst_buffer;
@@ -1354,11 +1356,7 @@ int DpdkMgr::rx_core_multi_q_worker(void* arg) {
   int ret = 0;
   uint64_t freq = rte_get_tsc_hz();
   uint64_t timeout_ticks = freq * 0.02;  // expect all packets within 20ms
-  uint64_t total_pkts = 0;
-  std::array<BurstParams*, Manager::MAX_RX_Q_PER_CORE> bursts;
-
   uint16_t num_queues = tparams->q_params.size();
-  struct rte_mbuf* mbuf_arr[DEFAULT_NUM_RX_BURST];
 
   std::string pq_str = "";
   for (const auto &pq : tparams->q_params) {
@@ -1371,155 +1369,151 @@ int DpdkMgr::rx_core_multi_q_worker(void* arg) {
                     rte_socket_id());
 
   std::array<int, Manager::MAX_RX_Q_PER_CORE> nb_rx{};
-  std::array<int, Manager::MAX_RX_Q_PER_CORE> to_copy{};
   std::array<int, Manager::MAX_RX_Q_PER_CORE> cur_pkt_in_batch{};
+  std::array<BurstParams*, Manager::MAX_RX_Q_PER_CORE> bursts{};
+  std::array<std::array<rte_mbuf*, DEFAULT_NUM_RX_BURST>, Manager::MAX_RX_Q_PER_CORE> mbuf_arr{};
+  std::array<uint64_t, Manager::MAX_RX_Q_PER_CORE> total_pkts{};
+  std::array<uint64_t, Manager::MAX_RX_Q_PER_CORE> last_cycles;
+  std::generate(last_cycles.begin(), last_cycles.end(), rte_get_tsc_cycles);
 
-  uint16_t cur_idx        = 0;
-  uint16_t cur_port       = tparams->q_params[cur_idx].port;
-  uint16_t cur_q          = tparams->q_params[cur_idx].queue;
-  uint16_t cur_segs       = tparams->q_params[cur_idx].num_segs;
-  uint32_t cur_batch_size = tparams->q_params[cur_idx].batch_size;
+  uint16_t cur_idx            = 0;
+  uint16_t cur_port;
+  uint16_t cur_q;
+  uint16_t cur_segs;
+  uint32_t cur_batch_size;
+  uint64_t cur_timeout_cycles;
 
+  auto update_cur_idx = [&]() {
+    cur_idx            = (cur_idx + 1) % num_queues;
+    cur_port           = tparams->q_params[cur_idx].port;
+    cur_q              = tparams->q_params[cur_idx].queue;
+    cur_segs           = tparams->q_params[cur_idx].num_segs;
+    cur_batch_size     = tparams->q_params[cur_idx].batch_size;
+    cur_timeout_cycles = tparams->q_params[cur_idx].timeout_us;
+  };
+
+  update_cur_idx();
 
   //
   //  run loop
   //
   while (!force_quit.load()) {
-    if (rte_mempool_get(tparams->meta_pool, reinterpret_cast<void**>(&bursts[cur_idx])) < 0) {
-      HOLOSCAN_LOG_ERROR("Processing function falling behind. No free buffers for metadata!");
-      exit(1);
-    }
+    if (bursts[cur_idx] == nullptr) {  // Allocate a new burst
+      if (rte_mempool_get(tparams->meta_pool, reinterpret_cast<void**>(&bursts[cur_idx])) < 0) {
+        HOLOSCAN_LOG_ERROR("Processing function falling behind. No free buffers for metadata!");
+        exit(1);
+      }
 
-    BurstParams* burst  = bursts[cur_idx];
+      //  Queue ID for receiver to differentiate
+      bursts[cur_idx]->hdr.hdr.q_id     = cur_q;
+      bursts[cur_idx]->hdr.hdr.port_id  = cur_port;
+      bursts[cur_idx]->hdr.hdr.num_segs = cur_segs;
+      bursts[cur_idx]->hdr.hdr.num_pkts = 0;
 
-    //  Queue ID for receiver to differentiate
-    burst->hdr.hdr.q_id     = cur_q;
-    burst->hdr.hdr.port_id  = cur_port;
-    burst->hdr.hdr.num_segs = cur_segs;
+      for (int seg = 0; seg < cur_segs; seg++) {
+        if (rte_mempool_get(tparams->burst_pool,
+          reinterpret_cast<void**>(&bursts[cur_idx]->pkts[seg])) < 0) {
+          HOLOSCAN_LOG_ERROR(
+              "Processing function falling behind. No free RX bursts!");
+          continue;
+        }
+      }
 
-    for (int seg = 0; seg < cur_segs; seg++) {
-      if (rte_mempool_get(tparams->burst_pool, reinterpret_cast<void**>(&burst->pkts[seg])) < 0) {
-        HOLOSCAN_LOG_ERROR(
-            "Processing function falling behind. No free flow ID buffers for packets!");
+      if (rte_mempool_get(
+            tparams->flowid_pool, reinterpret_cast<void**>(&bursts[cur_idx]->pkt_extra_info)) < 0) {
+        HOLOSCAN_LOG_ERROR("Processing function falling behind. No free CPU buffers for packets!");
         continue;
       }
     }
 
-    if (rte_mempool_get(
-          tparams->flowid_pool, reinterpret_cast<void**>(&burst->pkt_extra_info)) < 0) {
-      HOLOSCAN_LOG_ERROR("Processing function falling behind. No free CPU buffers for packets!");
-      continue;
-    }
-
-    ExtraRxPacketInfo *pkt_info = reinterpret_cast<ExtraRxPacketInfo*>(burst->pkt_extra_info);
-
-    if (nb_rx[cur_idx] > 0) {
-      burst->hdr.hdr.num_pkts = nb_rx[cur_idx];
-
-      // Copy non-scattered buffers
-      memcpy(&burst->pkts[0][0],
-             &mbuf_arr[to_copy[cur_idx]],
-             sizeof(rte_mbuf*) * nb_rx[cur_idx]);
-
-      for (int flow_idx = 0; flow_idx < nb_rx[cur_idx]; flow_idx++) {
-        if (mbuf_arr[to_copy[cur_idx] + flow_idx]->ol_flags & RTE_MBUF_F_RX_FDIR_ID) {
-          pkt_info[flow_idx].flow_id = mbuf_arr[to_copy[cur_idx] + flow_idx]->hash.fdir.hi;
-        } else {
-          pkt_info[flow_idx].flow_id = 0;
-        }
-      }
-
-      if (cur_segs > 1) {  // Extra work when buffers are scattered
-        for (int p = 0; p < nb_rx[cur_idx]; p++) {
-          struct rte_mbuf* mbuf = mbuf_arr[p];
-          for (int seg = 1; seg < cur_segs; seg++) {
-            mbuf = mbuf->next;
-            burst->pkts[seg][p] = mbuf;
-          }
-        }
-
-        cur_pkt_in_batch[cur_idx] += nb_rx[cur_idx];
-      }
-
-      nb_rx[cur_idx] = 0;
-    } else {
-      burst->hdr.hdr.num_pkts = 0;
-    }
-
-    // Move on to the next queue to ensure fairness among queues
-    cur_idx = (cur_idx + 1) % num_queues;
-    cur_port       = tparams->q_params[cur_idx].port;
-    cur_q          = tparams->q_params[cur_idx].queue;
-    cur_segs       = tparams->q_params[cur_idx].num_segs;
-    cur_batch_size = tparams->q_params[cur_idx].batch_size;
-
-    // DPDK on some ARM platforms requires that you always pass nb_pkts as a number divisible
-    // by 4. If you pass something other than that, you get undefined results and will end up
-    // running out of buffers.
-    do {
-      int burst_size = std::min((uint32_t)DpdkMgr::DEFAULT_NUM_RX_BURST,
-                                (uint32_t)(cur_batch_size - burst->hdr.hdr.num_pkts));
-
-      nb_rx[cur_idx] = rte_eth_rx_burst(cur_port,
-                               cur_q,
-                               reinterpret_cast<rte_mbuf**>(&mbuf_arr[0]),
-                               DpdkMgr::DEFAULT_NUM_RX_BURST);
+    // Check if we need to get more packets
+    if (nb_rx[cur_idx] == 0) {
+      cur_pkt_in_batch[cur_idx] = 0;
+      nb_rx[cur_idx] = rte_eth_rx_burst(cur_port, cur_q,
+                      reinterpret_cast<rte_mbuf**>(&mbuf_arr[cur_idx][0]), DEFAULT_NUM_RX_BURST);
 
       if (nb_rx[cur_idx] == 0) {
-        cur_idx = (cur_idx + 1) % num_queues;
-        cur_port       = tparams->q_params[cur_idx].port;
-        cur_q          = tparams->q_params[cur_idx].queue;
-        cur_segs       = tparams->q_params[cur_idx].num_segs;
-        cur_batch_size = tparams->q_params[cur_idx].batch_size;
-        continue;
-      }
+        if (bursts[cur_idx]->hdr.hdr.num_pkts > 0 && cur_timeout_cycles > 0) {
+          const auto cur_cycles = rte_get_tsc_cycles();
 
-      to_copy[cur_idx] = std::min(nb_rx[cur_idx],
-                                  (int)(cur_batch_size - burst->hdr.hdr.num_pkts));
-      memcpy(&burst->pkts[0][burst->hdr.hdr.num_pkts],
-             &mbuf_arr,
-             sizeof(rte_mbuf*) * to_copy[cur_idx]);
-
-      for (int flow_idx = 0; flow_idx < to_copy[cur_idx]; flow_idx++) {
-        if (mbuf_arr[flow_idx]->ol_flags & RTE_MBUF_F_RX_FDIR_ID) {
-          pkt_info[burst->hdr.hdr.num_pkts + flow_idx].flow_id = mbuf_arr[flow_idx]->hash.fdir.hi;
-        } else {
-          pkt_info[burst->hdr.hdr.num_pkts + flow_idx].flow_id = 0;
-        }
-      }
-
-      if (cur_segs > 1) {  // Extra work when buffers are scattered
-        for (int p = 0; p < to_copy[cur_idx]; p++) {
-          struct rte_mbuf* mbuf = mbuf_arr[p];
-          for (int seg = 1; seg < cur_segs; seg++) {
-            mbuf = mbuf->next;
-            burst->pkts[seg][cur_pkt_in_batch[cur_idx] + p] = mbuf;
+          // We hit our timeout. Send the partial batch immediately
+          if ((cur_cycles - last_cycles[cur_idx]) > cur_timeout_cycles) {
+            rte_ring_enqueue(tparams->q_params[cur_idx].ring,
+                        reinterpret_cast<void*>(bursts[cur_idx]));
+            last_cycles[cur_idx] = cur_cycles;
+            bursts[cur_idx] = nullptr;
           }
         }
 
-        cur_pkt_in_batch[cur_idx] += to_copy[cur_idx];
+        update_cur_idx();
+        continue;
       }
+    }
 
-      burst->hdr.hdr.num_pkts += to_copy[cur_idx];
-      total_pkts              += nb_rx[cur_idx];
-      nb_rx[cur_idx]          -= to_copy[cur_idx];
+    // At this point we have some packets to copy either from a new batch or an existing one. Check
+    // if we are finishing a batch or copying all packets that came in
+    int to_copy = std::min(static_cast<size_t>(nb_rx[cur_idx]),
+                        cur_batch_size - bursts[cur_idx]->hdr.hdr.num_pkts);
+    memcpy(&bursts[cur_idx]->pkts[0][bursts[cur_idx]->hdr.hdr.num_pkts],
+                  &mbuf_arr[cur_idx][cur_pkt_in_batch[cur_idx]], sizeof(rte_mbuf*) * to_copy);
 
-      if (burst->hdr.hdr.num_pkts == cur_batch_size) {
-        cur_pkt_in_batch[cur_idx] = 0;
-        rte_ring_enqueue(tparams->q_params[cur_idx].ring, reinterpret_cast<void*>(burst));
-
-        // Don't move to the next queue yet since there may be some packets left over in the array
-        break;
+    ExtraRxPacketInfo* pkt_info =
+                          reinterpret_cast<ExtraRxPacketInfo*>(bursts[cur_idx]->pkt_extra_info);
+    for (int p = 0; p < to_copy; p++) {
+      if (mbuf_arr[cur_idx][cur_pkt_in_batch[cur_idx] + p]->ol_flags & RTE_MBUF_F_RX_FDIR_ID) {
+        pkt_info[bursts[cur_idx]->hdr.hdr.num_pkts + p].flow_id =
+                              mbuf_arr[cur_idx][cur_pkt_in_batch[cur_idx] + p]->hash.fdir.hi;
+      } else {
+        pkt_info[bursts[cur_idx]->hdr.hdr.num_pkts + p].flow_id = 0;
       }
-    } while (!force_quit.load());
+    }
+
+    if (cur_segs > 1) {  // Extra work when buffers are scattered
+      for (int p = 0; p < to_copy; p++) {
+        struct rte_mbuf* mbuf = mbuf_arr[cur_idx][cur_pkt_in_batch[cur_idx] + p];
+        for (int seg = 1; seg < cur_segs; seg++) {
+          mbuf = mbuf->next;
+          bursts[cur_idx]->pkts[seg][bursts[cur_idx]->hdr.hdr.num_pkts + p] = mbuf;
+        }
+      }
+    }
+
+    cur_pkt_in_batch[cur_idx]         += to_copy;
+    bursts[cur_idx]->hdr.hdr.num_pkts += to_copy;
+    nb_rx[cur_idx]                    -= to_copy;
+    total_pkts[cur_idx]               += to_copy;
+
+    if (bursts[cur_idx]->hdr.hdr.num_pkts == cur_batch_size) {
+      rte_ring_enqueue(tparams->q_params[cur_idx].ring, reinterpret_cast<void*>(bursts[cur_idx]));
+      last_cycles[cur_idx] = rte_get_tsc_cycles();
+      bursts[cur_idx] = nullptr;
+    } else if (cur_timeout_cycles > 0) {
+      const auto cur_cycles = rte_get_tsc_cycles();
+
+      // We hit our timeout. Send the partial batch immediately
+      if ((cur_cycles - last_cycles[cur_idx]) > cur_timeout_cycles) {
+        rte_ring_enqueue(tparams->q_params[cur_idx].ring, reinterpret_cast<void*>(bursts[cur_idx]));
+        last_cycles[cur_idx] = cur_cycles;
+        bursts[cur_idx] = nullptr;
+      }
+    }
+
+    update_cur_idx();
+  } while (!force_quit.load());
+
+  for (int i = 0; i < num_queues; i++) {
+    cur_port           = tparams->q_params[i].port;
+    cur_q              = tparams->q_params[i].queue;
+    HOLOSCAN_LOG_INFO("Total packets received by RX core {} (Port/Queue {}/{}): {}",
+                     rte_lcore_id(),
+                     cur_port,
+                     cur_q,
+                     total_pkts[i]);
   }
-
-  HOLOSCAN_LOG_INFO("Total packets received by application (Port/Queue {}): {}",
-                     pq_str,
-                     total_pkts);
 
   return 0;
 }
+
 
 ////////////////////////////////////////////////////////////////////////////////
 ///
@@ -1538,6 +1532,7 @@ int DpdkMgr::rx_core_worker(void* arg) {
 
   flush_packets(tparams->port);
   struct rte_mbuf* mbuf_arr[DEFAULT_NUM_RX_BURST];
+  int pkts_per_poll = std::min(DEFAULT_NUM_RX_BURST, (uint16_t)tparams->batch_size);
 
   HOLOSCAN_LOG_INFO("Starting RX Core {}, port {}, queue {}, socket {}",
                     rte_lcore_id(),
@@ -1545,81 +1540,47 @@ int DpdkMgr::rx_core_worker(void* arg) {
                     tparams->queue,
                     rte_socket_id());
   int nb_rx = 0;
-  int to_copy = 0;
   int cur_pkt_in_batch = 0;
+  BurstParams* burst = nullptr;
+  ExtraRxPacketInfo *pkt_info;
   //
   //  run loop
   //
   while (!force_quit.load()) {
-    BurstParams* burst;
-    if (rte_mempool_get(tparams->meta_pool, reinterpret_cast<void**>(&burst)) < 0) {
-      HOLOSCAN_LOG_ERROR("Processing function falling behind. No free buffers for metadata!");
-      exit(1);
-    }
+    if (burst == nullptr) {  // Allocate a new burst
+      if (rte_mempool_get(tparams->meta_pool, reinterpret_cast<void**>(&burst)) < 0) {
+        HOLOSCAN_LOG_ERROR("Processing function falling behind. No free buffers for metadata!");
+        exit(1);
+      }
 
-    //  Queue ID for receiver to differentiate
-    burst->hdr.hdr.q_id = tparams->queue;
-    burst->hdr.hdr.port_id = tparams->port;
-    burst->hdr.hdr.num_segs = tparams->num_segs;
+      //  Queue ID for receiver to differentiate
+      burst->hdr.hdr.q_id     = tparams->queue;
+      burst->hdr.hdr.port_id  = tparams->port;
+      burst->hdr.hdr.num_segs = tparams->num_segs;
+      burst->hdr.hdr.num_pkts = 0;
 
-    for (int seg = 0; seg < tparams->num_segs; seg++) {
-      if (rte_mempool_get(tparams->burst_pool, reinterpret_cast<void**>(&burst->pkts[seg])) < 0) {
-        HOLOSCAN_LOG_ERROR(
-            "Processing function falling behind. No free RX bursts!");
+      for (int seg = 0; seg < tparams->num_segs; seg++) {
+        if (rte_mempool_get(tparams->burst_pool, reinterpret_cast<void**>(&burst->pkts[seg])) < 0) {
+          HOLOSCAN_LOG_ERROR(
+              "Processing function falling behind. No free RX bursts!");
+          continue;
+        }
+      }
+
+      if (rte_mempool_get(
+            tparams->flowid_pool, reinterpret_cast<void**>(&burst->pkt_extra_info)) < 0) {
+        HOLOSCAN_LOG_ERROR("Processing function falling behind. No free CPU buffers for packets!");
         continue;
       }
+
+      pkt_info = reinterpret_cast<ExtraRxPacketInfo*>(burst->pkt_extra_info);
     }
 
-    if (rte_mempool_get(
-          tparams->flowid_pool, reinterpret_cast<void**>(&burst->pkt_extra_info)) < 0) {
-      HOLOSCAN_LOG_ERROR("Processing function falling behind. No free CPU buffers for packets!");
-      continue;
-    }
-
-    ExtraRxPacketInfo *pkt_info = reinterpret_cast<ExtraRxPacketInfo*>(burst->pkt_extra_info);
-
-    if (nb_rx > 0) {
-      burst->hdr.hdr.num_pkts = nb_rx;
-
-      // Copy non-scattered buffers
-      memcpy(&burst->pkts[0][0], &mbuf_arr[to_copy], sizeof(rte_mbuf*) * nb_rx);
-
-      for (int p = 0; p < nb_rx; p++) {
-        if (mbuf_arr[to_copy + p]->ol_flags & RTE_MBUF_F_RX_FDIR_ID) {
-          pkt_info[p].flow_id = mbuf_arr[to_copy + p]->hash.fdir.hi;
-        } else {
-          pkt_info[p].flow_id = 0;
-        }
-      }
-
-      if (tparams->num_segs > 1) {  // Extra work when buffers are scattered
-        for (int p = 0; p < nb_rx; p++) {
-          struct rte_mbuf* mbuf = mbuf_arr[to_copy + p];
-          for (int seg = 1; seg < tparams->num_segs; seg++) {
-            mbuf = mbuf->next;
-            burst->pkts[seg][p] = mbuf;
-          }
-        }
-
-        cur_pkt_in_batch += nb_rx;
-      }
-
-      nb_rx = 0;
-    } else {
-      burst->hdr.hdr.num_pkts = 0;
-    }
-
-    // DPDK on some ARM platforms requires that you always pass nb_pkts as a number divisible
-    // by 4. If you pass something other than that, you get undefined results and will end up
-    // running out of buffers.
-    do {
-      int burst_size = std::min((uint32_t)DEFAULT_NUM_RX_BURST,
-                                (uint32_t)(tparams->batch_size - burst->hdr.hdr.num_pkts));
-
-      nb_rx = rte_eth_rx_burst(tparams->port,
-                               tparams->queue,
-                               reinterpret_cast<rte_mbuf**>(&mbuf_arr[0]),
-                               DEFAULT_NUM_RX_BURST);
+    // Check if we need to get more packets
+    if (nb_rx == 0) {
+      cur_pkt_in_batch = 0;
+      nb_rx = rte_eth_rx_burst(tparams->port, tparams->queue,
+                          reinterpret_cast<rte_mbuf**>(&mbuf_arr[0]), DEFAULT_NUM_RX_BURST);
 
       if (nb_rx == 0) {
         if (burst->hdr.hdr.num_pkts > 0 && timeout_cycles > 0) {
@@ -1627,61 +1588,62 @@ int DpdkMgr::rx_core_worker(void* arg) {
 
           // We hit our timeout. Send the partial batch immediately
           if ((cur_cycles - last_cycles) > timeout_cycles) {
-            cur_pkt_in_batch = 0;
             rte_ring_enqueue(tparams->ring, reinterpret_cast<void*>(burst));
             last_cycles = cur_cycles;
-            break;
+            burst = nullptr;
           }
         }
 
         continue;
       }
+    }
 
-      to_copy = std::min(nb_rx, (int)(tparams->batch_size - burst->hdr.hdr.num_pkts));
-      memcpy(&burst->pkts[0][burst->hdr.hdr.num_pkts], &mbuf_arr, sizeof(rte_mbuf*) * to_copy);
+    // At this point we have some packets to copy either from a new batch or an existing one. Check
+    // if we are finishing a batch or copying all packets that came in
+    int to_copy = std::min(static_cast<size_t>(nb_rx),
+                                    tparams->batch_size - burst->hdr.hdr.num_pkts);
+    memcpy(&burst->pkts[0][burst->hdr.hdr.num_pkts],
+                                        &mbuf_arr[cur_pkt_in_batch], sizeof(rte_mbuf*) * to_copy);
 
+    for (int p = 0; p < to_copy; p++) {
+      if (mbuf_arr[cur_pkt_in_batch + p]->ol_flags & RTE_MBUF_F_RX_FDIR_ID) {
+        pkt_info[burst->hdr.hdr.num_pkts + p].flow_id =
+                                          mbuf_arr[cur_pkt_in_batch + p]->hash.fdir.hi;
+      } else {
+        pkt_info[burst->hdr.hdr.num_pkts + p].flow_id = 0;
+      }
+    }
+
+    if (tparams->num_segs > 1) {  // Extra work when buffers are scattered
       for (int p = 0; p < to_copy; p++) {
-        if (mbuf_arr[p]->ol_flags & RTE_MBUF_F_RX_FDIR_ID) {
-          pkt_info[burst->hdr.hdr.num_pkts + p].flow_id = mbuf_arr[p]->hash.fdir.hi;
-        } else {
-          pkt_info[burst->hdr.hdr.num_pkts + p].flow_id = 0;
+        struct rte_mbuf* mbuf = mbuf_arr[cur_pkt_in_batch + p];
+        for (int seg = 1; seg < tparams->num_segs; seg++) {
+          mbuf = mbuf->next;
+          burst->pkts[seg][burst->hdr.hdr.num_pkts + p] = mbuf;
         }
       }
+    }
 
-      if (tparams->num_segs > 1) {  // Extra work when buffers are scattered
-        for (int p = 0; p < to_copy; p++) {
-          struct rte_mbuf* mbuf = mbuf_arr[p];
-          for (int seg = 1; seg < tparams->num_segs; seg++) {
-            mbuf = mbuf->next;
-            burst->pkts[seg][cur_pkt_in_batch + p] = mbuf;
-          }
-        }
+    cur_pkt_in_batch        += to_copy;
+    burst->hdr.hdr.num_pkts += to_copy;
+    nb_rx                   -= to_copy;
+    total_pkts              += to_copy;
 
-        cur_pkt_in_batch += to_copy;
-      }
+    if (burst->hdr.hdr.num_pkts == tparams->batch_size) {
+      rte_ring_enqueue(tparams->ring, reinterpret_cast<void*>(burst));
+      last_cycles = rte_get_tsc_cycles();
+      burst = nullptr;
+    } else if (timeout_cycles > 0) {
+      const auto cur_cycles = rte_get_tsc_cycles();
 
-      burst->hdr.hdr.num_pkts += to_copy;
-      total_pkts += nb_rx;
-      nb_rx -= to_copy;
-
-      if (burst->hdr.hdr.num_pkts == tparams->batch_size) {
+      // We hit our timeout. Send the partial batch immediately
+      if ((cur_cycles - last_cycles) > timeout_cycles) {
         rte_ring_enqueue(tparams->ring, reinterpret_cast<void*>(burst));
-        cur_pkt_in_batch = 0;
-        last_cycles = rte_get_tsc_cycles();
-        break;
-      } else if (timeout_cycles > 0) {
-        const auto cur_cycles = rte_get_tsc_cycles();
-
-        // We hit our timeout. Send the partial batch immediately
-        if ((cur_cycles - last_cycles) > timeout_cycles) {
-          rte_ring_enqueue(tparams->ring, reinterpret_cast<void*>(burst));
-          cur_pkt_in_batch = 0;
-          last_cycles = cur_cycles;
-          break;
-        }
+        last_cycles = cur_cycles;
+        burst = nullptr;
       }
-    } while (!force_quit.load());
-  }
+    }
+  } while (!force_quit.load());
 
   HOLOSCAN_LOG_INFO("Total packets received by application (port/queue {}/{}): {}",
                      tparams->port,
@@ -1784,6 +1746,10 @@ Status DpdkMgr::set_packet_tx_time(BurstParams* burst, int idx, uint64_t timesta
       reinterpret_cast<rte_mbuf**>(burst->pkts[0])[idx], timestamp_offset_, uint64_t*) = timestamp;
 
   return Status::SUCCESS;
+}
+
+uint16_t DpdkMgr::get_num_rx_queues(int port_id) const {
+  return port_q_num.at(static_cast<uint16_t>(port_id)).first;
 }
 
 void* DpdkMgr::get_packet_extra_info(BurstParams* burst, int idx) {

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
@@ -1406,8 +1406,8 @@ int DpdkMgr::rx_core_multi_q_worker(void* arg) {
       if (rte_mempool_get(tparams->meta_pool, reinterpret_cast<void**>(&bursts[cur_idx])) < 0) {
         HOLOSCAN_LOG_CRITICAL("Running out of RX meta buffers due to high rates. Either increase "\
           "your number of metadata buffers (current: {}) with `rx_meta_buffers` (will "\
-          "increase memory usage) or increase your `batch_size` for port {} queue {} (will increase "\
-          "latency)", tparams->meta_pool_size, cur_port, cur_q);
+          "increase memory usage) or increase your `batch_size` for port {} queue {} (will "\
+          "increase latency)", tparams->meta_pool_size, cur_port, cur_q);
         exit(1);
       }
 
@@ -1556,8 +1556,8 @@ int DpdkMgr::rx_core_worker(void* arg) {
       if (rte_mempool_get(tparams->meta_pool, reinterpret_cast<void**>(&burst)) < 0) {
         HOLOSCAN_LOG_CRITICAL("Running out of RX meta buffers due to high rates. Either increase "\
           "your number of metadata buffers (current: {}) with `rx_meta_buffers` (will "\
-          "increase memory usage) or increase your `batch_size` for port {} queue {} (will increase "\
-          "latency)", tparams->meta_pool_size, tparams->port, tparams->queue);
+          "increase memory usage) or increase your `batch_size` for port {} queue {} (will "\
+          "increase latency)", tparams->meta_pool_size, tparams->port, tparams->queue);
         exit(1);
       }
 

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.cpp
@@ -1756,6 +1756,8 @@ Status DpdkMgr::set_packet_tx_time(BurstParams* burst, int idx, uint64_t timesta
   return Status::SUCCESS;
 }
 
+//  The number of RX can differ from the configured queues in TX-only mode where we need to create
+//  fake RX queues. 
 uint16_t DpdkMgr::get_num_rx_queues(int port_id) const {
   return port_q_num.at(static_cast<uint16_t>(port_id)).first;
 }

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.h
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.h
@@ -148,7 +148,7 @@ class DpdkMgr : public Manager {
   void run() override;
   static constexpr int JUMBOFRAME_SIZE = 9100;
   static constexpr int DEFAULT_NUM_TX_BURST = 256;
-  static constexpr int DEFAULT_NUM_RX_BURST = 64;
+  static constexpr uint16_t DEFAULT_NUM_RX_BURST = 64;
   uint16_t default_num_rx_desc = 8192;
   uint16_t default_num_tx_desc = 8192;
   int num_ports = 0;
@@ -198,6 +198,7 @@ class DpdkMgr : public Manager {
   uint64_t get_burst_tot_byte(BurstParams* burst) override;
   BurstParams* create_tx_burst_params() override;
   bool validate_config() const override;
+  uint16_t get_num_rx_queues(int port_id) const override;
 
  private:
   static void PrintDpdkStats(int port);
@@ -227,6 +228,7 @@ class DpdkMgr : public Manager {
   std::unordered_map<uint32_t, DPDKQueueConfig*> rx_dpdk_q_map_;
   std::unordered_map<uint32_t, DPDKQueueConfig*> tx_dpdk_q_map_;
   std::unordered_map<uint32_t, const RxQueueConfig*> rx_cfg_q_map_;
+  std::unordered_map<uint16_t, std::pair<uint16_t, uint16_t>> port_q_num;
   struct rte_mempool* pkt_len_buffer;
   struct rte_mempool* rx_burst_buffer;
   struct rte_mempool* rx_flow_id_buffer;

--- a/operators/advanced_network/advanced_network/types.h
+++ b/operators/advanced_network/advanced_network/types.h
@@ -392,6 +392,8 @@ struct NetworkConfig {
   std::unordered_map<std::string, MemoryRegionConfig> mrs_;
   std::vector<InterfaceConfig> ifs_;
   uint16_t debug_;
+  // Number of metadata buffers for TX and RX. Higher numbers can handle more bursts per second
+  // at the cost of more memory.
   uint32_t tx_meta_buffers_;
   uint32_t rx_meta_buffers_;
   LogLevel::Level log_level_;

--- a/operators/advanced_network/advanced_network/types.h
+++ b/operators/advanced_network/advanced_network/types.h
@@ -392,6 +392,8 @@ struct NetworkConfig {
   std::unordered_map<std::string, MemoryRegionConfig> mrs_;
   std::vector<InterfaceConfig> ifs_;
   uint16_t debug_;
+  uint32_t tx_meta_buffers_;
+  uint32_t rx_meta_buffers_;
   LogLevel::Level log_level_;
 };
 

--- a/operators/advanced_network/metadata.json
+++ b/operators/advanced_network/metadata.json
@@ -7,8 +7,9 @@
 				"affiliation": "NVIDIA"
 			}
 		],
-		"version": "1.4",
+		"version": "1.5",
 		"changelog": {
+			"1.5": "Multi-queue fixes plus support for UDP source and destination ports as ranges",
 			"1.4": "More flow support",
 			"1.3": "Plugin support",
 			"1.2": "TX GPUDirect",
@@ -28,7 +29,7 @@
 		"dependencies": {
 				"gxf_extensions": [{
 					"name": "advanced_network",
-					"version": "1.4"
+					"version": "1.5"
 				}
 			   ]
 			}


### PR DESCRIPTION
A customer reported a segfault with a config where a single core handles multiple queues. The receive functions had also become too complex over time with some repeated code. This PR cleans up the receive functions and fixes the segfault.