### PR TITLE
Add infrastructure to support custom holoscan DataLogger implementations in Holohub

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -88,6 +88,9 @@ add_subdirectory(benchmarks)
 
 # Build the operators
 add_subdirectory(operators)
+
+# Build the data loggers
+add_subdirectory(data_loggers)
 
 # Build the extensions
 add_subdirectory(gxf_extensions)

--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -28,7 +28,9 @@ add_holohub_application(body_pose_estimation DEPENDS
 
 add_holohub_application(colonoscopy_segmentation DEPENDS OPERATORS OPTIONAL aja_source)
 
-add_holohub_application(cvcuda_basic DEPENDS OPERATORS cvcuda_holoscan_interop)
+add_holohub_application(cvcuda_basic DEPENDS
+                        OPERATORS cvcuda_holoscan_interop
+                        DATA_LOGGERS message_logger)
 
 add_subdirectory(dds)
 

--- a/applications/cvcuda_basic/cpp/CMakeLists.txt
+++ b/applications/cvcuda_basic/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
 cmake_minimum_required(VERSION 3.20)
 project(cvcuda_basic CXX)
 
-find_package(holoscan 0.5 REQUIRED CONFIG
+find_package(holoscan 3.4 REQUIRED CONFIG
              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 # find_package(CUDAToolkit REQUIRED)  # Holoscan will already have included CUDA
 find_package(nvcv_types REQUIRED)
@@ -32,6 +32,7 @@ target_link_libraries(cvcuda_basic
   holoscan::ops::video_stream_replayer
   holoscan::ops::holoviz
   holoscan::ops::cvcuda_holoscan_interop
+  holoscan::data_loggers::message_logger
   nvcv_types
   cvcuda
 )

--- a/applications/cvcuda_basic/cpp/main.cpp
+++ b/applications/cvcuda_basic/cpp/main.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@
 #include "cvcuda_to_holoscan.hpp"
 #include "holoscan/holoscan.hpp"
 #include "holoscan_to_cvcuda.hpp"
+#include "message_logger.hpp"
 
 #include <cvcuda/OpFlip.hpp>     // cvcuda::Flip
 #include <nvcv/DataType.hpp>     // nvcv::DataType
@@ -134,6 +135,10 @@ class App : public holoscan::Application {
     add_flow(holoscan_to_cvcuda, image_processing);
     add_flow(image_processing, cvcuda_to_holoscan);
     add_flow(cvcuda_to_holoscan, visualizer2, {{"output", "receivers"}});
+
+    // configure this application to use Holohub's example MessageLogger
+    auto message_logger = make_resource<data_loggers::MessageLogger>("message_logger");
+    add_data_logger(message_logger);
   }
 
  private:

--- a/applications/cvcuda_basic/cpp/metadata.json
+++ b/applications/cvcuda_basic/cpp/metadata.json
@@ -8,15 +8,16 @@
 			}
 		],
 		"language": "C++",
-		"version": "1.0",
+		"version": "1.1",
 		"changelog": {
-			"1.0": "Initial Release"
+			"1.0": "Initial Release",
+			"1.1": "Add example MessageLogger"
 		},
 		"dockerfile": "applications/cvcuda_basic/Dockerfile",
 		"holoscan_sdk": {
-			"minimum_required_version": "0.6.0",
+			"minimum_required_version": "3.4.0",
 			"tested_versions": [
-				"0.6.0"
+				"3.4.0"
 			]
 		},
 		"platforms": [

--- a/applications/cvcuda_basic/python/CMakeLists.txt
+++ b/applications/cvcuda_basic/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/applications/cvcuda_basic/python/CMakeLists.txt
+++ b/applications/cvcuda_basic/python/CMakeLists.txt
@@ -16,7 +16,7 @@
 # Add testing
 if(BUILD_TESTING)
   # To get the environment path
-  find_package(holoscan 0.6 REQUIRED CONFIG
+  find_package(holoscan 3.4 REQUIRED CONFIG
                PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
   # Add test

--- a/applications/cvcuda_basic/python/cvcuda_basic.py
+++ b/applications/cvcuda_basic/python/cvcuda_basic.py
@@ -1,5 +1,5 @@
 """
-SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,8 @@ import cvcuda
 import nvcv
 from holoscan.core import Application, Operator, OperatorSpec
 from holoscan.operators import HolovizOp, VideoStreamReplayerOp
+
+from holohub.message_logger import MessageLogger
 
 
 # Define custom Operators for use in the demo
@@ -120,6 +122,9 @@ class MyVideoProcessingApp(Application):
 
         self.add_flow(source, image_processing)
         self.add_flow(image_processing, visualizer, {("output_tensor", "receivers")})
+
+        message_logger = MessageLogger(self, name="message_logger")
+        self.add_data_logger(message_logger)
 
 
 if __name__ == "__main__":

--- a/applications/cvcuda_basic/python/metadata.json
+++ b/applications/cvcuda_basic/python/metadata.json
@@ -8,15 +8,16 @@
 			}
 		],
 		"language": "Python",
-		"version": "1.0",
+		"version": "1.1",
 		"changelog": {
-			"1.0": "Initial Release"
+			"1.0": "Initial Release",
+			"1.1": "Add example MessageLogger"
 		},
 		"dockerfile": "applications/cvcuda_basic/Dockerfile",
 		"holoscan_sdk": {
-			"minimum_required_version": "0.6.0",
+			"minimum_required_version": "3.4.0",
 			"tested_versions": [
-				"0.6.0"
+				"3.4.0"
 			]
 		},
 		"platforms": [

--- a/cmake/pybind11_add_holohub_module.cmake
+++ b/cmake/pybind11_add_holohub_module.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,7 @@ FetchContent_Declare(pybind11
 )
 FetchContent_MakeAvailable(pybind11)
 
-# Helper function to generate pybind11 operator modules
+# Helper function to generate pybind11 operator or data logger modules
 function(pybind11_add_holohub_module)
     cmake_parse_arguments(MODULE        # PREFIX
         ""                              # OPTIONS

--- a/data_loggers/CMakeLists.txt
+++ b/data_loggers/CMakeLists.txt
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# add_holohub_data_logger(message_logger)

--- a/data_loggers/README.md
+++ b/data_loggers/README.md
@@ -1,0 +1,7 @@
+# HoloHub Data Loggers
+
+This directory contains data loggers for the Holoscan Platform.
+
+# Contributing to HoloHub Data Loggers
+
+Please review the [CONTRIBUTING.md file](https://github.com/nvidia-holoscan/holohub/blob/main/CONTRIBUTING.md) guidelines to contribute data loggers.

--- a/data_loggers/message_logger/CMakeLists.txt
+++ b/data_loggers/message_logger/CMakeLists.txt
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+cmake_minimum_required(VERSION 3.20)
+project(message_logger)
+
+find_package(holoscan 3.4 REQUIRED CONFIG
+             PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+
+add_library(message_logger SHARED
+  message_logger.cpp
+  message_logger.hpp
+  )
+
+add_library(holoscan::data_loggers::message_logger ALIAS message_logger)
+
+target_link_libraries(message_logger
+  PRIVATE
+    holoscan::core
+  )
+
+target_include_directories(message_logger INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(message_logger PRIVATE HOLOSCAN_MAJOR_VERSION=${holoscan_VERSION_MAJOR})
+target_compile_definitions(message_logger PRIVATE HOLOSCAN_MINOR_VERSION=${holoscan_VERSION_MINOR})
+
+if(HOLOHUB_BUILD_PYTHON)
+    add_subdirectory(python)
+endif()
+
+install(TARGETS message_logger)

--- a/data_loggers/message_logger/README.md
+++ b/data_loggers/message_logger/README.md
@@ -1,0 +1,11 @@
+### Message Logger
+
+This is a very basic logger that just prints an acknowledgement when messages are logged. It is provided merely as an example of the structure required to add a new logger to Holohub.
+
+#### `holoscan::data_loggers::MessageLogger`
+
+MessageLogger class to simply log an INFO level message whenever a message is emitted or received.
+
+##### Parameters
+
+This data logger has the same parameters as the `DataLoggerResource` class from which it is derived.

--- a/data_loggers/message_logger/message_logger.cpp
+++ b/data_loggers/message_logger/message_logger.cpp
@@ -50,8 +50,9 @@ bool MessageLogger::log_data(
     [[maybe_unused]] int64_t acquisition_timestamp,
     [[maybe_unused]] std::shared_ptr<MetadataDictionary> metadata,
     [[maybe_unused]] IOSpec::IOType io_type) {
+  auto current_timestamp = get_timestamp();
   HOLOSCAN_LOG_INFO("[timestamp: {}] log_data called for {} port with unique id {}",
-                    acquisition_timestamp,
+                    current_timestamp,
                     io_type == IOSpec::IOType::kInput ? "input" : "output",
                     unique_id);
   return true;
@@ -63,8 +64,9 @@ bool MessageLogger::log_tensor_data(
     [[maybe_unused]] int64_t acquisition_timestamp,
     [[maybe_unused]] const std::shared_ptr<MetadataDictionary>& metadata,
     [[maybe_unused]] IOSpec::IOType io_type) {
+  auto current_timestamp = get_timestamp();
   HOLOSCAN_LOG_INFO("[timestamp: {}] log_tensor_data called for {} port with unique id {}",
-                    acquisition_timestamp,
+                    current_timestamp,
                     io_type == IOSpec::IOType::kInput ? "input" : "output",
                     unique_id);
   return true;
@@ -76,8 +78,9 @@ bool MessageLogger::log_tensormap_data(
     [[maybe_unused]] int64_t acquisition_timestamp,
     [[maybe_unused]] const std::shared_ptr<MetadataDictionary>& metadata,
     [[maybe_unused]] IOSpec::IOType io_type) {
+  auto current_timestamp = get_timestamp();
   HOLOSCAN_LOG_INFO("[timestamp: {}] log_tensormap_data called for {} port with unique id {}",
-                    acquisition_timestamp,
+                    current_timestamp,
                     io_type == IOSpec::IOType::kInput ? "input" : "output",
                     unique_id);
   return true;

--- a/data_loggers/message_logger/message_logger.cpp
+++ b/data_loggers/message_logger/message_logger.cpp
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "message_logger.hpp"
+
+#include <any>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "holoscan/core/component_spec.hpp"
+#include "holoscan/core/domain/tensor.hpp"
+#include "holoscan/core/domain/tensor_map.hpp"
+#include "holoscan/core/resources/data_logger.hpp"
+
+namespace holoscan {
+namespace data_loggers {
+
+void MessageLogger::setup(ComponentSpec& spec) {
+  // add any additional parameters for the custom logger here
+
+  // setup the parameters present on the base DataLoggerResource
+  DataLoggerResource::setup(spec);
+}
+
+void MessageLogger::initialize() {
+  // add any additional initialize code here
+
+  // call parent initialize after adding missing serializer arg above
+  DataLoggerResource::initialize();
+}
+
+bool MessageLogger::log_data(
+    [[maybe_unused]] std::any data,
+    [[maybe_unused]] const std::string& unique_id,
+    [[maybe_unused]] int64_t acquisition_timestamp,
+    [[maybe_unused]] std::shared_ptr<MetadataDictionary> metadata,
+    [[maybe_unused]] IOSpec::IOType io_type) {
+  HOLOSCAN_LOG_INFO("[timestamp: {}] log_data called for {} port with unique id {}",
+                    acquisition_timestamp,
+                    io_type == IOSpec::IOType::kInput ? "input" : "output",
+                    unique_id);
+  return true;
+}
+
+bool MessageLogger::log_tensor_data(
+    [[maybe_unused]] const std::shared_ptr<Tensor>& tensor,
+    [[maybe_unused]] const std::string& unique_id,
+    [[maybe_unused]] int64_t acquisition_timestamp,
+    [[maybe_unused]] const std::shared_ptr<MetadataDictionary>& metadata,
+    [[maybe_unused]] IOSpec::IOType io_type) {
+  HOLOSCAN_LOG_INFO("[timestamp: {}] log_tensor_data called for {} port with unique id {}",
+                    acquisition_timestamp,
+                    io_type == IOSpec::IOType::kInput ? "input" : "output",
+                    unique_id);
+  return true;
+}
+
+bool MessageLogger::log_tensormap_data(
+    [[maybe_unused]] const TensorMap& tensor_map,
+    [[maybe_unused]] const std::string& unique_id,
+    [[maybe_unused]] int64_t acquisition_timestamp,
+    [[maybe_unused]] const std::shared_ptr<MetadataDictionary>& metadata,
+    [[maybe_unused]] IOSpec::IOType io_type) {
+  HOLOSCAN_LOG_INFO("[timestamp: {}] log_tensormap_data called for {} port with unique id {}",
+                    acquisition_timestamp,
+                    io_type == IOSpec::IOType::kInput ? "input" : "output",
+                    unique_id);
+  return true;
+}
+
+}  // namespace data_loggers
+}  // namespace holoscan

--- a/data_loggers/message_logger/message_logger.hpp
+++ b/data_loggers/message_logger/message_logger.hpp
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DATA_LOGGERS_MESSAGE_LOGGER_MESSAGE_LOGGER_HPP
+#define DATA_LOGGERS_MESSAGE_LOGGER_MESSAGE_LOGGER_HPP
+
+#include <any>
+#include <cstdint>
+#include <memory>  // For std::shared_ptr in parameters
+#include <string>
+#include <vector>
+
+#include "holoscan/core/component_spec.hpp"
+#include "holoscan/core/resource.hpp"
+#include "holoscan/core/resources/data_logger.hpp"
+
+namespace holoscan {
+namespace data_loggers {
+
+/**
+ * @brief Class for logging a message indicating when an emit or receive call is made.
+ */
+class MessageLogger : public DataLoggerResource {
+ public:
+  HOLOSCAN_RESOURCE_FORWARD_ARGS_SUPER(MessageLogger, DataLoggerResource)
+  MessageLogger() = default;
+
+  void setup(ComponentSpec& spec) override;
+  void initialize() override;
+  bool log_data(std::any data, const std::string& unique_id, int64_t acquisition_timestamp = -1,
+                std::shared_ptr<MetadataDictionary> metadata = nullptr,
+                IOSpec::IOType io_type = IOSpec::IOType::kOutput) override;
+  bool log_tensor_data(const std::shared_ptr<Tensor>& tensor, const std::string& unique_id,
+                       int64_t acquisition_timestamp = -1,
+                       const std::shared_ptr<MetadataDictionary>& metadata = nullptr,
+                       IOSpec::IOType io_type = IOSpec::IOType::kOutput) override;
+  bool log_tensormap_data(const TensorMap& tensor_map, const std::string& unique_id,
+                          int64_t acquisition_timestamp = -1,
+                          const std::shared_ptr<MetadataDictionary>& metadata = nullptr,
+                          IOSpec::IOType io_type = IOSpec::IOType::kOutput) override;
+};
+
+}  // namespace data_loggers
+}  // namespace holoscan
+
+#endif /* DATA_LOGGERS_MESSAGE_LOGGER_MESSAGE_LOGGER_HPP */

--- a/data_loggers/message_logger/metadata.json
+++ b/data_loggers/message_logger/metadata.json
@@ -1,0 +1,29 @@
+{
+    "data_logger": {
+        "name": "message_logger",
+        "authors": [
+            {
+                "name": "Holoscan Team",
+                "affiliation": "NVIDIA"
+            }
+        ],
+        "language": ["C++"],
+        "version": "1.0.0",
+        "changelog": {
+			"1.0": "Initial Release"
+        },
+        "holoscan_sdk": {
+            "minimum_required_version": "3.4.0",
+            "tested_versions": [
+                "3.4.0"
+            ]
+        },
+        "platforms": [
+            "x86_64",
+            "aarch64"
+        ],
+        "tags": [],
+        "ranking": 1,
+        "dependencies": { }
+    }
+}

--- a/data_loggers/message_logger/python/CMakeLists.txt
+++ b/data_loggers/message_logger/python/CMakeLists.txt
@@ -13,4 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_holohub_data_logger(message_logger)
+include(pybind11_add_holohub_module)
+pybind11_add_holohub_module(
+    CPP_CMAKE_TARGET message_logger
+    CLASS_NAME "MessageLogger"
+    SOURCES message_logger.cpp
+)

--- a/data_loggers/message_logger/python/message_logger.cpp
+++ b/data_loggers/message_logger/python/message_logger.cpp
@@ -1,0 +1,125 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>  // for vector
+
+#include <any>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <typeindex>
+#include <vector>
+
+#include "./message_logger_pydoc.hpp"
+
+#include "../message_logger.hpp"
+#include "holoscan/core/arg.hpp"
+#include "holoscan/core/component_spec.hpp"
+#include "holoscan/core/fragment.hpp"
+#include "holoscan/core/parameter.hpp"
+#include "holoscan/core/resources/data_logger.hpp"
+
+using std::string_literals::operator""s;  // NOLINT(misc-unused-using-decls)
+using pybind11::literals::operator""_a;   // NOLINT(misc-unused-using-decls)
+
+namespace py = pybind11;
+
+namespace holoscan::data_loggers {
+
+class PyMessageLogger : public MessageLogger {
+ public:
+  /* Inherit the constructors */
+  using MessageLogger::MessageLogger;
+
+  // Define a constructor that fully initializes the object.
+  PyMessageLogger(Fragment* fragment, const py::args& args,
+                       bool log_inputs = true, bool log_outputs = true,
+                       bool log_tensor_data_content = false, bool log_metadata = false,
+                       const std::vector<std::string>& allowlist_patterns = {},
+                       const std::vector<std::string>& denylist_patterns = {},
+                       const std::string& name = "message_logger")
+      : MessageLogger(ArgList{Arg{"log_inputs", log_inputs},
+                                   Arg{"log_outputs", log_outputs},
+                                   Arg{"log_tensor_data_content", log_tensor_data_content},
+                                   Arg{"log_metadata", log_metadata},
+                                   Arg{"allowlist_patterns", allowlist_patterns},
+                                   Arg{"denylist_patterns", denylist_patterns}}) {
+    // warn if non-empty allowlist and denylist are specified
+    if (!allowlist_patterns.empty() && !denylist_patterns.empty()) {
+      std::string warning_msg =
+          "MessageLogger: Both allowlist_patterns and denylist_patterns are specified. "
+          "Allowlist takes precedence and denylist will be ignored.";
+      try {
+        auto warnings = py::module_::import("warnings");
+        warnings.attr("warn")(
+            warning_msg, py::arg("category") = py::module_::import("builtins").attr("UserWarning"));
+      } catch (const py::error_already_set&) {
+        // If we can't import warnings or we're not in a Python context, just continue
+      } catch (...) {
+        // Ignore any other Python-related errors
+      }
+    }
+    name_ = name;
+    fragment_ = fragment;
+    spec_ = std::make_shared<ComponentSpec>(fragment);
+    setup(*spec_);
+  }
+
+  void initialize() override {
+    HOLOSCAN_LOG_TRACE("MessageLogger::initialize");
+
+    // call parent initialize after adding missing serializer arg above
+    MessageLogger::initialize();
+  }
+};
+
+/* The python module */
+
+PYBIND11_MODULE(_message_logger, m) {
+  m.doc() = R"pbdoc(
+        Holoscan SDK MessageLogger Python Bindings
+        -----------------------------------------------
+        .. currentmodule:: _message_logger
+    )pbdoc";
+
+  py::class_<MessageLogger,
+             PyMessageLogger,
+             DataLoggerResource,
+             std::shared_ptr<MessageLogger>>(
+      m, "MessageLogger", doc::MessageLogger::doc_MessageLogger)
+      .def(py::init<Fragment*,
+                    const py::args&,
+                    bool,
+                    bool,
+                    bool,
+                    bool,
+                    const std::vector<std::string>&,
+                    const std::vector<std::string>&,
+                    const std::string&>(),
+           "fragment"_a,
+           "log_inputs"_a = true,
+           "log_outputs"_a = true,
+           "log_tensor_data_content"_a = false,
+           "log_metadata"_a = false,
+           "allowlist_patterns"_a = py::list(),
+           "denylist_patterns"_a = py::list(),
+           "name"_a = "message_logger"s,
+           doc::MessageLogger::doc_MessageLogger);
+}  // PYBIND11_MODULE NOLINT
+}  // namespace holoscan::data_loggers

--- a/data_loggers/message_logger/python/message_logger_pydoc.hpp
+++ b/data_loggers/message_logger/python/message_logger_pydoc.hpp
@@ -41,12 +41,12 @@ log_tensor_data_content : bool, optional
 log_metadata : bool, optional
     Whether to log metadata associated with messages. Default is True.
 allowlist_patterns : list of str, optional
-    List of regex patterns. Only messages matching these patterns will be logged.
-    If empty, all messages are allowed.
+    List of regex patterns to apply to message unique IDs. If empty, all messages not matching a
+    denylist pattern will be logged. Otherwise, there must be a match to one of the allowlist
+    patterns.
 denylist_patterns : list of str, optional
-    List of regex patterns. Messages matching these patterns will be filtered out.
-    If any `allowlist_patterns` are specified, those take precendence and
-    `denylist_patterns` is not used.
+    List of regex patterns to apply to message unique IDs. If specified and there is a match at
+    least one of these patterns, the message is not logged.
 name : str, optional (constructor only)
     The name of the data logger. Default value is ``"message_logger"``.
 
@@ -58,12 +58,19 @@ assigned to messages by the underlying framework.
 In a non-distributed application (without a fragment name), the unique_id for a message will have
 one of the following forms:
 
-- operator_name.port_name
-- operator_name.port_name:index  (for multi-receivers with N:1 connection)
+  - operator_name.port_name
+  - operator_name.port_name:index  (for multi-receivers with N:1 connection)
 
 For distributed applications, the fragment name will also appear in the unique id:
 
-- fragment_name.operator_name.port_name
-- fragment_name.operator_name.port_name:index  (for multi-receivers with N:1 connection)
+  - fragment_name.operator_name.port_name
+  - fragment_name.operator_name.port_name:index  (for multi-receivers with N:1 connection)
+
+The pattern matching logic is as follows:
+
+  - If `denylist patterns` is specified and there is a match, do not log it.
+  - Next check if `allowlist_patterns` is empty:
+    - If yes, return true (allow everything)
+    - If no, return true only if there is a match to at least one of the specified patterns.
 )doc")
 }  // namespace holoscan::doc::MessageLogger

--- a/data_loggers/message_logger/python/message_logger_pydoc.hpp
+++ b/data_loggers/message_logger/python/message_logger_pydoc.hpp
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+#include "macros.hpp"
+
+namespace holoscan::doc::MessageLogger {
+
+PYDOC(MessageLogger, R"doc(
+Basic message logger for debugging and development purposes.
+
+This data logger is a basic example that only indicates when a message was emitted or received.
+
+Parameters
+----------
+fragment : holoscan.core.Fragment (constructor only)
+    The fragment that the data logger belongs to.
+log_inputs : bool, optional
+    Whether to log input messages. Default is True.
+log_outputs : bool, optional
+    Whether to log output messages. Default is True.
+log_tensor_data_content : bool, optional
+    Whether to log the actual content of tensor data. Default is False.
+log_metadata : bool, optional
+    Whether to log metadata associated with messages. Default is True.
+allowlist_patterns : list of str, optional
+    List of regex patterns. Only messages matching these patterns will be logged.
+    If empty, all messages are allowed.
+denylist_patterns : list of str, optional
+    List of regex patterns. Messages matching these patterns will be filtered out.
+    If any `allowlist_patterns` are specified, those take precendence and
+    `denylist_patterns` is not used.
+name : str, optional (constructor only)
+    The name of the data logger. Default value is ``"message_logger"``.
+
+Notes
+-----
+If `allowlist_patterns` or `denylist_patterns` are specified, they are applied to the `unique_id`
+assigned to messages by the underlying framework.
+
+In a non-distributed application (without a fragment name), the unique_id for a message will have
+one of the following forms:
+
+- operator_name.port_name
+- operator_name.port_name:index  (for multi-receivers with N:1 connection)
+
+For distributed applications, the fragment name will also appear in the unique id:
+
+- fragment_name.operator_name.port_name
+- fragment_name.operator_name.port_name:index  (for multi-receivers with N:1 connection)
+)doc")
+}  // namespace holoscan::doc::MessageLogger

--- a/data_loggers/metadata.schema.json
+++ b/data_loggers/metadata.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "holohub/data_logger/v1",
+  "type": "object",
+  "properties": {
+    "data_logger": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "holohub/project/v1#/$defs/name"
+        },
+        "description": {
+          "$ref": "holohub/project/v1#/$defs/description"
+        },
+        "authors": {
+          "$ref": "holohub/project/v1#/$defs/authors"
+        },
+        "version": {
+          "$ref": "holohub/project/v1#/$defs/version"
+        },
+        "changelog": {
+          "$ref": "holohub/project/v1#/$defs/changelog"
+        },
+        "language": {
+          "$ref": "holohub/project/v1#/$defs/multi_language"
+        },
+        "platforms": {
+          "$ref": "holohub/project/v1#/$defs/platforms"
+        },
+        "tags": {
+          "$ref": "holohub/project/v1#/$defs/tags"
+        },
+        "holoscan_sdk": {
+          "$ref": "holohub/project/v1#/$defs/sdk_version"
+        },
+        "ranking": {
+          "$ref": "holohub/project/v1#/$defs/ranking"
+        },
+        "dependencies": {
+          "$ref": "holohub/project/v1#/$defs/dependencies"
+        }
+      },
+      "required": [
+        "name",
+        "authors",
+        "version",
+        "changelog",
+        "language",
+        "platforms",
+        "tags",
+        "holoscan_sdk",
+        "ranking",
+        "dependencies"
+      ]
+    }
+  },
+  "required": [
+    "data_logger"
+  ]
+}

--- a/dev_container
+++ b/dev_container
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -941,7 +941,6 @@ build_and_run_desc() { c_echo 'Build and run a requested application in a Docker
         --build_args : Build the app with additional CMake configuration arguments
         --build_docker_args : additional docker arguments when building the container
         --build_with : List of optional operators that should be built separated by semicolons (;)
-        --build_with_logger : List of optional data loggers that should be built separated by semicolons (;)
         --run_args : Run the app with additional args
         --ssh_x11 : Enable X11 forwarding of graphical HoloHub applications over SSH
         --verbose : Print extra output to console
@@ -961,7 +960,6 @@ build_and_run() {
     local docker_file=""
     local extra_build_args=""
     local extra_build_with=""
-    local extra_build_with_logger=""
     local extra_run_args=""
     local run_app=1
     local install=""
@@ -1021,16 +1019,6 @@ build_and_run() {
                 shift 2
             else
                 echo "Error: --build_with requires a value"
-                build_and_run_desc
-                exit 1
-            fi
-            ;;
-        --build_with_logger)
-            if [[ -n "$2" ]]; then
-                extra_build_with_logger="--with_logger '$2'"
-                shift 2
-            else
-                echo "Error: --build_with_logger requires a value"
                 build_and_run_desc
                 exit 1
             fi
@@ -1169,7 +1157,7 @@ build_and_run() {
     run_command  ${SCRIPT_DIR}/dev_container build "${container_build_args[@]}"
     if [[ $build_app == 1 ]]; then
         c_echo "Building $app_name..."
-        run_command ${SCRIPT_DIR}/dev_container launch $container_launch_args --docker_opts "$docker_opts" -- -c "./run build $app_name $install $parallel_jobs $extra_build_with $extra_build_with_logger $extra_build_args"
+        run_command ${SCRIPT_DIR}/dev_container launch $container_launch_args --docker_opts "$docker_opts" -- -c "./run build $app_name $install $parallel_jobs $extra_build_with $extra_build_args"
     fi
 
     if [[ $run_app == 1 ]]; then

--- a/dev_container
+++ b/dev_container
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -941,6 +941,7 @@ build_and_run_desc() { c_echo 'Build and run a requested application in a Docker
         --build_args : Build the app with additional CMake configuration arguments
         --build_docker_args : additional docker arguments when building the container
         --build_with : List of optional operators that should be built separated by semicolons (;)
+        --build_with_logger : List of optional data loggers that should be built separated by semicolons (;)
         --run_args : Run the app with additional args
         --ssh_x11 : Enable X11 forwarding of graphical HoloHub applications over SSH
         --verbose : Print extra output to console
@@ -960,6 +961,7 @@ build_and_run() {
     local docker_file=""
     local extra_build_args=""
     local extra_build_with=""
+    local extra_build_with_logger=""
     local extra_run_args=""
     local run_app=1
     local install=""
@@ -1019,6 +1021,16 @@ build_and_run() {
                 shift 2
             else
                 echo "Error: --build_with requires a value"
+                build_and_run_desc
+                exit 1
+            fi
+            ;;
+        --build_with_logger)
+            if [[ -n "$2" ]]; then
+                extra_build_with_logger="--with_logger '$2'"
+                shift 2
+            else
+                echo "Error: --build_with_logger requires a value"
                 build_and_run_desc
                 exit 1
             fi
@@ -1157,7 +1169,7 @@ build_and_run() {
     run_command  ${SCRIPT_DIR}/dev_container build "${container_build_args[@]}"
     if [[ $build_app == 1 ]]; then
         c_echo "Building $app_name..."
-        run_command ${SCRIPT_DIR}/dev_container launch $container_launch_args --docker_opts "$docker_opts" -- -c "./run build $app_name $install $parallel_jobs $extra_build_with $extra_build_args"
+        run_command ${SCRIPT_DIR}/dev_container launch $container_launch_args --docker_opts "$docker_opts" -- -c "./run build $app_name $install $parallel_jobs $extra_build_with $extra_build_with_logger $extra_build_args"
     fi
 
     if [[ $run_app == 1 ]]; then

--- a/run
+++ b/run
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -640,7 +640,7 @@ lint() {
 
 build_desc() {
   echo
-  echo -e "${BOLD}Build a Holohub operator, application, data logger, workflow, or package, in its isolated build directory.${NOCOLOR}"
+  echo -e "${BOLD}Build a Holohub operator, application, workflow, or package, in its isolated build directory.${NOCOLOR}"
   echo
   echo -e "${CYAN}USAGE:${NOCOLOR}"
   echo
@@ -653,9 +653,6 @@ build_desc() {
   echo "   --with <list of operators>           : Optional operators that should be built"
   echo "                                          If multiple operators are to be built, list must be"
   echo "                                          in quotes with operators separated by semicolons (;)"
-  echo "   --with_logger <list of data loggers> : Optional data loggers that should be built"
-  echo "                                          If multiple data loggers are to be built, list must be"
-  echo "                                          in quotes with data loggers separated by semicolons (;)"
   echo "   --type <debug | release | rel-debug> : Specify the type of build"
   echo "                                          Default: release"
   echo "                                          Associated environment variable: CMAKE_BUILD_TYPE"
@@ -749,11 +746,6 @@ build() {
          configure_args="${configure_args} -D HOLOHUB_BUILD_OPERATORS=\"${operators}\""
          echo "Building with operator(s) ${operators}"
          skipnext=1
-      elif [ "$arg" = "--with_logger" ]; then
-         data_loggers="${ARGS[i+1]}"
-         configure_args="${configure_args} -D HOLOHUB_BUILD_DATA_LOGGERS=\"${data_loggers}\""
-         echo "Building with data_loggers(s) ${data_loggers}"
-         skipnext=1
       elif [ "$arg" = "--benchmark" ]; then
           benchmark=true
           configure_args="${configure_args} -D CMAKE_CXX_FLAGS=-I$PWD/benchmarks/holoscan_flow_benchmarking"
@@ -786,9 +778,9 @@ build() {
       fi
   done
 
-  # Package, application, operator or data logger to build
+  # Package, application or operator to build
   if [ "$1" == "" ]; then
-    print_error "Please specify which package, application, operator or data logger to build."
+    print_error "Please specify which package, application, or operator to build."
     echo "You can run ./run list for a full list of options."
     exit 1
   fi
@@ -806,10 +798,8 @@ build() {
     is_app=true
   elif list_operators | awk '{print $1}' | grep -Fxq "$project"; then
     opt_prefix="OP"
-  elif list_data_loggers | awk '{print $1}' | grep -Fxq "$project"; then
-    opt_prefix="DATA_LOGGER"
   else
-    print_error "Unknown package, application, workflow, operator, or data logger: $1"
+    print_error "Unknown package, application, workflow, or operator: $1"
     echo "You can run ./run list for a full list of options."
     exit 1
   fi
@@ -1055,7 +1045,7 @@ list_desc() {
   echo -e "
   ${BOLD}Display the list of Holohub targets.${NOCOLOR}
 
-  Includes workflows, applications, operators, packages, data loggers.
+  Includes workflows, applications, operators, packages.
   "
 }
 
@@ -1097,10 +1087,6 @@ list_operators() {
   list_metadata_json_dir ${SCRIPT_DIR}/operators
 }
 
-list_data_loggers() {
-  list_metadata_json_dir ${SCRIPT_DIR}/data_loggers
-}
-
 list_packages() {
   list_cmake_dir_options add_holohub_package
 }
@@ -1118,10 +1104,6 @@ list() {
   echo -e "${BOLD}== OPERATORS ====================${NOCOLOR}"
   echo
   list_operators
-  echo
-  echo -e "${BOLD}== DATA LOGGERS ====================${NOCOLOR}"
-  echo
-  list_data_loggers
   echo
   echo -e "${BOLD}== PACKAGES =====================${NOCOLOR}"
   echo
@@ -1221,16 +1203,15 @@ print_usage() {
     echo -e "${BOLD}USAGE: $0 [command] [arguments]...${NOCOLOR}"
     echo
     echo -e "${CYAN}Global Arguments${NOCOLOR}"
-    echo "  --help, -h                                   : Print help messages for [command]"
-    echo "  --dryrun                                     : Print commands to screen without running"
+    echo "  --help, -h                            : Print help messages for [command]"
+    echo "  --dryrun                              : Print commands to screen without running"
     echo
     echo -e "${CYAN}Commands${NOCOLOR}"
-    echo "  setup                                        : Install HoloHub main required packages"
-    echo "  clear_cache                                  : Clear cache folders"
-    echo "  list                                         : List all the available build targets"
-    echo "  build <package|application|operator|logger>  : Build a specific package, application, operator, "
-    echo "                                                 or data_logger"
-    echo "  launch <application> <language>              : Run the application"
+    echo "  setup                                 : Install HoloHub main required packages"
+    echo "  clear_cache                           : Clear cache folders"
+    echo "  list                                  : List all the available build targets"
+    echo "  build <package|application|operator>  : Build a specific package, application, or operator"
+    echo "  launch <application> <language>       : Run the application"
     echo
 }
 

--- a/run
+++ b/run
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -640,7 +640,7 @@ lint() {
 
 build_desc() {
   echo
-  echo -e "${BOLD}Build a Holohub operator, application, workflow, or package, in its isolated build directory.${NOCOLOR}"
+  echo -e "${BOLD}Build a Holohub operator, application, data logger, workflow, or package, in its isolated build directory.${NOCOLOR}"
   echo
   echo -e "${CYAN}USAGE:${NOCOLOR}"
   echo
@@ -653,6 +653,9 @@ build_desc() {
   echo "   --with <list of operators>           : Optional operators that should be built"
   echo "                                          If multiple operators are to be built, list must be"
   echo "                                          in quotes with operators separated by semicolons (;)"
+  echo "   --with_logger <list of data loggers> : Optional data loggers that should be built"
+  echo "                                          If multiple data loggers are to be built, list must be"
+  echo "                                          in quotes with data loggers separated by semicolons (;)"
   echo "   --type <debug | release | rel-debug> : Specify the type of build"
   echo "                                          Default: release"
   echo "                                          Associated environment variable: CMAKE_BUILD_TYPE"
@@ -746,6 +749,11 @@ build() {
          configure_args="${configure_args} -D HOLOHUB_BUILD_OPERATORS=\"${operators}\""
          echo "Building with operator(s) ${operators}"
          skipnext=1
+      elif [ "$arg" = "--with_logger" ]; then
+         data_loggers="${ARGS[i+1]}"
+         configure_args="${configure_args} -D HOLOHUB_BUILD_DATA_LOGGERS=\"${data_loggers}\""
+         echo "Building with data_loggers(s) ${data_loggers}"
+         skipnext=1
       elif [ "$arg" = "--benchmark" ]; then
           benchmark=true
           configure_args="${configure_args} -D CMAKE_CXX_FLAGS=-I$PWD/benchmarks/holoscan_flow_benchmarking"
@@ -778,9 +786,9 @@ build() {
       fi
   done
 
-  # Package, application or operator to build
+  # Package, application, operator or data logger to build
   if [ "$1" == "" ]; then
-    print_error "Please specify which package, application, or operator to build."
+    print_error "Please specify which package, application, operator or data logger to build."
     echo "You can run ./run list for a full list of options."
     exit 1
   fi
@@ -798,8 +806,10 @@ build() {
     is_app=true
   elif list_operators | awk '{print $1}' | grep -Fxq "$project"; then
     opt_prefix="OP"
+  elif list_data_loggers | awk '{print $1}' | grep -Fxq "$project"; then
+    opt_prefix="DATA_LOGGER"
   else
-    print_error "Unknown package, application, workflow, or operator: $1"
+    print_error "Unknown package, application, workflow, operator, or data logger: $1"
     echo "You can run ./run list for a full list of options."
     exit 1
   fi
@@ -1045,7 +1055,7 @@ list_desc() {
   echo -e "
   ${BOLD}Display the list of Holohub targets.${NOCOLOR}
 
-  Includes workflows, applications, operators, packages.
+  Includes workflows, applications, operators, packages, data loggers.
   "
 }
 
@@ -1087,6 +1097,10 @@ list_operators() {
   list_metadata_json_dir ${SCRIPT_DIR}/operators
 }
 
+list_data_loggers() {
+  list_metadata_json_dir ${SCRIPT_DIR}/data_loggers
+}
+
 list_packages() {
   list_cmake_dir_options add_holohub_package
 }
@@ -1104,6 +1118,10 @@ list() {
   echo -e "${BOLD}== OPERATORS ====================${NOCOLOR}"
   echo
   list_operators
+  echo
+  echo -e "${BOLD}== DATA LOGGERS ====================${NOCOLOR}"
+  echo
+  list_data_loggers
   echo
   echo -e "${BOLD}== PACKAGES =====================${NOCOLOR}"
   echo
@@ -1203,15 +1221,16 @@ print_usage() {
     echo -e "${BOLD}USAGE: $0 [command] [arguments]...${NOCOLOR}"
     echo
     echo -e "${CYAN}Global Arguments${NOCOLOR}"
-    echo "  --help, -h                            : Print help messages for [command]"
-    echo "  --dryrun                              : Print commands to screen without running"
+    echo "  --help, -h                                   : Print help messages for [command]"
+    echo "  --dryrun                                     : Print commands to screen without running"
     echo
     echo -e "${CYAN}Commands${NOCOLOR}"
-    echo "  setup                                 : Install HoloHub main required packages"
-    echo "  clear_cache                           : Clear cache folders"
-    echo "  list                                  : List all the available build targets"
-    echo "  build <package|application|operator>  : Build a specific package, application, or operator"
-    echo "  launch <application> <language>       : Run the application"
+    echo "  setup                                        : Install HoloHub main required packages"
+    echo "  clear_cache                                  : Clear cache folders"
+    echo "  list                                         : List all the available build targets"
+    echo "  build <package|application|operator|logger>  : Build a specific package, application, operator, "
+    echo "                                                 or data_logger"
+    echo "  launch <application> <language>              : Run the application"
     echo
 }
 


### PR DESCRIPTION
The goal of this MR is to allow Holohub to support packaging custom implementations of the `holoscan::DataLogger` interface (new in Holoscan SDK v3.4: [Data Logging Docs](https://docs.nvidia.com/holoscan/sdk-user-guide/holoscan_data_logging.html)) in that same way that Operators are currently supported.

The build and CMake changes here are mostly a 1:1 copy of the logic currently used for operators so that each subfolder within the "data_loggers" folder gets built as a separate shared library. There are a few minor differences / simplifications:
- The OPTIONAL marker currently supported for operators is not supported for data loggers
- We also do not need to support GXF Extensions as dependencies for data loggers
- When writing loggers, the namespace `holoscan::data_loggers` should be used instead of `holoscan::ops`
- The CMake targets are prefixed with `holoscan::data_loggers` instead of `holoscan::ops` (e.g. `holoscan::data_loggers::message_logger`).

The example `MessageLogger` class bundled here is not intended as a fully featured logger. It is mainly just to demonstrate the required folder structure and CMake syntax to be used. We can potentially remove it in the future once we have some other example logger available on Holoscan.

I originally started this using the `dev_container` and `run` scripts, but also updated the new CLI accordingly.

I updated one existing application (`cvcuda_basic`) to use this logger (from both C++ and Python). This shows how DATA_LOGGERS should be listed in the `applications/CMakeLists.txt` for the application and how the `holoscan::data_loggers::message_logger` link target should be in the `CMakeLists.txt` for the C++ version of the application.

The following would build and run the application:
```bash
./holohub run cvcuda_basic
```

and due to the added `MessageLogger`, each frame will result on output like the following at the console
```cpp
[info] [message_logger.cpp:82] [timestamp: 1751549449056957] log_tensormap_data called for output port with unique id replayer.output
[info] [message_logger.cpp:82] [timestamp: 1751549449057201] log_tensormap_data called for input port with unique id image_processing.input_tensor
[info] [message_logger.cpp:82] [timestamp: 1751549449058125] log_tensormap_data called for output port with unique id image_processing.output_tensor
[info] [message_logger.cpp:82] [timestamp: 1751549449058314] log_tensormap_data called for input port with unique id holoviz.receivers:0
```

To see actual data contents one could use the `holoscan::data_loggers::BasicConsoleLogger` that ships with the core SDK instead, but I think it is useful to have a more minimal example fully contained within Holohub as a test case for the build script changes that were made.
