### PR TITLE
App: Relax package requirements in `hyperspectral_segmentation`

### DIFF
--- a/applications/hyperspectral_segmentation/Dockerfile
+++ b/applications/hyperspectral_segmentation/Dockerfile
@@ -26,13 +26,13 @@ ARG DEBIAN_FRONTEND=noninteractive
 #
 # Install required python modules
 RUN pip3 install \
-    numpy==1.24.4 \
-    blosc==1.11.1 \
-    torch==2.1.0 \
-    onnx==1.15.0 \
-    onnxruntime==1.16.1 \
-    Pillow==10.1.0 \
-    matplotlib==3.7.4
+    numpy>=1.24.4 \
+    blosc>=1.11.1 \
+    torch>=2.1.0 \
+    onnx>=1.15.0 \
+    onnxruntime>=1.16.1 \
+    Pillow>=10.1.0 \
+    matplotlib>=3.7.4
 
 # --------------------------------------------------------------------------
 #


### PR DESCRIPTION
Allow `hyperspectral_segmentation` to run with packages above some minimum requirement

Aims to address build failure where NumPy 1.24.4 wheels are not available for Python 3.12, which is default in Ubuntu 24.04 base containers for Holoscan SDK v3.3

```
pip._vendor.pyproject_hooks._impl.BackendUnavailable: Cannot import 'setuptools.build_meta'
```

Resulting installed packages:
```
$ python -m pip list 
Package                  Version
------------------------ -----------
blosc                    1.11.2
cloudpickle              3.1.1
coloredlogs              15.0.1
contourpy                1.3.2
cupy-cuda12x             13.4.1
cycler                   0.12.1
fastrlock                0.8.3
filelock                 3.18.0
flatbuffers              25.2.10
fonttools                4.58.0
fsspec                   2025.3.2
humanfriendly            10.0
intel-openmp             2021.4.0
Jinja2                   3.1.6
kiwisolver               1.4.8
Mako                     1.3.9
MarkupSafe               3.0.2
matplotlib               3.10.3
mkl                      2021.1.1
mpmath                   1.3.0
networkx                 3.4.2
numpy                    2.2.5
nvidia-cublas-cu12       12.6.4.1
nvidia-cuda-cupti-cu12   12.6.80
nvidia-cuda-nvrtc-cu12   12.6.77
nvidia-cuda-runtime-cu12 12.6.77
nvidia-cudnn-cu12        9.5.1.17
nvidia-cufft-cu12        11.3.0.4
nvidia-cufile-cu12       1.11.1.6
nvidia-curand-cu12       10.3.7.77
nvidia-cusolver-cu12     11.7.1.2
nvidia-cusparse-cu12     12.5.4.2
nvidia-cusparselt-cu12   0.6.3
nvidia-nccl-cu12         2.26.2
nvidia-nvjitlink-cu12    12.6.85
nvidia-nvtx-cu12         12.6.77
onnx                     1.18.0
onnxruntime              1.22.0
packaging                25.0
pillow                   11.2.1
pip                      25.0.1
platformdirs             4.3.6
polygraphy               0.49.20
protobuf                 6.31.0
pycuda                   2025.1
pyparsing                3.2.3
python-dateutil          2.9.0.post0
pytools                  2025.1.1
setuptools               80.4.0
six                      1.17.0
sympy                    1.14.0
tbb                      2021.13.1
tensorrt                 10.9.0.34
torch                    2.7.0
triton                   3.3.0
typing_extensions        4.12.2
```