### PR TITLE
Infra: Add `./holohub run --docker-opts` flag for container arguments

### DIFF
--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -159,7 +159,7 @@ class HoloHubCLI:
             "--as_root", action="store_true", help="Run the container with root permissions"
         )
         run_container.add_argument(
-            "--docker_opts", default="", help="Additional options to pass to the Docker launch"
+            "--docker-opts", default="", help="Additional options to pass to the Docker launch"
         )
         run_container.add_argument(
             "--language", choices=["cpp", "python"], help="Specify language implementation"
@@ -211,7 +211,7 @@ class HoloHubCLI:
             help="Optional operators that should be built, separated by semicolons (;)",
         )
         run.add_argument(
-            "--docker_opts",
+            "--docker-opts",
             default="",
             help="Additional options to pass to the underlying Docker launch (if applicable)",
         )

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -114,8 +114,8 @@ class HoloHubCLI:
             "build-container", help="Build the development container"
         )
         build_container.add_argument("project", nargs="?", help="Project to build container for")
-        build_container.add_argument("--base_img", help="Fully qualified base image name")
-        build_container.add_argument("--docker_file", help="Path to Dockerfile to use")
+        build_container.add_argument("--base-img", help="Fully qualified base image name")
+        build_container.add_argument("--docker-file", help="Path to Dockerfile to use")
         build_container.add_argument("--img", help="Specify fully qualified container name")
         build_container.add_argument(
             "--verbose", action="store_true", help="Print variables passed to docker build command"
@@ -141,7 +141,7 @@ class HoloHubCLI:
         run_container.add_argument("project", nargs="?", help="Project to run container for")
         run_container.add_argument("--img", help="Fully qualified image name")
         run_container.add_argument(
-            "--local_sdk_root",
+            "--local-sdk-root",
             help="Path to Holoscan SDK used for building local Holoscan SDK container",
         )
         run_container.add_argument("--init", action="store_true", help="Support tini entry point")
@@ -156,7 +156,7 @@ class HoloHubCLI:
         )
         run_container.add_argument("--add-volume", action="append", help="Mount additional volume")
         run_container.add_argument(
-            "--as_root", action="store_true", help="Run the container with root permissions"
+            "--as-root", action="store_true", help="Run the container with root permissions"
         )
         run_container.add_argument(
             "--docker-opts", default="", help="Additional options to pass to the Docker launch"
@@ -179,7 +179,7 @@ class HoloHubCLI:
             help="Build type (debug, release, rel-debug)",
         )
         build.add_argument(
-            "--build_with",
+            "--build-with",
             dest="with_operators",
             help="Optional operators that should be built, separated by semicolons (;)",
         )
@@ -203,10 +203,10 @@ class HoloHubCLI:
             "--language", choices=["cpp", "python"], help="Specify language implementation"
         )
         run.add_argument(
-            "--run_args", help="Additional arguments to pass to the application executable"
+            "--run-args", help="Additional arguments to pass to the application executable"
         )
         run.add_argument(
-            "--build_with",
+            "--build-with",
             dest="with_operators",
             help="Optional operators that should be built, separated by semicolons (;)",
         )


### PR DESCRIPTION
Add support for forwarding container arguments to underlying container run when doing a containerized build/run with the Holohub CLI.

Supports projects requiring certain environment variables or volume mounts at runtime. Previous approach required two steps:
1. `./holohub run-container <myproject> --docker-opts <my_opts>`
2. `./holohub run <myproject>`