### PR TITLE
Remove `run` from default Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ RUN mkdir -p /tmp/scripts
 COPY holohub /tmp/scripts/
 RUN mkdir -p /tmp/scripts/utilities
 COPY utilities /tmp/scripts/utilities/
-RUN chmod +x /tmp/scripts/run
 RUN /tmp/scripts/holohub setup && rm -rf /var/lib/apt/lists/*
 
 # Enable autocomplete


### PR DESCRIPTION
`run` script was removed from the default Dockerfile in 795d1226 but was still referenced in a chmod command.

Fixes `./holohub build-container` error:
```
[2025-06-09T19:53:52.708Z] #13 [ 6/16] RUN chmod +x /tmp/scripts/run

[2025-06-09T19:53:52.708Z] #13 0.158 chmod: cannot access '/tmp/scripts/run': No such file or directory

[2025-06-09T19:53:52.708Z] #13 ERROR: process "/bin/sh -c chmod +x /tmp/scripts/run" did not complete successfully: exit code: 1

[2025-06-09T19:53:52.708Z] ------

[2025-06-09T19:53:52.708Z]  > [ 6/16] RUN chmod +x /tmp/scripts/run:

[2025-06-09T19:53:52.708Z] #13 0.158 chmod: cannot access '/tmp/scripts/run': No such file or directory
```