### PR TITLE
mode preset config

### DIFF
--- a/applications/body_pose_estimation/metadata.json
+++ b/applications/body_pose_estimation/metadata.json
@@ -68,8 +68,9 @@
 					"docker_args": [
 						"-e ACCEPT_EULA='Yes with whitespace'",
 						"-e PRIVACY_CONSENT=Y",
-						"-v ~/docker/rti:/root/rti:ro",
-						"-v /dev:/dev"
+						"-v /tmp/docker/rti:/root/rti:ro",
+						"-v /dev:/dev",
+						"--detach"
 					]
 				}
 			},

--- a/applications/body_pose_estimation/metadata.json
+++ b/applications/body_pose_estimation/metadata.json
@@ -34,14 +34,50 @@
 			"hardware": [
 				{
 					"name": "camera",
-					"description": "This application requires a Video4Linux (V4L2) compatible device as input.",
-					"required": true
+					"description": "This application requires a Video4Linux (V4L2) compatible device as input."
 				}
 			]
 		},
-		"run": {
-			"command": "python3 <holohub_app_source>/body_pose_estimation.py",
-			"workdir": "holohub_bin"
+		"modes": {
+			"default": {
+				"description": "Run with camera input (default)",
+				"hardware": ["camera"],
+				"run": {
+					"command": "python3 <holohub_app_source>/body_pose_estimation.py",
+					"workdir": "holohub_bin"
+				}
+			},
+			"replayer": {
+				"description": "Run with pre-recorded video (no camera required)",
+				"run": {
+					"command": "python3 <holohub_app_source>/body_pose_estimation.py",
+					"workdir": "holohub_bin",
+					"args": "--source replayer"
+				}
+			},
+			"dds": {
+				"description": "Run with DDS video stream input",
+				"build": {
+					"op_depends": [
+						"dds_video_subscriber",
+						"dds_video_publisher"
+					]
+				},
+				"run": {
+					"command": "python3 <holohub_app_source>/body_pose_estimation.py",
+					"workdir": "holohub_bin",
+					"args": "--source dds"
+				}
+			},
+			"video_device": {
+				"description": "Run with specific camera device, replace 1 with the device number accordingly",
+				"hardware": ["camera"],
+				"run": {
+					"command": "python3 <holohub_app_source>/body_pose_estimation.py",
+					"workdir": "holohub_bin",
+					"args": "--video_device /dev/video1"
+				}
+			}
 		}
 	}
 }

--- a/applications/body_pose_estimation/metadata.json
+++ b/applications/body_pose_estimation/metadata.json
@@ -40,7 +40,7 @@
 		},
 		"modes": {
 			"default": {
-				"description": "Run with camera input (default)",
+				"description": "Body pose estimation with camera input (default)",
 				"hardware": ["camera"],
 				"run": {
 					"command": "python3 <holohub_app_source>/body_pose_estimation.py",
@@ -48,34 +48,38 @@
 				}
 			},
 			"replayer": {
-				"description": "Run with pre-recorded video (no camera required)",
+				"description": "Body pose estimation with pre-recorded video (no camera required)",
 				"run": {
 					"command": "python3 <holohub_app_source>/body_pose_estimation.py",
 					"workdir": "holohub_bin",
-					"args": "--source replayer"
+					"cmd_args": ["--source replayer"]
 				}
 			},
 			"dds": {
-				"description": "Run with DDS video stream input",
+				"description": "Body pose estimation with DDS video stream input",
 				"build": {
-					"op_depends": [
-						"dds_video_subscriber",
-						"dds_video_publisher"
-					]
+					"depends": ["dds_video_subscriber", "dds_video_publisher"],
+					"docker_args": ["--ssh default"]
 				},
 				"run": {
 					"command": "python3 <holohub_app_source>/body_pose_estimation.py",
 					"workdir": "holohub_bin",
-					"args": "--source dds"
+					"cmd_args": ["--source dds"],
+					"docker_args": [
+						"-e ACCEPT_EULA='Yes with whitespace'",
+						"-e PRIVACY_CONSENT=Y",
+						"-v ~/docker/rti:/root/rti:ro",
+						"-v /dev:/dev"
+					]
 				}
 			},
 			"video_device": {
-				"description": "Run with specific camera device, replace 1 with the device number accordingly",
+				"description": "Body pose estimation with specific camera device, replace 'video1' with device accordingly",
 				"hardware": ["camera"],
 				"run": {
 					"command": "python3 <holohub_app_source>/body_pose_estimation.py",
 					"workdir": "holohub_bin",
-					"args": "--video_device /dev/video1"
+					"cmd_args": ["--video_device /dev/video1"]
 				}
 			}
 		}

