### PR TITLE
CLI docker build enhancements

### DIFF
--- a/.github/workflows/check_cli.yml
+++ b/.github/workflows/check_cli.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: [main, holoscan-sdk-lws2, fixes-docker]
+    branches: [main, holoscan-sdk-lws2]
 
 permissions:
   contents: read
@@ -49,18 +49,3 @@ jobs:
         run: |
           cd build
           ctest --verbose
-
-  check-docker-build:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Run Docker build
-        run: |
-          ./holohub build-container --base-img ubuntu:22.04
-          if command -v nvidia-ctk >/dev/null 2>&1; then
-            ./holohub run-container --base-img ubuntu:22.04
-          else
-            echo "Skipping run-container: NVIDIA Container Toolkit not available"
-          fi

--- a/.github/workflows/check_cli.yml
+++ b/.github/workflows/check_cli.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: [main, holoscan-sdk-lws2]
+    branches: [main, holoscan-sdk-lws2, fixes-docker]
 
 permissions:
   contents: read
@@ -49,3 +49,18 @@ jobs:
         run: |
           cd build
           ctest --verbose
+
+  check-docker-build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Run Docker build
+        run: |
+          ./holohub build-container --base-img ubuntu:22.04
+          if command -v nvidia-ctk >/dev/null 2>&1; then
+            ./holohub run-container --base-img ubuntu:22.04
+          else
+            echo "Skipping run-container: NVIDIA Container Toolkit not available"
+          fi

--- a/.github/workflows/check_docker.yml
+++ b/.github/workflows/check_docker.yml
@@ -1,0 +1,24 @@
+name: Check Docker
+
+on:
+  push:
+    branches: [main, holoscan-sdk-lws2]
+
+permissions:
+  contents: read
+
+jobs:
+  check-docker-build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Run Docker build
+        run: |
+          ./holohub build-container --base-img ubuntu:22.04
+          if command -v nvidia-ctk >/dev/null 2>&1; then
+            ./holohub run-container --base-img ubuntu:22.04
+          else
+            echo "Skipping run-container: NVIDIA Container Toolkit not available"
+          fi

--- a/.github/workflows/check_docker.yml
+++ b/.github/workflows/check_docker.yml
@@ -2,7 +2,7 @@ name: Check Docker
 
 on:
   push:
-    branches: [main, holoscan-sdk-lws2]
+    branches: [main, holoscan-sdk-lws2, fixes-docker]
 
 permissions:
   contents: read

--- a/.github/workflows/check_docker.yml
+++ b/.github/workflows/check_docker.yml
@@ -2,7 +2,7 @@ name: Check Docker
 
 on:
   push:
-    branches: [main, holoscan-sdk-lws2, fixes-docker]
+    branches: [main, holoscan-sdk-lws2]
 
 permissions:
   contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,13 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # --------------------------------------------------------------------------
 #
-# Holohub run setup
+# Holohub CLI setup
 #
 
+# Install python3 if not present (needed for holohub CLI)
+RUN if ! command -v python3 >/dev/null 2>&1; then \
+        apt-get update && apt-get install -y python3 python3-pip; \
+    fi
 RUN mkdir -p /tmp/scripts
 COPY holohub /tmp/scripts/
 RUN mkdir -p /tmp/scripts/utilities

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -1459,7 +1459,10 @@ class HoloHubCLI:
                 potential_command = sys.argv[1]
                 if potential_command in self.subparsers:
                     # Show help for the specific subcommand
-                    print(f"\nError parsing arguments for '{potential_command}' command.\n")
+                    print(
+                        f"\nError parsing arguments for '{potential_command}' command.\n",
+                        file=sys.stderr,
+                    )
                     self.subparsers[potential_command].print_help()
                     sys.exit(e.code if e.code is not None else 1)
             raise

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -753,7 +753,7 @@ class HoloHubCLI:
             if hasattr(args, "with_operators") and args.with_operators:
                 run_cmd += f' --build-with "{args.with_operators}"'
             if hasattr(args, "run_args") and args.run_args:
-                run_cmd += f" --run_args {shlex.quote(args.run_args)}"
+                run_cmd += f" --run-args {shlex.quote(args.run_args)}"
             if getattr(args, "parallel", None):
                 run_cmd += f" --parallel {args.parallel}"
 

--- a/utilities/cli/tests/test_cli.py
+++ b/utilities/cli/tests/test_cli.py
@@ -204,7 +204,7 @@ class TestHoloHubCLI(unittest.TestCase):
         kwargs = mock_container.run.call_args[1]
         cmd_string = kwargs["extra_args"][1]
         self.assertIn("./holohub run test_project", cmd_string)
-        self.assertIn("--run_args", cmd_string)
+        self.assertIn("--run-args", cmd_string)
         self.assertIn(quoted_value, cmd_string)
 
     def test_list_command(self):


### PR DESCRIPTION
- support consistent docker build options such as `--base-img, --build-args` for various ./holohub commands ` build-container, run-container, run, build`
- dockerfile includes a python3 installation if not present. (the dockerfile seems to already assume python such as `/tmp/scripts/holohub setup` and `pip install`)
- add github ci tests for `./holohub build-container --base-img ubuntu:22.04` (so that we can verify dockerfile such as https://github.com/nvidia-holoscan/holohub/pull/910)
- improve argparse help message: the current `./holohub build --invalid_arg` doesn't print subparser usage
- fix an issue of passing `--run_args` to container's `--run-args` parser
