### PR TITLE
Enable X11 display container parameters by default

### DIFF
--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -232,7 +232,7 @@ class HoloHubContainer:
         self,
         img: Optional[str] = None,
         local_sdk_root: Optional[Path] = None,
-        ssh_x11: bool = False,
+        enable_x11: bool = True,
         use_tini: bool = False,
         persistent: bool = False,
         nsys_profile: bool = False,
@@ -317,7 +317,7 @@ class HoloHubContainer:
         cmd.extend(self.ucx_args())
 
         # Add display server options
-        cmd.extend(self.get_display_options(ssh_x11))
+        cmd.extend(self.get_display_options(enable_x11))
 
         # Add nsys options
         cmd.extend(self.get_nsys_options(nsys_profile, nsys_location))
@@ -346,7 +346,7 @@ class HoloHubContainer:
 
         run_command(cmd, dry_run=self.dryrun)
 
-    def get_display_options(self, ssh_x11: bool) -> List[str]:
+    def get_display_options(self, enable_x11: bool) -> List[str]:
         """Get display-related options"""
         options = []
         if "XDG_SESSION_TYPE" in os.environ:
@@ -361,7 +361,7 @@ class HoloHubContainer:
                     ["-v", f"{os.environ['XDG_RUNTIME_DIR']}:{os.environ['XDG_RUNTIME_DIR']}"]
                 )
 
-        if ssh_x11:
+        if enable_x11:
             options.extend(["-v", "/tmp/.X11-unix:/tmp/.X11-unix", "-e", "DISPLAY"])
         return options
 

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -101,11 +101,6 @@ class HoloHubCLI:
             "--local_sdk_root",
             help="Path to Holoscan SDK used for building local Holoscan SDK container",
         )
-        run_container.add_argument(
-            "--ssh_x11",
-            action="store_true",
-            help="Enable X11 forwarding of graphical HoloHub applications over SSH",
-        )
         run_container.add_argument("--init", action="store_true", help="Support tini entry point")
         run_container.add_argument(
             "--persistent", action="store_true", help="Does not delete container after it is run"
@@ -291,7 +286,6 @@ class HoloHubCLI:
         container.run(
             img=args.img,
             local_sdk_root=args.local_sdk_root,
-            ssh_x11=args.ssh_x11,
             use_tini=args.init,
             persistent=args.persistent,
             as_root=args.as_root,


### PR DESCRIPTION
Under previous behavior the `--ssh_x11` flag must be specified to mount the X11 socket directory and set the DISPLAY variable in the container, with headless as the default. (`./holohub run-container --ssh_x11`)

This fixes behavior so that X11 display behavior is enabled by default. (`./holohub run-container` or `./holohub run <app>`)