--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -273,8 +273,7 @@ class HoloHubContainer:
         nsys_profile: bool = False,
         nsys_location: str = "",
         as_root: bool = False,
-        docker_opts: str = "",
-        docker_args: List[str] = None,
+        docker_opts: List[str] = None,
         add_volumes: List[str] = None,
         verbose: bool = False,
         extra_args: List[str] = None,
@@ -287,7 +286,7 @@ class HoloHubContainer:
         img = img or self.image_name
         add_volumes = add_volumes or []
         extra_args = extra_args or []
-        docker_args = docker_args or []
+        docker_opts = docker_opts or []
 
         # Build docker command
         cmd = [self.holoscan_docker_exe, "run"]
@@ -337,11 +336,7 @@ class HoloHubContainer:
 
         # Add docker options if provided
         if docker_opts:
-            cmd.extend(docker_opts.split())
-
-        # Add docker arguments list if provided (preferred method)
-        if docker_args:
-            cmd.extend(docker_args)
+            cmd.extend(docker_opts)
 
         # Add the image name
         cmd.append(img)

--- a/utilities/cli/docker_config.json
+++ b/utilities/cli/docker_config.json
@@ -1,0 +1,70 @@
+{
+	"modes": {
+		"default": {
+			"description": "Default container mode with standard docker options",
+			"build": {
+				"docker_args": [
+					"--build-arg BUILDKIT_INLINE_CACHE=1",
+					"--network host"
+				]
+			},
+			"run": {
+				"docker_args": [
+					"--net host",
+					"--interactive",
+					"--runtime nvidia",
+					"--gpus all",
+					"--cap-add CAP_SYS_PTRACE",
+					"--ipc host",
+					"-v /dev:/dev",
+					"--device-cgroup-rule 'c 81:* rmw'",
+					"--device-cgroup-rule 'c 189:* rmw'",
+					"-e NVIDIA_DRIVER_CAPABILITIES=graphics,video,compute,utility,display",
+					"-e HOME=/workspace/holohub",
+					"-e HOLOHUB_BUILD_LOCAL=1",
+					"-v /etc/group:/etc/group:ro",
+					"-v /etc/passwd:/etc/passwd:ro"
+				]
+			}
+		},
+		"ucx": {
+			"description": "UCX-enabled mode with additional memory and IPC settings",
+			"run": {
+				"docker_args": [
+					"--ipc host",
+					"--cap-add CAP_SYS_PTRACE",
+					"--ulimit memlock=-1",
+					"--ulimit stack=67108864"
+				]
+			}
+		},
+		"runtime": {
+			"description": "Basic runtime mode with GPU access",
+			"run": {
+				"docker_args": [
+					"--runtime nvidia",
+					"--gpus all"
+				]
+			}
+		},
+		"display": {
+			"description": "Display server options for X11",
+			"run": {
+				"docker_args": [
+					"-v /tmp/.X11-unix:/tmp/.X11-unix",
+					"-e DISPLAY"
+				]
+			}
+		},
+		"conditional": {
+			"description": "Conditional options that can be applied",
+			"run": {
+				"docker_args": {
+					"tini": ["--init"],
+					"non_persistent": ["--rm"],
+					"tty_interactive": ["--tty"]
+				}
+			}
+		}
+	}
+}

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -798,15 +798,23 @@ class HoloHubCLI:
             if hasattr(args, "run_args") and args.run_args:
                 run_cmd += f" --run_args {shlex.quote(args.run_args)}"
 
-            # Get mode-specific docker run args
+                        # Get mode-specific docker run args
             run_config = mode_config.get("run", {})
-            docker_args = run_config.get("docker_args", [])
-            docker_opts_str = args.docker_opts
-            if isinstance(docker_args, list):
-                docker_opts_str += " " + " ".join(docker_args)
+            mode_docker_args = run_config.get("docker_args", [])
+
+            # Process docker args using shlex for proper quote handling
+            import shlex
+            processed_docker_args = []
+            if isinstance(mode_docker_args, list):
+                for arg in mode_docker_args:
+                    if arg.startswith("-") and " " in arg:
+                        processed_docker_args.extend(shlex.split(arg))
+                    else:
+                        processed_docker_args.append(arg)
 
             container.run(
-                docker_opts="--entrypoint=bash " + docker_opts_str,
+                docker_opts="--entrypoint=bash " + args.docker_opts,
+                docker_args=processed_docker_args,
                 extra_args=["-c", run_cmd],
                 verbose=args.verbose,
             )

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -428,9 +428,11 @@ class HoloHubCLI:
         container.build(build_args=mode_build_args if mode_build_args else None)
 
         # Combine user-provided docker opts with mode-specific opts
