### PR TITLE
Reverting default config for endoscopy tool tracking

### DIFF
--- a/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
+++ b/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
@@ -41,8 +41,8 @@ record_type: "none"   # or "input" if you want to record input video stream, or 
                       # to record the visualizer output.
 
 external_source:
-  rdma: false
-  enable_overlay: true
+  rdma: true
+  enable_overlay: false
 
 aja:
   width: 1920


### PR DESCRIPTION
Disabling RDMA and enabling it for overlay is not possible with AJA.
For simplicity and consistency reverting back to original default configuration.
Note: the modification was introduced by Deltacast for testing.