### PR TITLE
Infra: Revert default SDK container version to v3.3.0

### DIFF
--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -38,7 +38,7 @@ from .util import (
     run_command,
 )
 
-base_sdk_version = "3.4.0"
+base_sdk_version = "3.3.0"
 
 
 class HoloHubContainer:


### PR DESCRIPTION
Holoscan SDK v3.4.0 is not publicly available at this time. Reverting to v3.3.0 container default.

Addresses issue introduced in c7e7768ae5c075d079e792d193c2e46d82c337ef: `ERROR: failed to solve: nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu: nvcr.io/nvidia/clara-holoscan/holoscan:v3.4.0-dgpu: not found`