### PR TITLE
CLI enable custom script entrypoint

### DIFF
--- a/.github/workflows/check_docker.yml
+++ b/.github/workflows/check_docker.yml
@@ -2,7 +2,7 @@ name: Check Docker
 
 on:
   push:
-    branches: [main, holoscan-sdk-lws2]
+    branches: [main, holoscan-sdk-lws2, entrypoint]
 
 permissions:
   contents: read

--- a/.github/workflows/check_docker.yml
+++ b/.github/workflows/check_docker.yml
@@ -2,7 +2,7 @@ name: Check Docker
 
 on:
   push:
-    branches: [main, holoscan-sdk-lws2, entrypoint]
+    branches: [main, holoscan-sdk-lws2]
 
 permissions:
   contents: read

--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -82,8 +82,8 @@ class HoloHubContainer:
         )
         parser.add_argument(
             "--build-args",
-            help="(Build container) Extra arguments to docker build command. "
-            "Example: `--build-args '--network=host --build-arg \"CUSTOM=value with spaces\"'`",
+            help="(Build container) Extra arguments to docker build command, "
+            "example: `--build-args '--network=host --build-arg \"CUSTOM=value with spaces\"'`",
         )
         return parser
 
@@ -94,8 +94,8 @@ class HoloHubContainer:
         parser.add_argument(
             "--docker-opts",
             default="",
-            help="Additional options to the Docker run command. "
-            "Examples: `--docker-opts '--env \"VAR=value with spaces\"'`",
+            help="Additional options to the Docker run command, "
+            "example: `--docker-opts='--entrypoint=bash'` or `--docker-opts '-e DISPLAY=:1'`",
         )
         parser.add_argument(
             "--ssh-x11",

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -700,9 +700,13 @@ class HoloHubCLI:
                 for configure_arg in args.configure_args:
                     build_cmd += f' --configure-args "{configure_arg}"'
 
-            docker_opts = "--entrypoint=bash"
-            if hasattr(args, "docker_opts") and args.docker_opts:
-                docker_opts += " " + args.docker_opts
+            img = getattr(args, "img", None) or container.image_name
+            docker_opts = getattr(args, "docker_opts", "")
+            docker_opts_extra, extra_args = holohub_cli_util.get_shell_command_args(
+                img, build_cmd, docker_opts, dry_run=args.dryrun
+            )
+            if docker_opts_extra:
+                docker_opts = f"{docker_opts} {docker_opts_extra}".strip()
             container.run(
                 img=getattr(args, "img", None),
                 local_sdk_root=getattr(args, "local_sdk_root", None),
@@ -716,7 +720,7 @@ class HoloHubCLI:
                 docker_opts=docker_opts,
                 add_volumes=getattr(args, "add_volume", None),
                 enable_mps=getattr(args, "mps", False),
-                extra_args=["-c", build_cmd],
+                extra_args=extra_args,
             )
 
     def handle_run(self, args: argparse.Namespace) -> None:
@@ -900,6 +904,13 @@ class HoloHubCLI:
                 for configure_arg in args.configure_args:
                     run_cmd += f' --configure-args "{configure_arg}"'
 
+            img = getattr(args, "img", None) or container.image_name
+            docker_opts = getattr(args, "docker_opts", "")
+            docker_opts_extra, extra_args = holohub_cli_util.get_shell_command_args(
+                img, run_cmd, docker_opts, dry_run=args.dryrun
+            )
+            if docker_opts_extra:
+                docker_opts = f"{docker_opts} {docker_opts_extra}".strip()
             container.run(
                 img=getattr(args, "img", None),
                 local_sdk_root=getattr(args, "local_sdk_root", None),
@@ -910,10 +921,10 @@ class HoloHubCLI:
                 nsys_profile=getattr(args, "nsys_profile", False),
                 nsys_location=getattr(args, "nsys_location", ""),
                 as_root=getattr(args, "as_root", False),
-                docker_opts="--entrypoint=bash " + args.docker_opts,
+                docker_opts=docker_opts,
                 add_volumes=getattr(args, "add_volume", None),
                 enable_mps=getattr(args, "mps", False),
-                extra_args=["-c", run_cmd],
+                extra_args=extra_args,
             )
 
     def handle_list(self, args: argparse.Namespace) -> None:
@@ -1488,9 +1499,13 @@ class HoloHubCLI:
                 for configure_arg in args.configure_args:
                     install_cmd += f' --configure-args "{configure_arg}"'
 
-            docker_opts = "--entrypoint=bash"
-            if hasattr(args, "docker_opts") and args.docker_opts:
-                docker_opts += " " + args.docker_opts
+            img = getattr(args, "img", None) or container.image_name
+            docker_opts = getattr(args, "docker_opts", "")
+            docker_opts_extra, extra_args = holohub_cli_util.get_shell_command_args(
+                img, install_cmd, docker_opts, dry_run=args.dryrun
+            )
+            if docker_opts_extra:
+                docker_opts = f"{docker_opts} {docker_opts_extra}".strip()
             container.run(
                 img=getattr(args, "img", None),
                 local_sdk_root=getattr(args, "local_sdk_root", None),
@@ -1504,7 +1519,7 @@ class HoloHubCLI:
                 docker_opts=docker_opts,
                 add_volumes=getattr(args, "add_volume", None),
                 enable_mps=getattr(args, "mps", False),
-                extra_args=["-c", install_cmd],
+                extra_args=extra_args,
             )
 
     def handle_clear_cache(self, args: argparse.Namespace) -> None:

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -702,7 +702,7 @@ class HoloHubCLI:
 
             img = getattr(args, "img", None) or container.image_name
             docker_opts = getattr(args, "docker_opts", "")
-            docker_opts_extra, extra_args = holohub_cli_util.get_shell_command_args(
+            docker_opts_extra, extra_args = holohub_cli_util.get_entrypoint_command_args(
                 img, build_cmd, docker_opts, dry_run=args.dryrun
             )
             if docker_opts_extra:
@@ -906,7 +906,7 @@ class HoloHubCLI:
 
             img = getattr(args, "img", None) or container.image_name
             docker_opts = getattr(args, "docker_opts", "")
-            docker_opts_extra, extra_args = holohub_cli_util.get_shell_command_args(
+            docker_opts_extra, extra_args = holohub_cli_util.get_entrypoint_command_args(
                 img, run_cmd, docker_opts, dry_run=args.dryrun
             )
             if docker_opts_extra:
@@ -1501,7 +1501,7 @@ class HoloHubCLI:
 
             img = getattr(args, "img", None) or container.image_name
             docker_opts = getattr(args, "docker_opts", "")
-            docker_opts_extra, extra_args = holohub_cli_util.get_shell_command_args(
+            docker_opts_extra, extra_args = holohub_cli_util.get_entrypoint_command_args(
                 img, install_cmd, docker_opts, dry_run=args.dryrun
             )
             if docker_opts_extra:

--- a/utilities/cli/tests/CMakeLists.txt
+++ b/utilities/cli/tests/CMakeLists.txt
@@ -97,7 +97,7 @@ set_property(TEST test_holohub_build_container_build_args PROPERTY
 
 add_test(
     NAME test_holohub_run_container_docker_opts
-    COMMAND ${CMAKE_SOURCE_DIR}/holohub run-container --dryrun --docker-opts "--memory 4g"
+    COMMAND ${CMAKE_SOURCE_DIR}/holohub run-container --dryrun --docker-opts "--memory 4g --entrypoint=bash"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 set_property(TEST test_holohub_run_container_docker_opts PROPERTY

--- a/utilities/cli/tests/test_cli.py
+++ b/utilities/cli/tests/test_cli.py
@@ -212,7 +212,7 @@ class TestHoloHubCLI(unittest.TestCase):
 
         # Verify the container.run was called with the correctly quoted arguments
         kwargs = mock_container.run.call_args[1]
-        cmd_string = kwargs["extra_args"][1]
+        cmd_string = kwargs["extra_args"][0]
         self.assertIn("./holohub run test_project", cmd_string)
         self.assertIn("--run-args", cmd_string)
         self.assertIn(quoted_value, cmd_string)
@@ -408,7 +408,7 @@ class TestHoloHubCLI(unittest.TestCase):
         # Verify container build
         mock_container.run.assert_called()
         kwargs = mock_container.run.call_args[1]
-        command_string = kwargs["extra_args"][1]
+        command_string = kwargs["extra_args"][0]
         self.assertIn(f'--build-with "{operators}"', command_string)
         mock_container.reset_mock()
 
@@ -418,7 +418,7 @@ class TestHoloHubCLI(unittest.TestCase):
         # Verify container run
         mock_container.run.assert_called()
         kwargs = mock_container.run.call_args[1]
-        command_string = kwargs["extra_args"][1]
+        command_string = kwargs["extra_args"][0]
         self.assertIn(f'--build-with "{operators}"', command_string)
 
     @patch("utilities.cli.holohub.HoloHubCLI.find_project")
@@ -609,7 +609,7 @@ exec {holohub_script} "$@"
         mock_container.build.assert_called_once()
         mock_container.run.assert_called_once()
         kwargs = mock_container.run.call_args[1]
-        command_string = kwargs["extra_args"][1]
+        command_string = kwargs["extra_args"][0]
         self.assertIn("./holohub install test_project --local", command_string)
         self.assertIn("--build-type debug", command_string)
         self.assertIn("--language cpp", command_string)
@@ -617,7 +617,7 @@ exec {holohub_script} "$@"
         args = self.cli.parser.parse_args("install test_project --parallel 4".split())
         args.func(args)
         kwargs = mock_container.run.call_args[1]
-        command_string = kwargs["extra_args"][1]
+        command_string = kwargs["extra_args"][0]
         self.assertIn("--parallel 4", command_string)
 
     @patch("utilities.cli.holohub.HoloHubCLI.find_project")
@@ -740,7 +740,7 @@ exec {holohub_script} "$@"
 
             mock_container.build.assert_called_once()
             mock_container.run.assert_called_once()
-            command_string = mock_container.run.call_args[1]["extra_args"][1]
+            command_string = mock_container.run.call_args[1]["extra_args"][0]
             self.assertIn("--benchmark", command_string)
             self.assertIn("./holohub build test_app --local", command_string)
 

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -19,6 +19,7 @@ import json
 import os
 import platform
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -547,8 +548,12 @@ def get_shell_command_args(
     img: str, command: str, docker_opts: str, dry_run: bool = False
 ) -> tuple[str, List[str]]:
     """Determine how to execute a shell command in a Docker container."""
-    if "--entrypoint" in docker_opts:  # User explicitly provided an entrypoint
-        return "", [command]
+    if "--entrypoint" in docker_opts:
+        try:
+            command_args = shlex.split(command)  # "command" splits into a list of arguments
+            return "", command_args
+        except ValueError:
+            return "", [command]
     entrypoint = get_container_entrypoint(img, dry_run=dry_run)
     if not entrypoint:  # image has no entrypoint, docker uses default "/bin/sh -c" for command
         return "", [command]

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import grp
+import json
 import os
 import platform
 import re
@@ -542,23 +543,72 @@ def docker_args_to_devcontainer_format(docker_args: List[str]) -> List[str]:
     return result
 
 
+def get_shell_command_args(
+    img: str, command: str, docker_opts: str, dry_run: bool = False
+) -> tuple[str, List[str]]:
+    """Determine how to execute a shell command in a Docker container."""
+    if "--entrypoint" in docker_opts:  # User explicitly provided an entrypoint
+        return "", [command]
+    entrypoint = get_container_entrypoint(img, dry_run=dry_run)
+    if not entrypoint:  # image has no entrypoint, docker uses default "/bin/sh -c" for command
+        return "", [command]
+    # Image has an ENTRYPOINT
+    if entrypoint in [["/bin/sh", "-c"], ["/bin/bash", "-c"], ["sh", "-c"], ["bash", "-c"]]:
+        return "", [command]  # Shell is already configured to take command string
+    if entrypoint in [["/bin/sh"], ["/bin/bash"], ["sh"], ["bash"]]:
+        return "", ["-c", command]  # Shell needs -c to execute command string
+    return "--entrypoint=bash", ["-c", command]  # bash is used to run local build/run command
+
+
+def get_container_entrypoint(img: str, dry_run: bool = False) -> Optional[List[str]]:
+    """Check if container image has an entrypoint defined"""
+    if dry_run:
+        print(
+            "Inspect docker image entrypoint: "
+            f"docker inspect --format={{{{json .Config.Entrypoint}}}} {img}"
+        )
+        return None
+
+    try:
+        result = run_command(
+            ["docker", "inspect", "--format={{json .Config.Entrypoint}}", img],
+            capture_output=True,
+            check=False,
+            dry_run=dry_run,
+        )
+        if result.returncode != 0:
+            return None
+        entrypoint_json = result.stdout.strip()
+        if entrypoint_json in ["<no value>", "[]", "null", "''"]:
+            return None
+        parsed = json.loads(entrypoint_json)
+        if isinstance(parsed, list) and len(parsed) > 0:
+            return parsed
+        return None
+    except Exception:
+        pass
+    return None
+
+
 def get_image_pythonpath(img: str, dry_run: bool = False) -> str:
     """Get PYTHONPATH from the Docker image environment"""
-    try:
-        if dry_run:
-            print(
-                Color.yellow(
-                    f"Inspect docker image PYTHONPATH: docker inspect "
-                    f"--format '{{{{range .Config.Env}}}}{{{{println .}}}}{{{{end}}}}' {img}"
-                )
+    if dry_run:
+        print(
+            Color.yellow(
+                "Inspect docker image PYTHONPATH: docker inspect "
+                f"--format '{{{{range .Config.Env}}}}{{{{println .}}}}{{{{end}}}}' {img}"
             )
-            return ""
+        )
+        return ""
+    try:
         result = run_command(
             ["docker", "inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", img],
-            check=True,
+            check=False,
             capture_output=True,
             dry_run=dry_run,
         )
+        if result.returncode != 0:
+            return ""
         for line in result.stdout.decode().strip().split("\n"):
             if line.startswith("PYTHONPATH="):
                 return line[len("PYTHONPATH=") :]

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -544,7 +544,7 @@ def docker_args_to_devcontainer_format(docker_args: List[str]) -> List[str]:
     return result
 
 
-def get_shell_command_args(
+def get_entrypoint_command_args(
     img: str, command: str, docker_opts: str, dry_run: bool = False
 ) -> tuple[str, List[str]]:
     """Determine how to execute a shell command in a Docker container."""


### PR DESCRIPTION
This mainly considers `./holohub [build|run|install]` within a container:
1. if with `--docker-opts="--entrypoint=/custom/script"`
```
./holohub build endoscopy_tool_tracking --docker-opts="--entrypoint=/opt/nvidia/nvidia_entrypoint.sh"
```
the within container command will be `/opt/nvidia/nvidia_entrypoint.sh ./holohub build endoscopy_tool_tracking --local `

2. depending on the entrypoint, it automatically adds `-c` to the command string, for example when the entrypoint is `/bin/bash`.