### PR TITLE
Add Documentation for Holohub CMake Helper Functions

### DIFF
--- a/cmake/HoloHubConfigHelpers.cmake
+++ b/cmake/HoloHubConfigHelpers.cmake
@@ -52,7 +52,7 @@
 #   PKG_${NAME}: CMake option to enable/disable this package
 #
 # Example:
-#   add_holohub_package(my_package 
+#   add_holohub_package(my_package
 #     EXTENSIONS gxf_core gxf_serialization
 #     OPERATORS my_operator
 #     APPLICATIONS my_application
@@ -104,8 +104,8 @@ endfunction()
 #   APP_${NAME}: CMake option to enable/disable this application
 #
 # Example:
-#   add_holohub_application(my_app 
-#     DEPENDS 
+#   add_holohub_application(my_app
+#     DEPENDS
 #       EXTENSIONS gxf_core gxf_serialization
 #       OPERATORS required_op OPTIONAL optional_op1 optional_op2
 #   )
@@ -167,7 +167,7 @@ endfunction()
 #   OP_${NAME}: CMake option to enable/disable this operator
 #
 # Example:
-#   add_holohub_operator(my_op 
+#   add_holohub_operator(my_op
 #     DEPENDS EXTENSIONS gxf_core gxf_serialization
 #   )
 function(add_holohub_operator NAME)

--- a/cmake/HoloHubConfigHelpers.cmake
+++ b/cmake/HoloHubConfigHelpers.cmake
@@ -13,7 +13,50 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# HoloHub Configuration Helpers
+# =============================
+#
+# This file provides CMake helper functions for building HoloHub packages, applications,
+# operators, and extensions. These functions simplify the build configuration process
+# and handle dependency management automatically.
+#
+# Available Functions:
+# - add_holohub_package(): Build packages with dependencies
+# - add_holohub_application(): Build applications with operator/extension dependencies
+# - add_holohub_operator(): Build operators with extension dependencies
+# - add_holohub_extension(): Build extensions
+#
+# Global Variables:
+# - BUILD_ALL: Global flag to enable/disable all components (default: OFF)
+# - HOLOHUB_BUILD_OPERATORS: List of operators to build when optional dependencies are specified
+#
+# Usage Examples:
+#   add_holohub_package(my_package EXTENSIONS gxf_core OPERATORS my_op APPLICATIONS my_app)
+#   add_holohub_application(my_app DEPENDS EXTENSIONS gxf_core OPERATORS my_op)
+#   add_holohub_operator(my_op DEPENDS EXTENSIONS gxf_core)
+#   add_holohub_extension(my_ext)
+
 # Helper function to build packages
+# =================================
+# Builds a package and automatically enables its dependencies.
+#
+# Parameters:
+#   NAME: The name of the package to build
+#
+# Keyword Arguments:
+#   EXTENSIONS: List of GXF extensions that this package depends on
+#   OPERATORS: List of Holoscan operators that this package depends on
+#   APPLICATIONS: List of applications that this package depends on
+#
+# Creates:
+#   PKG_${NAME}: CMake option to enable/disable this package
+#
+# Example:
+#   add_holohub_package(my_package 
+#     EXTENSIONS gxf_core gxf_serialization
+#     OPERATORS my_operator
+#     APPLICATIONS my_application
+#   )
 function(add_holohub_package NAME)
   set(pkgname "PKG_${NAME}")
   option(${pkgname} "Build the ${NAME} package" ${BUILD_ALL})
@@ -44,6 +87,28 @@ endfunction()
 
 
 # Helper function to build application and dependencies
+# ====================================================
+# Builds an application and automatically enables its required dependencies.
+# Supports optional operator dependencies based on HOLOHUB_BUILD_OPERATORS.
+#
+# Parameters:
+#   NAME: The name of the application to build
+#
+# Keyword Arguments:
+#   DEPENDS: Dependency specification with sub-arguments:
+#     EXTENSIONS: List of GXF extensions that this application depends on
+#     OPERATORS: List of Holoscan operators that this application depends on
+#               Use "OPTIONAL" keyword to make subsequent operators optional
+#
+# Creates:
+#   APP_${NAME}: CMake option to enable/disable this application
+#
+# Example:
+#   add_holohub_application(my_app 
+#     DEPENDS 
+#       EXTENSIONS gxf_core gxf_serialization
+#       OPERATORS required_op OPTIONAL optional_op1 optional_op2
+#   )
 function(add_holohub_application NAME)
 
   cmake_parse_arguments(APP "" "" "DEPENDS" ${ARGN})
@@ -88,6 +153,23 @@ endfunction()
 
 
 # Helper function to build operators
+# ==================================
+# Builds a Holoscan operator and automatically enables its extension dependencies.
+#
+# Parameters:
+#   NAME: The name of the operator to build
+#
+# Keyword Arguments:
+#   DEPENDS: Dependency specification with sub-arguments:
+#     EXTENSIONS: List of GXF extensions that this operator depends on
+#
+# Creates:
+#   OP_${NAME}: CMake option to enable/disable this operator
+#
+# Example:
+#   add_holohub_operator(my_op 
+#     DEPENDS EXTENSIONS gxf_core gxf_serialization
+#   )
 function(add_holohub_operator NAME)
 
   cmake_parse_arguments(OP "" "" "DEPENDS" ${ARGN})
@@ -113,6 +195,17 @@ endfunction()
 
 
 # Helper function to build extensions
+# ===================================
+# Builds a GXF extension. This is the simplest helper function with no dependencies.
+#
+# Parameters:
+#   NAME: The name of the extension to build
+#
+# Creates:
+#   EXT_${NAME}: CMake option to enable/disable this extension
+#
+# Example:
+#   add_holohub_extension(my_extension)
 function(add_holohub_extension NAME)
   set(extname "EXT_${NAME}")
   option(${extname} "Build the ${NAME} extension" ${BUILD_ALL})

--- a/cmake/HoloHubConfigHelpers.cmake
+++ b/cmake/HoloHubConfigHelpers.cmake
@@ -36,8 +36,9 @@
 #   add_holohub_operator(my_op DEPENDS EXTENSIONS gxf_core)
 #   add_holohub_extension(my_ext)
 
+# =====================================================
 # Helper function to build packages
-# =================================
+# =====================================================
 # Builds a package and automatically enables its dependencies.
 #
 # Parameters:
@@ -85,9 +86,9 @@ function(add_holohub_package NAME)
   endforeach()
 endfunction()
 
-
+# =====================================================
 # Helper function to build application and dependencies
-# ====================================================
+# =====================================================
 # Builds an application and automatically enables its required dependencies.
 # Supports optional operator dependencies based on HOLOHUB_BUILD_OPERATORS.
 #
@@ -151,9 +152,9 @@ function(add_holohub_application NAME)
 
 endfunction()
 
-
+# =====================================================
 # Helper function to build operators
-# ==================================
+# =====================================================
 # Builds a Holoscan operator and automatically enables its extension dependencies.
 #
 # Parameters:
@@ -193,9 +194,9 @@ function(add_holohub_operator NAME)
   endif()
 endfunction()
 
-
+# =====================================================
 # Helper function to build extensions
-# ===================================
+# =====================================================
 # Builds a GXF extension. This is the simplest helper function with no dependencies.
 #
 # Parameters:


### PR DESCRIPTION
This pull request enhances the `cmake/HoloHubConfigHelpers.cmake` file by adding detailed documentation and examples for CMake helper functions used to build HoloHub components.