### PR TITLE
Update HoloHub CLI default base container to v3.3.0

### DIFF
--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -30,7 +30,7 @@ from .util import (
     run_command,
 )
 
-base_sdk_version = "3.2.0"
+base_sdk_version = "3.3.0"
 
 
 class HoloHubContainer:


### PR DESCRIPTION
Followup to dev_container update in bfb93972