### PR TITLE
Infra: Update project folder READMES for HoloHub CLI

### DIFF
--- a/applications/README.md
+++ b/applications/README.md
@@ -23,9 +23,7 @@ See the [HoloHub application template](./template/) for example `README` and `me
 
 ## Recommended Conventions
 
-Contributors may additionally opt to lay out their project structure in a way that conforms to HoloHub conventions in order to enable common infrastructure for their project, including streamlined build and run support in the [`dev_container`](../dev_container) and [`run`](../run) scripts and search support on the HoloHub landing page.
-
-If your code does not adhere to these conventions, please set the field `manual_setup` to `true` in your project `metadata.json` file to opt out and indicate that your project is not eligible for streamlined infrastructure support.
+Contributors may additionally opt to lay out their project structure in a way that conforms to HoloHub conventions in order to enable common infrastructure for their project, including streamlined build and run support in the [`holohub`](../holohub) script and search support on the HoloHub landing page.
 
 HoloHub recommended application convention is as follows:
 - Languages
@@ -48,11 +46,10 @@ applications/
     - Default project environment must be named `Dockerfile`
     - Project `Dockerfile` must be located at either:
       - The same directory as `metadata.json`, or
-      - If the project defines a language directory (`cpp`, `python`), may provide at the project folder one level above, or
       - The project may provide an alternative default Dockerfile path in `metadata.json`
   - If the project does not specify a `Dockerfile` then the [default HoloHub `Dockerfile`](../Dockerfile) will be used
 
 - Build and Run Instructions
-  - Must provide a run command in `metadata.json` for `./run launch` to reference
-  - Must otherwise comply with `./dev_container build_and_run` command options for the default use case
+  - Must provide a run command in `metadata.json` for `./holohub run` to reference
+  - Must otherwise comply with `./holohub run` command options for the default use case
   - Advanced instructions may also be specified in the project README

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -19,9 +19,7 @@ We expect that a workflow contributed to HoloHub conforms to the following organ
 
 ### Recommended Conventions
 
-Contributors may additionally opt to lay out their project structure in a way that conforms to HoloHub conventions in order to enable common infrastructure for their project, including streamlined build and run support in the [`dev_container`](../dev_container) and [`run`](../run) scripts and search support on the HoloHub landing page.
-
-If your code does not adhere to these conventions, please set the field `manual_setup` to `true` in your project `metadata.json` file to opt out and indicate that your project is not eligible for streamlined infrastructure support.
+Contributors may additionally opt to lay out their project structure in a way that conforms to HoloHub conventions in order to enable common infrastructure for their project, including streamlined build and run support in the [`holohub`](../holohub) script and search support on the HoloHub landing page.
 
 HoloHub recommended workflow convention is as follows:
 
@@ -46,11 +44,10 @@ workflows/
     - Default project environment must be named `Dockerfile`
     - Project `Dockerfile` must be located at either:
       - The same directory as `metadata.json`, or
-      - If the project defines a language directory (`cpp`, `python`), may provide at the project folder one level above, or
       - The project may provide an alternative default Dockerfile path in `metadata.json`
   - If the project does not specify a `Dockerfile` then the [default HoloHub `Dockerfile`](../Dockerfile) will be used
 
 - Build and Run Instructions
-  - Must provide a run command in `metadata.json` for `./run launch` to reference
-  - Must otherwise comply with `./dev_container build_and_run` command options for the default use case
+  - Must provide a run command in `metadata.json` for `./holohub run` to reference
+  - Must otherwise comply with `./holohub run` command options for the default use case
   - Advanced instructions may also be specified in the project README


### PR DESCRIPTION
Address legacy script references in project-level folder READMEs.

Also note:
- `manual_setup` was proposed but does not appear to have been implemented, remove.
- Updates CLI Dockerfile strategy

From link failures in draft removal PR: https://github.com/nvidia-holoscan/holohub/actions/runs/15980280992/job/45072851027