### PR TITLE
Infra: Update default Python3 installation strategy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,28 @@ ARG DEBIAN_FRONTEND=noninteractive
 #
 
 # Install python3 if not present (needed for holohub CLI)
+ARG PYTHON_VERSION=python3.12
 RUN if ! command -v python3 >/dev/null 2>&1; then \
-        apt-get update && apt-get install -y python3 python3-pip; \
-    fi
+        apt-get update \
+        && apt-get install --no-install-recommends -y \
+            software-properties-common curl \
+        && add-apt-repository ppa:deadsnakes/ppa \
+        && apt-get update \
+        && apt-get install --no-install-recommends -y \
+            ${PYTHON_VERSION} ${PYTHON_VERSION}-dev \
+        && apt purge -y \
+            python3-pip \
+            software-properties-common \
+        && apt-get autoremove --purge -y \
+        && rm -rf /var/lib/apt/lists/* \
+        && update-alternatives --install /usr/bin/python3 python3 /usr/bin/${PYTHON_VERSION} 100 \
+        && update-alternatives --install /usr/bin/python python /usr/bin/${PYTHON_VERSION} 100 \
+    ; fi
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+RUN if ! python3 -m pip --version >/dev/null 2>&1; then \
+        curl -sS https://bootstrap.pypa.io/get-pip.py | ${PYTHON_VERSION} \
+    ; fi
+
 RUN mkdir -p /tmp/scripts
 COPY holohub /tmp/scripts/
 RUN mkdir -p /tmp/scripts/utilities

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ARG PYTHON_VERSION=python3.12
 RUN if ! command -v python3 >/dev/null 2>&1; then \
         apt-get update \
         && apt-get install --no-install-recommends -y \
-            software-properties-common curl \
+            software-properties-common curl gpg-agent \
         && add-apt-repository ppa:deadsnakes/ppa \
         && apt-get update \
         && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
Support installing `python3` in default `ubuntu:24.04` container

To address failure:
```
=> ERROR [12/17] RUN pip install meson                                                      0.4s 
------
 > [12/17] RUN pip install meson:
0.378 error: externally-managed-environment
0.378 
0.378 × This environment is externally managed
0.378 ╰─> To install Python packages system-wide, try apt install
0.378     python3-xyz, where xyz is the package you are trying to
0.378     install.
0.378     
0.378     If you wish to install a non-Debian-packaged Python package,
0.378     create a virtual environment using python3 -m venv path/to/venv.
0.378     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
0.378     sure you have python3-full installed.
0.378     
0.378     If you wish to install a non-Debian packaged Python application,
0.378     it may be easiest to use pipx install xyz, which will manage a
0.378     virtual environment for you. Make sure you have pipx installed.
0.378     
0.378     See /usr/share/doc/python3.12/README.venv for more information.
0.378 
0.378 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
0.378 hint: See PEP 668 for the detailed specification.
```

Test with: `./holohub run-container --base_img ubuntu:24.04 --img holohub:24.04`