### PR TITLE
VolumeRendering: fix GCC 13 build error

### DIFF
--- a/operators/volume_renderer/CMakeLists.txt
+++ b/operators/volume_renderer/CMakeLists.txt
@@ -47,6 +47,8 @@ FetchContent_Declare(
     ClaraViz
     URL https://github.com/NVIDIA/clara-viz/archive/refs/tags/${_clara_viz_version}.tar.gz
     URL_MD5 cbb39f33316c6365f623bf6920126b5c
+    # apply a patch to fix building with gcc 13
+    PATCH_COMMAND patch -p1 -N < "${CMAKE_CURRENT_SOURCE_DIR}/clara_viz_gcc_13_fix.patch" || true
     )
 
 # enable CMP0077 to allow overwriting option() statements in FetchContent sub-projects

--- a/operators/volume_renderer/clara_viz_gcc_13_fix.patch
+++ b/operators/volume_renderer/clara_viz_gcc_13_fix.patch
@@ -1,0 +1,11 @@
+diff -Naur a/src/claraviz/util/Exception.h b/src/claraviz/util/Exception.h
+--- a/src/claraviz/util/Exception.h	2025-05-15 09:09:08.863921942 +0200
++++ b/src/claraviz/util/Exception.h	2025-05-15 09:08:43.697934661 +0200
+@@ -18,6 +18,7 @@
+ 
+ #include <sstream>
+ #include <stdexcept>
++#include <cstdint>
+ 
+ namespace clara::viz
+ {


### PR DESCRIPTION
Output: `error: 'uint32_t' has not been declared`
Solution: Patch ClaraViz `Exception.h` file to include <cstdint>