### PR TITLE
Infra: Address `python3` version mismatch in HoloHub default Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 #
 
 # Install python3 if not present (needed for holohub CLI)
-ARG PYTHON_VERSION=python3.12
+ARG PYTHON_VERSION=python3
 RUN if ! command -v python3 >/dev/null 2>&1; then \
         apt-get update \
         && apt-get install --no-install-recommends -y \
@@ -41,14 +41,16 @@ RUN if ! command -v python3 >/dev/null 2>&1; then \
         && add-apt-repository ppa:deadsnakes/ppa \
         && apt-get update \
         && apt-get install --no-install-recommends -y \
-            ${PYTHON_VERSION} ${PYTHON_VERSION}-dev \
+            ${PYTHON_VERSION} \
         && apt purge -y \
             python3-pip \
             software-properties-common \
         && apt-get autoremove --purge -y \
         && rm -rf /var/lib/apt/lists/* \
-        && update-alternatives --install /usr/bin/python3 python3 /usr/bin/${PYTHON_VERSION} 100 \
         && update-alternatives --install /usr/bin/python python /usr/bin/${PYTHON_VERSION} 100 \
+        && if [ "${PYTHON_VERSION}" != "python3" ]; then \
+            update-alternatives --install /usr/bin/python3 python3 /usr/bin/${PYTHON_VERSION} 100 \
+            ; fi \
     ; fi
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 RUN if ! python3 -m pip --version >/dev/null 2>&1; then \
@@ -86,8 +88,7 @@ RUN apt update \
     gobject-introspection \
     libgtk-3-dev \
     libcanberra-gtk-module \
-    graphviz\
-    ninja-build
+    graphviz
 
 RUN pip install meson
 

--- a/utilities/cli/tests/test_cli.py
+++ b/utilities/cli/tests/test_cli.py
@@ -811,6 +811,18 @@ class TestRunCommand(unittest.TestCase):
         self.assertIn("echo hello", printed_args)
         self.assertIn("[dryrun]", printed_args)
 
+    def test_parse_semantic_version(self):
+        """Test the parse_semantic_version function"""
+        self.assertEqual(util.parse_semantic_version("1.2.3"), (1, 2, 3))
+        self.assertEqual(util.parse_semantic_version("1.2.3+dev4"), (1, 2, 3))
+        self.assertEqual(util.parse_semantic_version("1.2.3-rc4"), (1, 2, 3))
+        self.assertEqual(util.parse_semantic_version("1.2.3.dev4"), (1, 2, 3))
+        self.assertEqual(util.parse_semantic_version("1.0.0-beta+exp.sha.5114f85"), (1, 0, 0))
+        self.assertRaises(ValueError, util.parse_semantic_version, "1.2")
+        self.assertRaises(ValueError, util.parse_semantic_version, "1.2.dev3")
+        self.assertGreater(util.parse_semantic_version("1.2.3"), (1, 1, 10))
+        self.assertLess(util.parse_semantic_version("1.2.3"), (1, 12, 3))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -174,6 +174,11 @@ def run_info_command(cmd: List[str]) -> Optional[str]:
         return None
 
 
+def parse_semantic_version(version: str) -> Tuple[int, int, int]:
+    """Parse semantic version string MAJOR.MINOR. into tuple of integers for comparison"""
+    return tuple(map(int, version.split(".")))
+
+
 def check_nvidia_ctk(min_version: str = "1.12.0", recommended_version: str = "1.14.1") -> None:
     """Check NVIDIA Container Toolkit version"""
 
@@ -187,20 +192,12 @@ def check_nvidia_ctk(min_version: str = "1.12.0", recommended_version: str = "1.
         match = re.search(r"(\d+\.\d+\.\d+)", output)
         if match:
             version = match.group(1)
-
             try:
-                from packaging import version as ver
-
-                version_check = ver.parse(version) < ver.parse(min_version)
-            except ImportError:
-
-                def parse_version(v):
-                    try:
-                        return tuple(map(int, v.split(".")))
-                    except ValueError:
-                        return (10, 0, 0)
-
-                version_check = parse_version(version) < parse_version(min_version)
+                version_check = parse_semantic_version(version) < parse_semantic_version(
+                    min_version
+                )
+            except ValueError:
+                version_check = False
 
             if version_check:
                 fatal(

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -175,8 +175,17 @@ def run_info_command(cmd: List[str]) -> Optional[str]:
 
 
 def parse_semantic_version(version: str) -> Tuple[int, int, int]:
-    """Parse semantic version string MAJOR.MINOR. into tuple of integers for comparison"""
-    return tuple(map(int, version.split(".")))
+    """
+    Parse semantic version string MAJOR.MINOR.PATCH into tuple of integers for comparison
+
+    Note: Implementing our own version parsing to avoid dependency on PyPI 'packaging' module.
+
+    ref: https://semver.org/
+    """
+    match = re.match(r"^(\d+\.\d+\.\d+).*", version.strip())
+    if not match:
+        raise ValueError(f"Failed to parse semantic version string: {version}")
+    return tuple(map(int, match.group(1).split(".")))
 
 
 def check_nvidia_ctk(min_version: str = "1.12.0", recommended_version: str = "1.14.1") -> None:
@@ -187,8 +196,6 @@ def check_nvidia_ctk(min_version: str = "1.12.0", recommended_version: str = "1.
 
     try:
         output = subprocess.check_output(["nvidia-ctk", "--version"], text=True)
-        import re
-
         match = re.search(r"(\d+\.\d+\.\d+)", output)
         if match:
             version = match.group(1)


### PR DESCRIPTION
Followup to https://github.com/nvidia-holoscan/holohub/commit/5db60cfc20d737c0dbd3863d981624223db5b8ab to address an issue where a custom `python3.X` installation in the default Dockerfile is overridden in later layers.

## Previous behavior

[Dockerfile](https://github.com/nvidia-holoscan/holohub/blob/main/Dockerfile#L36) currently installs Python 3.12 by default across base images, however the output of `./holohub build-container --base-img ubuntu:22.04` shows different Python versions installed simultaneously:

```
$ python3 --version
Python 3.10.12
$ python --version
Python 3.12.11
```

__Impact__: This behavior is unexpected and could lead to confusion for developers working in a container based on Ubuntu 22.04, such as any projects that pin their base container to Holoscan SDK <= v3.2.0.

On inspection there are two later layers that override the default Python 3.12 installation in Ubuntu 22.04 environments:
- `./holohub setup` checks for and uses `python3-dev` explicitly, which installs Python 3.10
- `gobject-inspection` and `libgirepository1.0-dev` benchmarking dependencies depend explicitly on Python 3.10 in Ubuntu 22.04

## Proposed changes

- Revert to use the default `python3` version string for installation, which uses system defaults (3.10 on Ubuntu 22.04, 3.12 on Ubuntu 24.04)
- Install minimal `python3` by default and let `./holohub setup` be responsible for `python3.X-dev` package installation
- Update `./holohub setup` to check for the minor version of the interpreter running the CLI when inspecting `python3-dev` or `python3.X-dev`, allowing `./holohub setup` to complete without installing additional Python versions

## Test coverage
- `./holohub run-container --base-img ubuntu:22.04`
- `./holohub run-container --base-img ubuntu:24.04`

## Additional notes

This PR does not attempt to address Python version pinning in benchmarking dependencies. We've had separate conversations in the past about making benchmarking dependencies an optional build step, which would support the custom version request here.

Requesting a custom version with `PYTHON3_VERSION=python3.11` or similar will currently fail at the benchmarking requirements installation build layer.