### PR TITLE
App: Update `cvcuda_basic` metadata for Dockerfile discovery

### DIFF
--- a/applications/cvcuda_basic/cpp/metadata.json
+++ b/applications/cvcuda_basic/cpp/metadata.json
@@ -12,6 +12,7 @@
 		"changelog": {
 			"1.0": "Initial Release"
 		},
+		"dockerfile": "applications/cvcuda_basic/Dockerfile",
 		"holoscan_sdk": {
 			"minimum_required_version": "0.6.0",
 			"tested_versions": [

--- a/applications/cvcuda_basic/python/metadata.json
+++ b/applications/cvcuda_basic/python/metadata.json
@@ -12,6 +12,7 @@
 		"changelog": {
 			"1.0": "Initial Release"
 		},
+		"dockerfile": "applications/cvcuda_basic/Dockerfile",
 		"holoscan_sdk": {
 			"minimum_required_version": "0.6.0",
 			"tested_versions": [


### PR DESCRIPTION
The new `holohub` CLI has dropped support for automatically finding Dockerfiles in parent folders. Explicitly reference the common CVCUDA application Dockerfile environment for both C++ and Python applications.

Previous:
```bash
$ ./holohub build-container cvcuda_basic --dryrun
2025-05-20 17:23:55 [dryrun] $ docker build \
    --build-arg BUILDKIT_INLINE_CACHE=1 \
    --build-arg BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v3.2.0-dgpu \
    --build-arg GPU_TYPE=dgpu \
    --build-arg COMPUTE_CAPACITY=8.6 \
    --network=host \
    -f /home/tbirdsong/repos/holohub-internal/Dockerfile \
    -t holohub:ngc-v3.2.0-dgpu /home/tbirdsong/repos/holohub-internal
```

Updated result:
```bash
$ ./holohub build-container cvcuda_basic --dryrun
2025-05-20 17:23:34 [dryrun] $ docker build \
    --build-arg BUILDKIT_INLINE_CACHE=1 \
    --build-arg BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v3.2.0-dgpu \
    --build-arg GPU_TYPE=dgpu \
    --build-arg COMPUTE_CAPACITY=8.6 \
    --network=host \
    -f applications/cvcuda_basic/Dockerfile \
    -t holohub:cvcuda_basic /home/tbirdsong/repos/holohub-internal
```