### PR TITLE
CLI Fixes run args

### DIFF
--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -208,7 +208,8 @@ class HoloHubCLI:
         )
         run.add_argument(
             "--run-args",
-            help="Additional arguments to pass to the application executable (for flags use: --run-args=--flag or --run-args='--flag')",
+            help="Additional arguments to pass to the application executable, "
+            "example: --run-args=--flag or --run-args '-c config/file'",
         )
         run.add_argument(
             "--build-with",

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -207,7 +207,8 @@ class HoloHubCLI:
             "--language", choices=["cpp", "python"], help="Specify language implementation"
         )
         run.add_argument(
-            "--run-args", help="Additional arguments to pass to the application executable"
+            "--run-args",
+            help="Additional arguments to pass to the application executable (for flags use: --run-args=--flag or --run-args='--flag')",
         )
         run.add_argument(
             "--build-with",
@@ -861,7 +862,7 @@ class HoloHubCLI:
             if hasattr(args, "with_operators") and args.with_operators:
                 run_cmd += f' --build-with "{args.with_operators}"'
             if hasattr(args, "run_args") and args.run_args:
-                run_cmd += f" --run-args {shlex.quote(args.run_args)}"
+                run_cmd += f" --run-args={shlex.quote(args.run_args)}"
             if getattr(args, "parallel", None):
                 run_cmd += f" --parallel {args.parallel}"
 

--- a/utilities/cli/tests/CMakeLists.txt
+++ b/utilities/cli/tests/CMakeLists.txt
@@ -135,7 +135,7 @@ set_property(TEST test_holohub_run_dryrun PROPERTY
 
 add_test(
     NAME test_holohub_run_forward_args
-    COMMAND ${CMAKE_SOURCE_DIR}/holohub run endoscopy_tool_tracking --dryrun --run-args="--flag"
+    COMMAND ${CMAKE_SOURCE_DIR}/holohub run endoscopy_tool_tracking --dryrun --run-args=--flag
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 set_property(TEST test_holohub_run_forward_args PROPERTY

--- a/utilities/cli/tests/CMakeLists.txt
+++ b/utilities/cli/tests/CMakeLists.txt
@@ -139,7 +139,7 @@ add_test(
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 set_property(TEST test_holohub_run_forward_args PROPERTY
-    PASS_REGULAR_EXPRESSION "run endoscopy_tool_tracking.*--runargs=--flag"
+    PASS_REGULAR_EXPRESSION "run endoscopy_tool_tracking.*--run-args=--flag"
 )
 
 add_test(

--- a/utilities/cli/tests/CMakeLists.txt
+++ b/utilities/cli/tests/CMakeLists.txt
@@ -134,6 +134,15 @@ set_property(TEST test_holohub_run_dryrun PROPERTY
 )
 
 add_test(
+    NAME test_holohub_run_forward_args
+    COMMAND ${CMAKE_SOURCE_DIR}/holohub run endoscopy_tool_tracking --dryrun --run-args="--flag"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_property(TEST test_holohub_run_forward_args PROPERTY
+    PASS_REGULAR_EXPRESSION "run endoscopy_tool_tracking.*--runargs=--flag"
+)
+
+add_test(
     NAME test_holohub_run_pythonpath
     COMMAND ${CMAKE_SOURCE_DIR}/holohub run-container --dryrun
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}


### PR DESCRIPTION
this fixes an issue of forwarding '--run-args' from CLI into the command within the container.

```
./holohub run test_proj --run-args=--mcp
```
current issue: in the main branch ./holohub run will forward the args into 
`./holohub run test_proj --local --run-args --mcp` where `--mcp` will be interpreted as an unknown ./holohub argument.

This PR: it fixes the forwarding with format `--run-args=--mcp` so that values such as `--mcp` will always be passed to test_proj's launch command instead of parsed by ./holohub.