### PR TITLE
Infra: Remove extraneous CMake version check at configuration time

### DIFF
--- a/applications/laser_detection_latency/CMakeLists.txt
+++ b/applications/laser_detection_latency/CMakeLists.txt
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.24)
 project(laser_detection_apps LANGUAGES NONE)
 
 set(HOLOSCAN_OPERATORS


### PR DESCRIPTION
Remove unused CMake version minimum requirement in `laser_detection_latency` impacting minimum version across all projects.

The affected line reflected `laser_detection_latency` requirements but was added to all project configurations. The line was redundant with subdirectory CMake version checks and is removed to allow lower versions of CMake to be used for configuration HoloHub.

Fix originally proposed in https://github.com/nvidia-holoscan/holohub/pull/872