### PR TITLE
fixed file format error in generate_bar_graph.py

### DIFF
--- a/benchmarks/holoscan_flow_benchmarking/generate_bar_graph.py
+++ b/benchmarks/holoscan_flow_benchmarking/generate_bar_graph.py
@@ -18,7 +18,8 @@ import datetime
 import os
 
 import matplotlib
-matplotlib.use('Agg')
+
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
 keyword_dictionary = {

--- a/benchmarks/holoscan_flow_benchmarking/generate_bar_graph.py
+++ b/benchmarks/holoscan_flow_benchmarking/generate_bar_graph.py
@@ -17,6 +17,8 @@ import argparse
 import datetime
 import os
 
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
 keyword_dictionary = {


### PR DESCRIPTION
Fix for ```gi.repository.GLib.GError: gdk-pixbuf-error-quark: Couldn't recognize the image file format for file "/usr/local/lib/python3.12/dist-packages/matplotlib/mpl-data/images/matplotlib.svg" (3)``` error when running generate_bar_graph.py