### PR TITLE
App: Pin H.264 Dockerfile to Holoscan SDK v3.2.0

### DIFF
--- a/applications/h264/Dockerfile
+++ b/applications/h264/Dockerfile
@@ -21,7 +21,7 @@
 ARG BASE_IMAGE
 ARG GPU_TYPE
 
-FROM ${BASE_IMAGE} as base
+FROM nvcr.io/nvidia/clara-holoscan/holoscan:v3.2.0-dgpu as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
GXF Multimedia extensions for H.264 support are not publicly available for Holoscan SDK >= 3.3.0 (GXF >= 5.0).

Pin to Holoscan SDK v3.2.0 temporarily, pending GXF Multimedia release for GXF 5.0.