### PR TITLE
Operator Naming Convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,17 +52,17 @@ We recommend that new developers review GitHub's [starting documentation](https:
 
 2. Git clone the forked repository and push changes to the personal fork.
 
-```bash
-git clone https://github.com/YOUR_USERNAME/YOUR_FORK.git HoloHub
-# Checkout the targeted branch and commit changes
-# Push the commits to a branch on the fork (remote).
-git push -u origin <local-branch>:<remote-branch>
-```
+    ```bash
+    git clone https://github.com/YOUR_USERNAME/YOUR_FORK.git HoloHub
+    # Checkout the targeted branch and commit changes
+    # Push the commits to a branch on the fork (remote).
+    git push -u origin <local-branch>:<remote-branch>
+    ```
 
 3. Once the code changes are staged on the fork and ready for review, please [submit](https://help.github.com/en/articles/creating-a-pull-request) a [Pull Request](https://help.github.com/en/articles/about-pull-requests) (PR) to merge the changes from a branch of the fork into a selected branch of upstream.
 
-- Exercise caution when selecting the source and target branches for the PR.
-- Creation of a PR creation kicks off the [code review](#preparing-your-submission) process.
+    - Exercise caution when selecting the source and target branches for the PR.
+    - Creation of a PR kicks off the [code review](#preparing-your-submission) process.
 
 4. HoloHub maintainers will review the PR and accept the proposal if changes meet HoloHub standards.
 
@@ -77,7 +77,6 @@ A typical submission consists of:
 - Application, workflow, operator, and/or tutorial code making use of the Holoscan SDK;
 - A [`metadata.json`](#metadata-description) file;
 - A [README](#readme-file) file describing the application, workflow, operator, and/or tutorial;
-- A [LICENSE](#license-guidelines) file (optional).
 
 For a submission to be accepted into HoloHub it must meet at least these criteria:
 
@@ -98,56 +97,56 @@ and dependencies.
 ```json
 // Main json definition for application or operator
 "application|operator": {
-	    // Explicit name of the contribution
-		"name": "explicit name of the application/operator",
-		// Author(s) of the contribution
-		"authors": [
-			{
-				"name": "firstname lastname",
-				"affiliation": "affiliation"
-			}
-		],
-		// Supported language
-		// If multiple languages are supported, create a directory per language and a json file accordingly
-		"language": "C++|Python|GXF",
-		// Version of the contribution
-		"version": "Version of the contribution in the form: major.minor.patch",
-		// Change log
-		"changelog": {
-			"X.X": "Short description of the changes"
-		},
-		// Holoscan SDK
-		"holoscan_sdk": {
-			// Minimum supported holoscan version
-			"minimum_required_version": "0.6.0",
-			// All versions of Holoscan SDK tested for this operator/application
-			"tested_versions": [
-				"0.6.0"
-			]
-		},
-		// Supported platforms
-		"platforms": ["x86_64", "aarch64"],
-		// Free-form tags for referencing the contribution
-		"tags": ["Endoscopy", "Video Encoding"],
-		// Ranking of the contribution. See below for ranking meaning
-		"ranking": 4,
-		// Dependencies for the current contribution
-		"dependencies": {
-			"operators": [{
-				"name": "mydependency",
-				"version": "x.x.x"
-			}
-		   ]
-		},
-		// Command to run/test the contribution. This is valid for applications.
-		// This command is used by the main run script to test the application/
-		// Use the <holohub_data_dir> for referencing the data directory
-		// "workdir" specifies the working directory and can be holohub_app_bin, holohub_app_source or holohub_bin
-		"run": {
-			"command": "./myapplication --data <holohub_data_dir>/mydata",
-			"workdir": "holohub_app_bin|holohub_app_source|holohub_bin"
-		}
-	}
+    // Explicit name of the contribution
+    "name": "explicit name of the application/operator",
+    // Author(s) of the contribution
+    "authors": [
+        {
+            "name": "firstname lastname",
+            "affiliation": "affiliation"
+        }
+    ],
+    // Supported language
+    // If multiple languages are supported, create a directory per language and a json file accordingly
+    "language": "C++|Python|GXF",
+    // Version of the contribution
+    "version": "Version of the contribution in the form: major.minor.patch",
+    // Change log
+    "changelog": {
+        "X.X": "Short description of the changes"
+    },
+    // Holoscan SDK
+    "holoscan_sdk": {
+        // Minimum supported holoscan version
+        "minimum_required_version": "0.6.0",
+        // All versions of Holoscan SDK tested for this operator/application
+        "tested_versions": [
+            "0.6.0"
+        ]
+    },
+    // Supported platforms
+    "platforms": ["x86_64", "aarch64"],
+    // Free-form tags for referencing the contribution
+    "tags": ["Endoscopy", "Video Encoding"],
+    // Ranking of the contribution. See below for ranking meaning
+    "ranking": 4,
+    // Dependencies for the current contribution
+    "dependencies": {
+        "operators": [{
+            "name": "mydependency",
+            "version": "x.x.x"
+        }
+        ]
+    },
+    // Command to run/test the contribution. This is valid for applications.
+    // This command is used by the main run script to test the application/
+    // Use the <holohub_data_dir> for referencing the data directory
+    // "workdir" specifies the working directory and can be holohub_app_bin, holohub_app_source or holohub_bin
+    "run": {
+        "command": "./myapplication --data <holohub_data_dir>/mydata",
+        "workdir": "holohub_app_bin|holohub_app_source|holohub_bin"
+    }
+}
 ```
 
 ### Ranking Levels for `metadata.json`
@@ -205,8 +204,8 @@ Please use the [terms defined in the glossary](README.md#Glossary) to refer to s
 Add each operator or extension in its own directory under the [```operators```](./operators/) or [```gxf_extensions```](./gxf_extensions) directory. The subdirectory should contain:
 
 - A _metadata.json_ file which describes its specifications and requirements in accordance with the [operator metadata.json schema](./operators/metadata.schema.json).
-- A README file summarizing the operator's purpose;
-- A LICENSE file governing use (optional).
+- A README file summarizing the operator's purpose.
+- A separate unit test file (for Python operators).
 
 Additionally, each operator should have at least one associated [application](./applications/) to demonstrate the capabilities of the operator.
 
@@ -230,13 +229,23 @@ cmake -S . -B ./build -D OP_my_operator:BOOL=1
 cmake --build ./build -j
 ```
 
+#### Operator Naming Convention
+
+For an operator named "Adaptive Thresholding", follow these naming conventions:
+
+1. **Class Name**: `AdaptiveThresholdingOp` (title case without spaces and with "Op" at the end)
+2. **metadata.json ("name")**:  Same as class name.
+3. **Directory**: `adaptive_thresholding` (snake case)
+4. **Filename**: same as directory name with extension.
+5. **README (Title)**: "`Adaptive Thresholding Operator`" (title case with spaces and Operator at the end).
+6. **Unit testing**: `test_adaptive_thresholding.py` (for Python operators)
+
 ### Adding an Application
 
 Add each application in its own subdirectory under the [`applications`](./applications/) directory. The subdirectory should contain:
 
 - A _metadata.json_ file which describes its specifications and requirements in accordance with the [application metadata.json schema](./applications/metadata.schema.json).
 - A README file summarizing the application's purpose and architecture;
-- A LICENSE file governing use (optional).
 
 Edit [```CMakeLists.txt```](./applications/CMakeLists.txt) to add the new application as part of the build system using the ```add_holohub_application```
 CMake function, passing the new application folder name as the first argument. If the application relies on one or more operators then the optional ```DEPENDS OPERATORS``` should be added so that
@@ -267,7 +276,6 @@ Add each workflow in its own subdirectory under the [`workflows`](./workflows/) 
 
 - A _metadata.json_ file which describes its specifications and requirements in accordance with the [workflow metadata.json schema](./workflows/metadata.schema.json).
 - A README file summarizing the workflow's purpose and architecture;
-- A LICENSE file governing use (optional).
 
 Workflows should follow the organization conventions described in the [workflows README](./workflows/README.md), which includes:
 
@@ -321,11 +329,11 @@ You can run your workflow using the `./run launch` command:
 
 5. You can then generate the package(s) by configuring your build with `-D PKG_my_packager:BOOL=1` :
 
-  ```bash
-  cmake -S . -B ./build -D PKG_my_packager:BOOL=1 # NOTE: avoid adding any other -D PKG_, -D APP_ or -D OP_ as their built targets would currently pollute the content of your package, unless you used COMPONENTS in holohub_configure_deb above
-  cmake --build ./build -j
-  cpack --config ./build/pkg/CPackConfig-*.cmake
-  ```
+    ```bash
+    cmake -S . -B ./build -D PKG_my_packager:BOOL=1 # NOTE: avoid adding any other -D PKG_, -D APP_ or -D OP_ as their built targets would currently pollute the content of your package, unless you used COMPONENTS in holohub_configure_deb above
+    cmake --build ./build -j
+    cpack --config ./build/pkg/CPackConfig-*.cmake
+    ```
 
 ### Adding a Tutorial
 
@@ -333,16 +341,13 @@ Add each tutorial in its own subdirectory under the [```tutorials```](./tutorial
 
 - A README file summarizing the application's purpose and architecture;
 - A _metadata.json_ file which describes its specifications and requirements in accordance with the [tutorial metadata.json schema](./tutorials/metadata.schema.json) (optional);
-- A LICENSE file governing use (optional).
 
 There are no project-wide build requirements for tutorials.
 
 ### License Guidelines
 
 - Make sure that you can contribute your work to open source.  Verify that no license and/or patent conflict is introduced by your code. NVIDIA is not responsible for conflicts resulting from community contributions.
-
-- We encourage community submissions under the Apache 2.0 permissive open source license, which is the [default for HoloHub](./LICENSE). However, if you prefer you may use another license in the submission subdirectory at the time of submission.
-
+- Holohub license is the Apache 2.0 permissive open source license, so any contributions will inherit this license.
 - We require that members [sign](#signing-your-contribution) their contributions to certify their work.
 
 ### Coding Guidelines

--- a/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
+++ b/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
@@ -41,8 +41,8 @@ record_type: "none"   # or "input" if you want to record input video stream, or 
                       # to record the visualizer output.
 
 external_source:
-  rdma: false
-  enable_overlay: true
+  rdma: true
+  enable_overlay: false
 
 aja:
   width: 1920

--- a/operators/deidentification/pixelator/README.md
+++ b/operators/deidentification/pixelator/README.md
@@ -1,18 +1,18 @@
-# Pixelator: A Pixelation-based Deidentification Operator
+# Pixelator Operator
 
-This directory contains the `PixelatorOp` for use with NVIDIA Holoscan workflows. The operator performs pixelation-based deidentification on input images, suitable for applications such as surgical video anonymization.
+A Pixelation-based Deidentification Operator
 
-## Structure
+## Overview
 
-- `pixelator.py`: The main operator implementation (class `PixelatorOp`).
-- `README.md`: This file.
-- `metadata.json`: Operator metadata.
+In medical and sensitive imaging workflows, pixelation is a common method for deidentification. The `PixelatorOp` is a Holoscan operator that performs pixelation-based deidentification on input images, suitable for applications such as surgical video anonymization where the camera may get out of the body and capture sensitive or protected information.
 
 ## Requirements
+
 - [Holoscan SDK](https://docs.nvidia.com/holoscan/)
 - [cupy](https://cupy.dev/)
 
 ## Example Usage
+
 ```python
 from holohub.operators.deidentification.pixelator import PixelatorOp
 op = PixelatorOp(block_size_h=16, block_size_w=16)
@@ -20,5 +20,6 @@ op = PixelatorOp(block_size_h=16, block_size_w=16)
 
 ## Parameters
 
+- `tensor_name`: The name of the tensor to be pixelated.
 - `block_size_h`: Height of the pixelation block.
 - `block_size_w`: Width of the pixelation block.

--- a/operators/low_rate_psd/README.md
+++ b/operators/low_rate_psd/README.md
@@ -1,44 +1,56 @@
 # Low Rate PSD Operator
 
+A Power Spectral Density (PSD) accumulator and averager operator.
+
 ## Overview
 
-PSD accumulator/averager.
+The **Low Rate PSD Operator** is a utility for computing and averaging the Power Spectral Density (PSD) of input signals. PSD is a fundamental tool in signal processing for analyzing the power distribution of a signal across frequency components. This operator is designed to efficiently accumulate and average PSDs over multiple bursts of input data, making it suitable for applications such as spectrum monitoring, signal diagnostics, and real-time analysis in embedded or high-throughput environments.
 
-## Description
+The Low Rate PSD Operator performs the following steps:
 
-The low rate PSD operator...
-- takes in `num_averages` tensors of float data,
-- takes an average of all the accumulated tensors,
-- performs a 10 * log10() operation on the average,
-- clamps data to 8-bit integer boundaries,
-- casts to signed 8-bit integers,
-- emits the resultant tensor
+1. **Input Accumulation:** Receives `num_averages` tensors containing float data representing signal samples or pre-computed PSDs.
+2. **Averaging:** Computes the average of all accumulated tensors to smooth out noise and fluctuations.
+3. **Logarithmic Scaling:** Applies a `10 * log10()` operation to convert the averaged power values to decibel (dB) scale, which is standard for PSD representation.
+4. **Clamping:** Restricts the data to the range of 8-bit signed integers to ensure compatibility and efficient storage.
+5. **Casting:** Converts the clamped values to signed 8-bit integers.
+6. **Emission:** Outputs the final tensor for downstream processing or analysis.
 
 ## Requirements
 
-- [MatX](https://github.com/NVIDIA/MatX) (dependency - assumed to be installed on system)
+- [MatX](https://github.com/NVIDIA/MatX): Required for tensor operations (assumed to be installed on your system).
 
 ## Example Usage
 
-For an example of how to use this operator, see the
-[`psd_pipeline`](../../applications/psd_pipeline) application.
+For a practical example, see the [`psd_pipeline`](../../applications/psd_pipeline) application.
+
+### Basic Workflow
+
+1. Configure the operator parameters (see below).
+2. Feed input tensors (float32 arrays) to the operator.
+3. Collect the output signed 8-bit integer tensor representing the averaged PSD in dB.
 
 ## Multiple Channels
 
-The zero-indexed `channel_number` key will be looked up in [`metadata()`](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_create_app.html#dynamic-application-metadata)
-on each `compute()` run. If no value is found, the default channel number is `0`.
+The operator supports processing multiple channels in parallel. The zero-indexed `channel_number` key is retrieved from [`metadata()`](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_create_app.html#dynamic-application-metadata) on each `compute()` invocation. If `channel_number` is not provided, the default is `0` (single channel).
 
 ## Configuration
 
-The low rate PSD operator takes two parameters:
+Configure the operator in your application (e.g., YAML config):
 
 ```yaml
 low_rate_psd:
-  burst_size: 1280
-  num_averages: 625
-  num_channels: 1
+  burst_size: 1280         # Number of samples processed per compute() call
+  num_averages: 625        # Number of PSDs to accumulate before averaging
+  num_channels: 1          # Number of signal channels to process
 ```
 
-- `burst_size`: Number of samples to process on each invocation of `compute()`
-- `num_channels`: Number of channels for which to allocate memory
-- `num_averages`: How many PSDs to accumulate before averaging and emitting.
+## Input/Output
+
+- **Input:** Tensors of type `float32`, shape determined by `burst_size` and `num_channels`.
+- **Output:** Tensor of type `int8`, representing the averaged PSD in dB scale, clamped to [-128, 127].
+
+## Notes
+
+- Ensure the input data is properly normalized and formatted as expected by the operator.
+- The operator is optimized for performance and memory efficiency, leveraging MatX for tensor operations.
+- For advanced use cases, refer to the Holoscan SDK documentation and the example pipeline linked above.

--- a/operators/low_rate_psd/README.md
+++ b/operators/low_rate_psd/README.md
@@ -1,8 +1,3 @@
-<!--
-SPDX-FileCopyrightText: 2024 Valley Tech Systems, Inc.
-
-SPDX-License-Identifier: Apache-2.0
--->
 # Low Rate PSD Operator
 
 ## Overview

--- a/operators/low_rate_psd/metadata.json.license
+++ b/operators/low_rate_psd/metadata.json.license
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2024 Valley Tech Systems, Inc.
-
-SPDX-License-Identifier: Apache-2.0

--- a/operators/template/README.md.template
+++ b/operators/template/README.md.template
@@ -1,12 +1,10 @@
 # My HoloHub Operator
 
-## Overview
-
 Provide a one-sentence summary of your operator's purpose and operations.
 
-## Description
+## Overview
 
-Provide a detailed summary of your operator. Include any necessary background
+Provide a summary of your operator. Include any necessary background
 for the average HoloHub user to understand the general purpose of your project.
 Include any diagrams that are helpful for understanding functionality.
 

--- a/operators/template/metadata.json.template
+++ b/operators/template/metadata.json.template
@@ -1,6 +1,6 @@
 {
 	"operator": {
-		"name": "My Operator",
+		"name": "MyOperatorOp",
 		"authors": [
 			{
 				"name": "John Doe",
@@ -13,9 +13,9 @@
 			"0.1.0": "Initial Release"
 		},
 		"holoscan_sdk": {
-			"minimum_required_version": "1.0.3",
+			"minimum_required_version": "3.0.0",
 			"tested_versions": [
-				"1.0.3"
+				"3.1.0"
 			]
 		},
 		"platforms": [


### PR DESCRIPTION
This pull request updates the `CONTRIBUTING.md` guidelines and refines operator templates and documentation to improve clarity, standardization, and usability. Key changes include the removal of optional `LICENSE` files for contributions, the addition of operator naming conventions, and updates to operator templates for consistency with new standards.

### Updates to Contribution Guidelines:

* Added a new section detailing operator naming conventions, including class name, directory structure, and file naming standards. 
* Removed the requirement for optional `LICENSE` files in operator, application, workflow, and tutorial contributions, aligning all contributions under the default Apache 2.0 license.

### Documentation Improvements:

* Updated the `README.md` for the `Pixelator` operator to provide a clearer overview and better align with the new documentation standards.

### Template Updates:

* Modified the `metadata.json.template` to standardize operator naming with the suffix "Op" and updated the minimum and tested versions of the Holoscan SDK to `3.0.0` and `3.1.0`, respectively. 
* Refined the `README.md.template` for operators to merge the "Description" and "Overview" sections into a single, concise "Overview" section.