### PR TITLE
add quick run section

### DIFF
--- a/applications/body_pose_estimation/metadata.json
+++ b/applications/body_pose_estimation/metadata.json
@@ -58,7 +58,7 @@
 			"dds": {
 				"description": "Run with DDS video stream input",
 				"build": {
-					"op_depends": [
+					"target_depends": [
 						"dds_video_subscriber",
 						"dds_video_publisher"
 					]


### PR DESCRIPTION

the quick run has been merged into 'mode' as discussed

> an example of adding support of quick run in an application's metadata.json , and using the information to automatically update its readme and webpage.
> 
> to update the readme (this could be done via github action to ensure single-source truth from the metadata.json):
> ```
> python utilities/metadata/metadata_to_readme.py -p applications/body_pose_estimation
> ```
> 
> output example:
> <img width="1205" alt="Screenshot 2025-05-29 at 09 02 48" src="https://github.com/user-attachments/assets/6990f5a5-0053-46ef-9bed-ca383242e892" />
> 
> 
