### PR TITLE
CLI: run-container forward trailing commands

### DIFF
--- a/.github/workflows/check_docker.yml
+++ b/.github/workflows/check_docker.yml
@@ -35,3 +35,5 @@ jobs:
           ./holohub run-container --base-img ubuntu:${ubuntu_version} --no-docker-build | grep -q "docker run" || { echo "run-container failed"; exit 1; }
           ./holohub run-container --docker-opts "--memory 4g" --no-docker-build | grep -q "memory 4g" || { echo "docker-opts test failed"; exit 1; }
           ./holohub run-container --no-docker-build --add-volume "/tmp" | grep -q "/tmp" || { echo "add-volume test failed"; exit 1; }
+          ./holohub run-container --no-docker-build -- echo hello > /tmp/trailing-args.log 2>&1
+          grep -q "hello" /tmp/trailing-args.log || { echo "trailing args test failed"; cat /tmp/trailing-args.log; exit 1; }

--- a/utilities/cli/tests/CMakeLists.txt
+++ b/utilities/cli/tests/CMakeLists.txt
@@ -133,6 +133,16 @@ set_property(TEST test_holohub_run_dryrun PROPERTY
     PASS_REGULAR_EXPRESSION "run endoscopy_tool_tracking.*--local"
 )
 
+add_test(
+    NAME test_holohub_run_container_dryrun
+    COMMAND ${CMAKE_SOURCE_DIR}/holohub run-container --dryrun -- echo hello
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_property(TEST test_holohub_run_container_dryrun PROPERTY
+    PASS_REGULAR_EXPRESSION "docker run"
+    PASS_REGULAR_EXPRESSION "holohub.*echo hello"
+)
+
 # Add test for container module
 add_test(
     NAME test_container


### PR DESCRIPTION
Update HoloHub CLI to forward arguments following "--" to the docker run entrypoint.

example usage:
```
./holohub run-container endoscopy_tool_tracking --no-docker-build -- echo 'hello'
```