### PR TITLE
build_and_run subcommand support ssh_x11 option

### DIFF
--- a/dev_container
+++ b/dev_container
@@ -934,6 +934,7 @@ build_and_run_desc() { c_echo 'Build and run a requested application in a Docker
         --build_docker_args : additional docker arguments when building the container
         --build_with : List of optional operators that should be built separated by semicolons (;)
         --run_args : Run the app with additional args
+        --ssh_x11 : Enable X11 forwarding of graphical HoloHub applications over SSH
         --verbose : Print extra output to console
         --dryrun : View build and run commands without doing anything
         --parallel_jobs: Set the # of parallel build jobs, e.g. $(($(nproc)-1))
@@ -1056,6 +1057,10 @@ build_and_run() {
         --verbose)
             container_build_args+=(--verbose)
             container_launch_args+=" --verbose"
+            shift
+            ;;
+        --ssh_x11)
+            container_launch_args+=" --ssh_x11"
             shift
             ;;
         --language)


### PR DESCRIPTION
`./dev_container build_and_run` does not support x11.

```
./dev_container build_and_run yolo_model_deployment  --run_args "--source replayer"
...

[info] [inference.cpp:267] Inference context setup complete
MoTTY X11 proxy: No authorisation provided
Glfw Error 65550: Failed to detect any supported platform
[error] [gxf_wrapper.cpp:63] Exception occurred when starting operator: 'detection_visualizer' - Failed to initialize glfw
[warning] [entity_executor.cpp:539] Failed to start entity [detection_visualizer]
[warning] [greedy_scheduler.cpp:243] Error while executing entity 46 named 'detection_visualizer': GXF_FAILURE
[error] [entity_executor.cpp:641] Entity [detection_visualizer] must be in Started, Tick Pending, Ticking or Idle stage before stopping. Current state is StartPending
[info] [greedy_scheduler.cpp:401] Scheduler finished.
[error] [program.cpp:580] wait failed. Deactivating...
[error] [runtime.cpp:1649] Graph wait failed with error: GXF_FAILURE
[warning] [gxf_executor.cpp:2428] GXF call GxfGraphWait(context) in line 2428 of file /workspace/holoscan-sdk/src/core/executors/gxf/gxf_executor.cpp failed with 'GXF_FAILURE' (1)
[info] [gxf_executor.cpp:2438] [YOLO Detection App] Graph execution finished.
[error] [gxf_executor.cpp:2446] [YOLO Detection App] Graph execution error: GXF_FAILURE
Traceback (most recent call last):
  File "/workspace/holohub/applications/yolo_model_deployment/yolo_detection.py", line 330, in <module>
    app.run()
RuntimeError: Failed to initialize glfw
[command] export PYTHONPATH=/opt/nvidia/holoscan/python/lib:/workspace/holohub/benchmarks/holoscan_flow_benchmarking && export HOLOHUB_DATA_PATH="" && export HOLOSCAN_INPUT_PATH="/opt/nvidia/holoscan/data"
[iown@tower10 holohub]$
```

so add --ssh_x11 option.