### PR TITLE
fixes CLI create

### DIFF
--- a/applications/template/{{cookiecutter.project_slug}}/README.md
+++ b/applications/template/{{cookiecutter.project_slug}}/README.md
@@ -17,7 +17,6 @@ This application is built using Holoscan SDK version {{ cookiecutter.holoscan_ve
 
 1. Clone this repository
 
-
 2. Install dependencies:
 
 3. Build the application:

--- a/applications/template/{{cookiecutter.project_slug}}/metadata.json
+++ b/applications/template/{{cookiecutter.project_slug}}/metadata.json
@@ -25,7 +25,7 @@
 		"dependencies": {},
 		"run": {
 			"command": {% if cookiecutter.language == "python" %}
-				"python3 <holohub_app_source>/src/{{ cookiecutter.project_slug }}.py"
+				"python3 <holohub_app_source>/src/main.py"
 			{% else %}
 				"<holohub_app_bin>/{{ cookiecutter.project_slug }}"
 			{% endif %},


### PR DESCRIPTION
test case added gitlab

fixes an inconsistency in `./holohub create` when language=python - the main filename [in the template is `src/main.py`](https://github.com/nvidia-holoscan/holohub/tree/main/applications/template/%7B%7Bcookiecutter.project_slug%7D%7D/src) but the metadata.json run command is `src/project_slug.py`