### PR TITLE
improve CLI error message

### DIFF
--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -26,7 +26,7 @@ import sys
 import tempfile
 from collections import defaultdict
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import utilities.cli.util as holohub_cli_util
 import utilities.metadata.gather_metadata as metadata_util
@@ -1767,6 +1767,22 @@ class HoloHubCLI:
         distances.sort(key=lambda x: x[1])
         return [cmd for cmd, dist in distances[:2] if dist <= 2]  # Show up to 2 matches
 
+    def _check_for_dash_prefix_issue(self, cmd_args: List[str]) -> Optional[str]:
+        """
+        Check if the parsing error is likely due to dash-prefixed arguments
+        """
+        DASH_VALUE_ARGS = ["--run-args", "--build-args", "--docker-opts", "--configure-args"]
+        for i, arg in enumerate(cmd_args):
+            if arg in DASH_VALUE_ARGS and "=" not in arg:
+                if i + 1 < len(cmd_args) and cmd_args[i + 1].startswith("-"):
+                    next_arg = cmd_args[i + 1]
+                    return (
+                        f"💡 Tip: ambiguous dash-prefixed arguments, use the equals format:\n"
+                        f"   Instead of: {arg} {next_arg}\n"
+                        f"   Use: {arg}={next_arg}"
+                    )
+        return None
+
     def run(self) -> None:
         """Main entry point for the CLI"""
 
@@ -1776,26 +1792,36 @@ class HoloHubCLI:
             sep = cmd_args.index("--")
             cmd_args, trailing_docker_args = cmd_args[:sep], cmd_args[sep + 1 :]
 
+        potential_command = cmd_args[0] if cmd_args else None
+        dash_suggestion = None
+        if potential_command and potential_command in self.subparsers:
+            dash_suggestion = self._check_for_dash_prefix_issue(cmd_args)
+
         try:
             args = self.parser.parse_args(cmd_args)
             if trailing_docker_args:
                 args._trailing_args = trailing_docker_args  # " -- " used for run-container command
         except SystemExit as e:
             if len(cmd_args) > 0 and e.code != 0:  # exit code is 0 => help was successfully shown
-                potential_command = cmd_args[0]
-                if potential_command in self.subparsers:
-                    # Show help for the specific subcommand
-                    print(
-                        f"\nError parsing arguments for '{potential_command}' command.\n",
-                        file=sys.stderr,
-                    )
-                    self.subparsers[potential_command].print_help()
+                if dash_suggestion:
+                    print(f"\n{dash_suggestion}\n", file=sys.stderr)
+                if (  # a valid subcommand but parsing failed, show subcommand usage
+                    potential_command
+                    and not potential_command.startswith("-")
+                    and potential_command in self.subparsers
+                ):
+                    print(f"\n💡 For help with the '{potential_command}' command:", file=sys.stderr)
+                    print(f"  {self.script_name} {potential_command} --help\n", file=sys.stderr)
                     sys.exit(e.code if e.code is not None else 1)
-                elif not potential_command.startswith("-"):
+                if (  # don't have a valid subcommand
+                    potential_command
+                    and not potential_command.startswith("-")
+                    and potential_command not in self.subparsers
+                ):
                     # Suggest similar commands using existing utility
                     suggestions = self._suggest_command(potential_command)
                     if suggestions:
-                        print("\nDid you mean:", file=sys.stderr)
+                        print("\n💡 Did you mean:", file=sys.stderr)
                         for cmd in suggestions:
                             print(f"  {self.script_name} {cmd}", file=sys.stderr)
                         print(file=sys.stderr)

--- a/utilities/cli/tests/CMakeLists.txt
+++ b/utilities/cli/tests/CMakeLists.txt
@@ -181,3 +181,13 @@ set_property(TEST test_cli_env_info PROPERTY
     PASS_REGULAR_EXPRESSION "Holoscan Environment Variables"
     PASS_REGULAR_EXPRESSION "Other Relevant Environment Variables"
 )
+
+# test ambigous dash-prefixed arguments
+add_test(
+    NAME test_cli_ambiguous_dash_prefixed_arguments
+    COMMAND ${CMAKE_SOURCE_DIR}/holohub run-container --dryrun --run-args --local
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_property(TEST test_cli_ambiguous_dash_prefixed_arguments PROPERTY
+    PASS_REGULAR_EXPRESSION "ambiguous dash-prefixed arguments"
+)


### PR DESCRIPTION
command such as `--build-args --test --dryrun` can be ambiguous, the previous `./dev_container` handled it differently, in the new CLI `--build-args=--test` is needed to make it clear that `--test` is a value provided to the option `build-args`.

adding more error messages when this is detected:

```
$ ./holohub build-container --build-args --test --dryrun
usage: ./holohub build-container [-h] [--base-img BASE_IMG] [--docker-file DOCKER_FILE] [--img IMG] [--no-cache] [--build-args BUILD_ARGS] [--verbose] [--dryrun] [--language {cpp,python}] [project]
./holohub build-container: error: argument --build-args: expected one argument

💡 Tip: ambiguous dash-prefixed arguments, use the equals format:
   Instead of: --build-args --test
   Use: --build-args=--test


💡 For help with the 'build-container' command:
  ./holohub build-container --help

```