### PR TITLE
Fixes CLI benchmarking

### DIFF
--- a/benchmarks/holoscan_flow_benchmarking/benchmark.py
+++ b/benchmarks/holoscan_flow_benchmarking/benchmark.py
@@ -332,9 +332,7 @@ assignment in Holoscan's Inference operator.",
 
     # Use the new holohub CLI command format
     if args.run_command == "":
-        app_launch_command = (
-            f"./holohub run {args.holohub_application} --local --no-local-build --language {args.language}"
-        )
+        app_launch_command = f"./holohub run {args.holohub_application} --local --no-local-build --language {args.language}"
         logger.info(f"Using holohub CLI command: {app_launch_command}")
     else:
         app_launch_command = args.run_command


### PR DESCRIPTION
when in the benchmark.py threads, there's no need to build the app again.
addressing issue:
```
2025-06-26 11:25:33,047 INFO: Using holohub CLI command: ./holohub run colonoscopy_segmentation --local --language python
2025-06-26 11:25:33,047 INFO: Run 1 started for eventbased scheduler.
2025-06-26 11:28:10,452 ERROR: Command "./holohub run colonoscopy_segmentation --local --language python" exited with code 245
2025-06-26 11:28:15,362 INFO: Run 1 completed for eventbased scheduler.
2025-06-26 11:28:16,364 INFO: Run 2 started for eventbased scheduler.
2025-06-26 11:30:15,940 ERROR: Command "./holohub run colonoscopy_segmentation --local --language python" exited with code 1
2025-06-26 11:30:23,589 ERROR: Command "./holohub run colonoscopy_segmentation --local --language python" exited with code 1
2025-06-26 11:30:38,084 INFO: Run 2 completed for eventbased scheduler.
2025-06-26 11:30:39,086 INFO: Run 3 started for eventbased scheduler.
2025-06-26 11:30:39,511 ERROR: Command "./holohub run colonoscopy_segmentation --local --language python" exited with code 1
2025-06-26 11:30:39,512 ERROR: Command "./holohub run colonoscopy_segmentation --local --language python" exited with code 1
2025-06-26 11:32:02,047 INFO: Run 3 completed for eventbased scheduler.
2025-06-26 11:32:03,049 INFO: ****************************************************************
```