### PR TITLE
Bump Holoscan SDK to v3.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Check to verify that the image is created:
 $ docker images
 REPOSITORY      TAG               IMAGE ID       CREATED         SIZE
 ...
-holohub         ngc-v3.2.0-dgpu   17e3aa51f129   13 days ago     13.2GB
+holohub         ngc-v3.3.0-dgpu   17e3aa51f129   13 days ago     13.2GB
 ...
 ```
 

--- a/dev_container
+++ b/dev_container
@@ -474,11 +474,11 @@ get_host_gpu() {
 }
 
 get_default_base_img() {
-    echo -n "nvcr.io/nvidia/clara-holoscan/holoscan:v3.2.0-"$(get_host_gpu)
+    echo -n "nvcr.io/nvidia/clara-holoscan/holoscan:v3.3.0-"$(get_host_gpu)
 }
 
 get_default_img() {
-    echo -n "holohub:ngc-v3.2.0-"$(get_host_gpu)
+    echo -n "holohub:ngc-v3.3.0-"$(get_host_gpu)
 }
 
 # This function returns the compute capacity of the system's GPU (8.6, 8.9, etc.)


### PR DESCRIPTION
Bump default base container to latest Holoscan SDK release

https://github.com/nvidia-holoscan/holoscan-sdk/releases/tag/v3.3.0