### PR TITLE
fixes CLI -- TypeError: 'staticmethod' object is not callable

### DIFF
--- a/.github/workflows/check_cli.yml
+++ b/.github/workflows/check_cli.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: [main, holoscan-sdk-lws2, fixes-cli]
+    branches: [main, holoscan-sdk-lws2]
 
 jobs:
   check-cli-py:

--- a/.github/workflows/check_cli.yml
+++ b/.github/workflows/check_cli.yml
@@ -1,0 +1,30 @@
+name: Check CLI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main, holoscan-sdk-lws2, fixes-cli]
+
+jobs:
+  check-cli-py:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: |
+          pip install -r utilities/requirements.lint.txt
+          pip install -r utilities/requirements.template.txt
+          python -m unittest utilities.cli.tests.test_cli
+          python -m unittest utilities.cli.tests.test_container

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -49,7 +49,6 @@ class Color:
         result += text + Color.RESET
         return result
 
-    @staticmethod
     def _create_color_method(color_code: str):
         """Create a color method for the given color code"""
 
@@ -110,7 +109,8 @@ def check_nvidia_ctk() -> None:
     recommended_version = "1.14.1"
 
     if not shutil.which("nvidia-ctk"):
-        fatal("nvidia-ctk not found. Please install the NVIDIA Container Toolkit.")
+        print(Color.red("nvidia-ctk not found. Please install the NVIDIA Container Toolkit."))
+        return
 
     try:
         output = subprocess.check_output(["nvidia-ctk", "--version"], text=True)
@@ -122,13 +122,19 @@ def check_nvidia_ctk() -> None:
             from packaging import version as ver
 
             if ver.parse(version) < ver.parse(min_version):
-                fatal(
-                    f"Found nvidia-ctk Version {version}. Version {min_version}+ is required ({recommended_version}+ recommended)."
+                print(
+                    Color.red(
+                        f"Found nvidia-ctk Version {version}. \n"
+                        f"Version {min_version}+ is required ({recommended_version}+ recommended)."
+                    )
                 )
+                return
         else:
-            print(f"Failed to parse available nvidia-ctk version: {output}")
+            print(Color.red(f"Failed to parse available nvidia-ctk version: {output}"))
     except subprocess.CalledProcessError:
-        fatal(f"Could not determine nvidia-ctk version. Version {min_version}+ required.")
+        print(
+            Color.red(f"Could not determine nvidia-ctk version. Version {min_version}+ required.")
+        )
 
 
 def get_host_gpu() -> str:


### PR DESCRIPTION
- fixes
```
main/utilities/cli/util.py", line 62, in Color
    red = _create_color_method(RED)
TypeError: 'staticmethod' object is not callable
``` 

- make `check_nvidia_ctk ` less strict so that we only need minimal setup to run the CLI and tests