### PR TITLE
Benchmark: Update `release_benchmarking` README links to prev reports

### DIFF
--- a/benchmarks/release_benchmarking/README.md
+++ b/benchmarks/release_benchmarking/README.md
@@ -11,7 +11,7 @@ real-time, low-latency processing.
 ## Contents
 
 - [Background](#background)
-- [Previous Holoscan Release Benchmark Reports](#previous-release-reports)
+- [Previous Holoscan Release Benchmark Reports](#previous-holoscan-release-benchmark-reports)
 - Running the Tutorial
   - [Running Benchmarks](#running-benchmarks-getting-started)
   - [Summarizing Data](#summarizing-data)
@@ -46,6 +46,8 @@ definitions and background
 ## Previous Holoscan Release Benchmark Reports
 
 - [Holoscan SDK v2.3.0](./release/v2.3.0/v2.3.0.md)
+- [Holoscan SDK v2.6.0](./release/v2.6.0/v2.6.0.md)
+- [Holoscan SDK v3.0.0](./release/v3.0.0/v3.0.0.md)
 
 ## Running Benchmarks: Getting Started
 


### PR DESCRIPTION
- Update links to 2.6.0 and 3.0.0 reports in README
- Fix section hyperlink

Links will appear on the Holohub landing page at: https://nvidia-holoscan.github.io/holohub/benchmarks/release_benchmarking/#previous-holoscan-release-benchmark-reports