-        combined_docker_opts = args.docker_opts
+        combined_docker_opts = []
+        if args.docker_opts:
+            combined_docker_opts.extend(shlex.split(args.docker_opts))
         if mode_docker_opts:
-            combined_docker_opts = f"{args.docker_opts} {mode_docker_opts}".strip()
+            combined_docker_opts.extend(shlex.split(mode_docker_opts))
 
         container.run(
             img=args.img,
@@ -438,7 +440,7 @@ class HoloHubCLI:
             use_tini=args.init,
             persistent=args.persistent,
             as_root=args.as_root,
-            docker_opts=combined_docker_opts,
+            docker_opts=combined_docker_opts if combined_docker_opts else None,
             add_volumes=args.add_volume,
             verbose=args.verbose,
         )
@@ -798,12 +800,11 @@ class HoloHubCLI:
             if hasattr(args, "run_args") and args.run_args:
                 run_cmd += f" --run_args {shlex.quote(args.run_args)}"
 
-                        # Get mode-specific docker run args
+            # Get mode-specific docker run args
             run_config = mode_config.get("run", {})
             mode_docker_args = run_config.get("docker_args", [])
 
             # Process docker args using shlex for proper quote handling
-            import shlex
             processed_docker_args = []
             if isinstance(mode_docker_args, list):
                 for arg in mode_docker_args:

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -25,28 +25,12 @@ import subprocess
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 import utilities.cli.util as holohub_cli_util
 import utilities.metadata.gather_metadata as metadata_util
 from utilities.cli.container import HoloHubContainer, base_sdk_version
 from utilities.cli.util import Color
-
-
-def list_cmake_dir_options(script_dir: Path, cmake_function: str) -> List[str]:
-    """Get list of directories from CMakeLists.txt files"""
-    results = []
-    for cmakelists in script_dir.rglob("CMakeLists.txt"):
-        with open(cmakelists) as f:
-            content = f.read()
-            for line in content.splitlines():
-                if cmake_function in line:
-                    try:
-                        name = line.split("(")[1].split(")")[0].strip()
-                        results.append(name)
-                    except IndexError:
-                        continue
-    return sorted(results)
 
 
 class HoloHubCLI:

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -377,3 +377,19 @@ def levenshtein_distance(s1: str, s2: str) -> int:
         previous_row = current_row
 
     return previous_row[-1]
+
+
+def list_cmake_dir_options(script_dir: Path, cmake_function: str) -> List[str]:
+    """Get list of directories from CMakeLists.txt files"""
+    results = []
+    for cmakelists in script_dir.rglob("CMakeLists.txt"):
+        with open(cmakelists) as f:
+            content = f.read()
+            for line in content.splitlines():
+                if cmake_function in line:
+                    try:
+                        name = line.split("(")[1].split(")")[0].strip()
+                        results.append(name)
+                    except IndexError:
+                        continue
+    return sorted(results)


### PR DESCRIPTION
this is to discuss the updated metadata mode:
- this is a demo metadata.json showing the possible args: https://github.com/nvidia-holoscan/holohub/blob/mode-preset/applications/body_pose_estimation/metadata.json
- implemented `./holohub list-modes body_pose_estimation `, output:
```
Metadata file: /home/wenqil/Documents/holohub/applications/body_pose_estimation/metadata.json

Available modes for project body_pose_estimation:

default: Body pose estimation with camera input (default)
  Hardware: camera
  Command: python3 <holohub_app_source>/body_pose_estimation.py

replayer: Body pose estimation with pre-recorded video (no camera required)
  Command: python3 <holohub_app_source>/body_pose_estimation.py

dds: Body pose estimation with DDS video stream input
  Build dependencies: dds_video_subscriber, dds_video_publisher
  Command: python3 <holohub_app_source>/body_pose_estimation.py

video_device: Body pose estimation with specific camera device, replace 'video1' with device accordingly
  Hardware: camera
  Command: python3 <holohub_app_source>/body_pose_estimation.py
```

- `./holohub run body_pose_estimation dds` will build and run the mode preset
- static default docker arguments are extracted to a json for further customization flexibility https://github.com/nvidia-holoscan/holohub/blob/mode-preset/utilities/cli/docker_config.json