### PR TITLE
CLI feature preset modes: ./holohub run <app> [mode]

### DIFF
--- a/applications/holochat/README.md
+++ b/applications/holochat/README.md
@@ -37,7 +37,7 @@ HoloChat is an AI-driven chatbot, built on top of a **locally hosted Code-Llama 
 ### TLDR; 🥱
 To run locally:
 ```bash
-./holohub run holochat --run-args=--local
+./holohub run holochat standalone
 ```
 To run using the NVIDIA NIM API:
 ```bash
@@ -47,7 +47,7 @@ echo "NVIDIA_API_KEY=<api_key_here>" > ./applications/holochat/.env
 ```
 To run as an MCP server:
 ```bash
-./holohub run holochat --run-args=--mcp
+./holohub run holochat mcp
 ```
 See [MCP_MODE.md](MCP_MODE.md) for more details on using MCP mode.
 
@@ -74,7 +74,7 @@ ssh <user_name>@<IP address> -L 7860:localhost:7860 -L 8080:localhost:8080 -L 80
 ### Running w/ Local LLM 💻
 **To build and start the app:**
 ```bash
-./holohub run holochat --run-args=--local
+./holohub run holochat standalone
 ```
 Once the LLM is loaded on the GPU and the Gradio app is running, HoloChat should be available at http://127.0.0.1:7860/.
 ### Running w/ NIM API ☁️

--- a/applications/holochat/metadata.json
+++ b/applications/holochat/metadata.json
@@ -22,20 +22,58 @@
 			"tags": ["Natural Language and Conversational AI", "RAG", "Vector Database", "LLM"],
 			"ranking": 4,
 			"requirements": {
-				"OSS": [
-					{
-						"name": "Llama.cpp",
-						"version": "cf9b08485c4c2d4d945c6e74fe20f273a38b6104"
-					},
-					{
-						"name": "LangChain",
-						"version": "0.1.11"
-					}
-			   ]
+				"vector_database": {
+					"type": "data",
+					"name": "Vector Database",
+					"description": "ChromaDB vector database for RAG document storage and retrieval, will be created if not present"
+				},
+				"llm_model": {
+					"type": "model",
+					"name": "Local LLM Model",
+					"description": "Local language model files for offline inference"
+				},
+				"gpu": {
+					"type": "hardware",
+					"name": "gpu",
+					"description": "NVIDIA GPU required for local LLM inference"
+				},
+				"openai_api": {
+					"type": "software",
+					"name": "OpenAI API or similar LLM service",
+					"description": "External API service for cloud-based LLM inference"
+				},
+				"NIM": {
+					"type": "software",
+					"name": "NVIDIA API",
+					"description": "NVIDIA API for cloud-based LLM inference"
+				}
 			},
-			"run": {
-				"command": "<holohub_app_source>/holochat.sh",
-				"workdir": "holohub_app_source"
+			"default_mode": "cloud",
+			"modes": {
+				"cloud": {
+					"description": "Remote LLM mode using NVIDIA NIM API with Llama-3-70b-Instruct for cloud-based inference and production deployment",
+					"requirements": ["vector_database", "NIM"],
+					"run": {
+						"command": "<holohub_app_source>/holochat.sh",
+						"workdir": "holohub_app_source"
+					}
+				},
+				"standalone": {
+					"description": "Local LLM mode using Phind-CodeLlama-34B-v2 with Llama.cpp for offline usage, privacy-sensitive deployments, and development",
+					"requirements": ["gpu", "vector_database", "llm_model"],
+					"run": {
+						"command": "<holohub_app_source>/holochat.sh --local",
+						"workdir": "holohub_app_source"
+					}
+				},
+				"mcp": {
+					"description": "Model Context Protocol server mode that provides Holoscan documentation and code context to upstream",
+					"requirements": ["vector_database"],
+					"run": {
+						"command": "<holohub_app_source>/holochat.sh --mcp",
+						"workdir": "holohub_app_source"
+					}
+				}
 			}
 		}
 	}

--- a/applications/isaac_holoscan_bridge/README.md
+++ b/applications/isaac_holoscan_bridge/README.md
@@ -45,15 +45,7 @@ flowchart LR
 ## Run Instructions
 
 ```bash
-./holohub run --docker-opts="-u root -e ACCEPT_EULA=Y -e PRIVACY_CONSENT=Y \
--v ${HOME}/docker/isaac-sim/cache/kit:/isaac-sim/kit/cache:rw \
--v ${HOME}/docker/isaac-sim/cache/ov:/root/.cache/ov:rw \
--v ${HOME}/docker/isaac-sim/cache/pip:/root/.cache/pip:rw \
--v ${HOME}/docker/isaac-sim/cache/glcache:/root/.cache/nvidia/GLCache:rw \
--v ${HOME}/docker/isaac-sim/cache/computecache:/root/.nv/ComputeCache:rw \
--v ${HOME}/docker/isaac-sim/logs:/root/.nvidia-omniverse/logs:rw \
--v ${HOME}/docker/isaac-sim/data:/root/.local/share/ov/data:rw \
--v ${HOME}/docker/isaac-sim/documents:/root/Documents:rw" isaac_holoscan_bridge
+./holohub run isaac_holoscan_bridge
 ```
 
 To keep Isaac Sim configuration and data persistent when running in a container, various directories are mounted into the container.

--- a/applications/isaac_holoscan_bridge/metadata.json
+++ b/applications/isaac_holoscan_bridge/metadata.json
@@ -29,10 +29,40 @@
 			"Robotics"
 		],
 		"ranking": 3,
-		"requirements": {},
-		"run": {
-			"command": "python3 <holohub_app_source>/app.py",
-			"workdir": "holohub_bin"
+		"requirements": {
+			"gpu": {
+				"type": "hardware",
+				"name": "gpu",
+				"description": "NVIDIA GPU with at least 8GB memory required for Isaac Sim"
+			},
+			"isaac_sim": {
+				"type": "software",
+				"name": "Isaac Sim",
+				"description": "NVIDIA Isaac Sim simulation platform"
+			}
+		},
+		"modes": {
+			"interactive": {
+				"description": "Full Isaac Sim environment with interactive GUI and visualization for development, interactive debugging, and visual monitoring",
+				"requirements": ["gpu", "isaac_sim"],
+				"run": {
+					"command": "python3 <holohub_app_source>/app.py",
+					"workdir": "holohub_bin",
+					"docker_run_args": [
+						"-u root",
+						"-e ACCEPT_EULA=Y",
+						"-e PRIVACY_CONSENT=Y",
+						"-v ${HOME}/docker/isaac-sim/cache/kit:/isaac-sim/kit/cache:rw",
+						"-v ${HOME}/docker/isaac-sim/cache/ov:/root/.cache/ov:rw",
+						"-v ${HOME}/docker/isaac-sim/cache/pip:/root/.cache/pip:rw",
+						"-v ${HOME}/docker/isaac-sim/cache/glcache:/root/.cache/nvidia/GLCache:rw",
+						"-v ${HOME}/docker/isaac-sim/cache/computecache:/root/.nv/ComputeCache:rw",
+						"-v ${HOME}/docker/isaac-sim/logs:/root/.nvidia-omniverse/logs:rw",
+						"-v ${HOME}/docker/isaac-sim/data:/root/.local/share/ov/data:rw",
+						"-v ${HOME}/docker/isaac-sim/documents:/root/Documents:rw"
+					]
+				}
+			}
 		}
 	}
 }

--- a/applications/metadata.schema.json
+++ b/applications/metadata.schema.json
@@ -13,7 +13,7 @@
           "$ref": "holohub/project/v1#/$defs/description"
         },
         "authors": {
-          "$refs": "holohub/project/v1#/$defs/authors"
+          "$ref": "holohub/project/v1#/$defs/authors"
         },
         "version": {
           "$ref": "holohub/project/v1#/$defs/version"
@@ -38,9 +38,6 @@
         },
         "dockerfile": {
           "type": "string"
-        },
-        "run": {
-          "$ref": "holohub/project/v1#/$defs/run_command"
         }
       },
       "required": [
@@ -53,6 +50,86 @@
         "holoscan_sdk",
         "ranking",
         "requirements"
+      ],
+      "oneOf": [
+        {
+          "properties": {
+            "run": {
+              "$ref": "holohub/project/v1#/$defs/run_command"
+            }
+          },
+          "required": ["run"],
+          "not": {
+            "properties": {
+              "modes": {
+                "type": "object"
+              }
+            },
+            "required": ["modes"]
+          }
+        },
+        {
+          "properties": {
+            "modes": {
+              "$ref": "holohub/project/v1#/$defs/modes"
+            },
+            "default_mode": {
+              "type": "string",
+              "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+              "description": "Name of the default mode to use when none is specified. Only needed when there are multiple modes."
+            }
+          },
+          "required": ["modes"],
+          "anyOf": [
+            {
+              "properties": {
+                "modes": {
+                  "type": "object",
+                  "maxProperties": 1
+                }
+              }
+            },
+            {
+              "properties": {
+                "modes": {
+                  "type": "object",
+                  "minProperties": 2
+                }
+              },
+              "required": ["default_mode"]
+            }
+          ],
+          "not": {
+            "properties": {
+              "run": {
+                "type": "object"
+              }
+            },
+            "required": ["run"]
+          }
+        },
+        {
+          "not": {
+            "anyOf": [
+              {
+                "properties": {
+                  "run": {
+                    "type": "object"
+                  }
+                },
+                "required": ["run"]
+              },
+              {
+                "properties": {
+                  "modes": {
+                    "type": "object"
+                  }
+                },
+                "required": ["modes"]
+              }
+            ]
+          }
+        }
       ]
     },
     "$ref": "holohub/operator/v1#/properties/operator",

--- a/applications/template/{{cookiecutter.project_slug}}/metadata.json
+++ b/applications/template/{{cookiecutter.project_slug}}/metadata.json
@@ -22,14 +22,26 @@
 		"platforms": {% if cookiecutter.platforms %}{{ cookiecutter.platforms }}{% else %}["x86_64", "aarch64"]{% endif %},
 		"tags": {% if cookiecutter.tags %}{{ cookiecutter.tags }}{% else %}["keyword1", "keyword2", "keyword3"]{% endif %},
 		"ranking": 1,
-		"requirements": {},
-		"run": {
-			"command": {% if cookiecutter.language == "python" %}
-				"python3 <holohub_app_source>/src/main.py"
-			{% else %}
-				"<holohub_app_bin>/{{ cookiecutter.project_slug }}"
-			{% endif %},
-			"workdir": "holohub_bin"
+		"requirements": {
+			"example_requirement_1": {
+				"type": "data",
+				"name": "Example Data",
+				"description": "Example data dependency - remove or replace with actual requirements"
+			}
+		},
+		"modes": {
+			"standard": {
+				"description": "Standard mode for {{ cookiecutter.project_name }} - development, testing, and basic usage",
+				"requirements": [],
+				"run": {
+					"command":{% if cookiecutter.language == "python" %}
+            "python3 <holohub_app_source>/src/main.py"
+          {% else %}
+            "<holohub_app_bin>/{{ cookiecutter.project_slug }}"
+          {% endif %},
+					"workdir": "holohub_bin"
+				}
+			}
 		}
 	}
 }

--- a/gxf_extensions/metadata.schema.json
+++ b/gxf_extensions/metadata.schema.json
@@ -13,7 +13,7 @@
           "$ref": "holohub/project/v1#/$defs/description"
         },
         "authors": {
-          "$refs": "holohub/project/v1#/$defs/authors"
+          "$ref": "holohub/project/v1#/$defs/authors"
         },
         "version": {
           "$ref": "holohub/project/v1#/$defs/version"

--- a/operators/metadata.schema.json
+++ b/operators/metadata.schema.json
@@ -13,7 +13,7 @@
           "$ref": "holohub/project/v1#/$defs/description"
         },
         "authors": {
-          "$refs": "holohub/project/v1#/$defs/authors"
+          "$ref": "holohub/project/v1#/$defs/authors"
         },
         "version": {
           "$ref": "holohub/project/v1#/$defs/version"

--- a/tutorials/high_performance_networking/metadata.json
+++ b/tutorials/high_performance_networking/metadata.json
@@ -26,8 +26,7 @@
 		},
 		"platforms": [
 			"x86_64",
-			"SBSA",
-			"IGX Orin (dGPU)"
+			"aarch64"
 		],
 		"tags": ["DPDK", "RDMA", "GPUNetIO", "GPUDirect", "Networking and Distributed Computing", "HPC"],
 		"ranking": 1,

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -166,6 +166,7 @@ class HoloHubCLI:
         )
         self.subparsers["build"] = build
         build.add_argument("project", help="Project to build")
+        build.add_argument("mode", nargs="?", help="Mode to build (optional)")
         build.add_argument(
             "--local", action="store_true", help="Build locally instead of in container"
         )
@@ -216,6 +217,7 @@ class HoloHubCLI:
         )
         self.subparsers["run"] = run
         run.add_argument("project", help="Project to run")
+        run.add_argument("mode", nargs="?", help="Mode to run (optional)")
         run.add_argument("--local", action="store_true", help="Run locally instead of in container")
         run.add_argument("--verbose", action="store_true", help="Print extra output")
         run.add_argument(
@@ -234,6 +236,7 @@ class HoloHubCLI:
             help="Additional arguments to pass to the application executable, "
             "example: --run-args=--flag or --run-args '-c config/file'",
         )
+
         run.add_argument(
             "--build-with",
             dest="with_operators",
@@ -265,6 +268,15 @@ class HoloHubCLI:
         list_cmd = subparsers.add_parser("list", help="List all available targets")
         self.subparsers["list"] = list_cmd
         list_cmd.set_defaults(func=self.handle_list)
+
+        # modes command
+        modes = subparsers.add_parser("modes", help="List available modes for an application")
+        self.subparsers["modes"] = modes
+        modes.add_argument("project", help="Project to list modes for")
+        modes.add_argument(
+            "--language", choices=["cpp", "python"], help="Specify language implementation"
+        )
+        modes.set_defaults(func=self.handle_modes)
 
         # autocompletion_list command (for bash completion)
         autocomp_cmd = subparsers.add_parser(
@@ -311,6 +323,7 @@ class HoloHubCLI:
         )
         self.subparsers["install"] = install
         install.add_argument("project", help="Project to install")
+        install.add_argument("mode", nargs="?", help="Mode to install (optional)")
         install.add_argument(
             "--local", action="store_true", help="Install locally instead of in container"
         )
@@ -457,6 +470,125 @@ class HoloHubCLI:
         holohub_cli_util.fatal(msg)
         return None
 
+    def resolve_mode(self, project_data: dict, requested_mode: Optional[str] = None) -> tuple:
+        """
+        Resolve mode from metadata and validate
+        Returns: (mode_name, mode_config) or (None, None) for legacy behavior
+        """
+        modes = project_data.get("metadata", {}).get("modes", {})
+        if not modes:
+            return None, None  # No modes defined - should use legacy behavior
+
+        if requested_mode is None:
+            # Validate that multiple modes have a default_mode specified
+            application_metadata = project_data.get("metadata", {})
+            if len(modes) > 1 and "default_mode" not in application_metadata:
+                available = ", ".join(modes.keys())
+                holohub_cli_util.fatal(
+                    f"Multiple modes found ({available}) but no 'default_mode' specified. "
+                    f"Please add a 'default_mode' field to specify which mode to use by default."
+                )
+
+            if "default_mode" in application_metadata:
+                requested_mode = application_metadata["default_mode"]
+                # Validate that default_mode references an existing mode
+                if requested_mode not in modes:
+                    available = ", ".join(modes.keys())
+                    holohub_cli_util.fatal(
+                        f"Invalid default_mode '{requested_mode}' in metadata among {available}"
+                    )
+            else:
+                requested_mode = list(modes.keys())[0]
+        if requested_mode not in modes:
+            available = ", ".join(modes.keys())
+            holohub_cli_util.fatal(
+                f"Mode '{requested_mode}' not found. Available modes: {available}"
+            )
+        return requested_mode, modes[requested_mode]
+
+    def validate_mode(
+        self, args: argparse.Namespace, mode_name: Optional[str], mode_config: dict
+    ) -> None:
+        """Validate that when mode is specified, no conflicting CLI parameters are provided"""
+        if not mode_name or not mode_config:
+            return  # No mode specified, allow CLI parameters
+        conflicting_params = []
+        # Check build-related parameters
+        if "build" in mode_config:
+            build_config = mode_config["build"]
+            if "depends" in build_config and getattr(args, "with_operators", None):
+                conflicting_params.append("--build-with")
+            if "docker_build_args" in build_config and getattr(args, "build_args", None):
+                conflicting_params.append("--build-args")
+            if "cmake_options" in build_config and getattr(args, "configure_args", None):
+                conflicting_params.append("--configure-args")
+        # Check run-related parameters
+        if "run" in mode_config:
+            run_config = mode_config["run"]
+            if "docker_run_args" in run_config and getattr(args, "docker_opts", None):
+                conflicting_params.append("--docker-opts")
+            if "command" in run_config and getattr(args, "run_args", None):
+                conflicting_params.append("--run-args")
+        if conflicting_params:
+            params_str = ", ".join(conflicting_params)
+            holohub_cli_util.fatal(
+                f"Cannot specify CLI parameters {params_str} when using mode '{mode_name}'. "
+                f"All configuration must be provided through the mode definition.\n"
+                f"See https://github.com/nvidia-holoscan/holohub/blob/main/utilities/cli/README.md"
+            )
+
+    def get_effective_build_config(self, args: argparse.Namespace, mode_config: dict) -> dict:
+        """Get effective build configuration combining CLI args and mode config without mutation"""
+        config = {
+            "with_operators": getattr(args, "with_operators", None),
+            "docker_opts": getattr(args, "docker_opts", ""),
+            "build_args": getattr(args, "build_args", ""),
+            "configure_args": getattr(args, "configure_args", None),
+        }
+        if not mode_config:
+            return config
+
+        # Apply build configuration
+        if "build" in mode_config:
+            build_config = mode_config["build"]
+            if "depends" in build_config:
+                mode_deps = [dep.strip() for dep in build_config["depends"] if dep.strip()]
+                config["with_operators"] = ";".join(mode_deps) if mode_deps else ""
+            if "docker_build_args" in build_config:
+                config["build_args"] = holohub_cli_util.normalize_args_str(
+                    build_config["docker_build_args"]
+                )
+            if "cmake_options" in build_config:
+                config["configure_args"] = build_config["cmake_options"]
+
+        # Apply run.docker_run_args for build container (Docker run arguments)
+        if "run" in mode_config and "docker_run_args" in mode_config["run"]:
+            config["docker_opts"] = holohub_cli_util.normalize_args_str(
+                mode_config["run"]["docker_run_args"]
+            )
+
+        return config
+
+    def get_effective_run_config(self, args: argparse.Namespace, mode_config: dict) -> dict:
+        """Get effective run configuration combining CLI args and mode config without mutation"""
+        config = {
+            "run_args": getattr(args, "run_args", "") or "",
+            "docker_opts": getattr(args, "docker_opts", ""),
+        }
+
+        if mode_config and "run" in mode_config:
+            run_config = mode_config["run"]
+            # Replace with mode-specific values
+            if "command" in run_config:
+                config["command"] = run_config["command"]
+            if "workdir" in run_config:
+                config["workdir"] = run_config["workdir"]
+            if "docker_run_args" in run_config:
+                config["docker_opts"] = holohub_cli_util.normalize_args_str(
+                    run_config["docker_run_args"]
+                )
+        return config
+
     def _make_project_container(
         self, project_name: Optional[str] = None, language: Optional[str] = None
     ) -> HoloHubContainer:
@@ -501,7 +633,7 @@ class HoloHubCLI:
         trailing_args = getattr(args, "_trailing_args", [])
         docker_opts = args.docker_opts
         if trailing_args:  # additional commands requires a bash entrypoint
-            command = " ".join(trailing_args)
+            command = holohub_cli_util.normalize_args_str(trailing_args)
             docker_opts_extra, extra_args = holohub_cli_util.get_entrypoint_command_args(
                 args.img or container.image_name, command, docker_opts, dry_run=args.dryrun
             )
@@ -690,17 +822,29 @@ class HoloHubCLI:
         """Handle build command"""
         skip_docker_build, _ = holohub_cli_util.check_skip_builds(args)
 
+        # Handle mode-specific configuration
+        project_data = self.find_project(args.project, language=args.language)
+        mode_name, mode_config = self.resolve_mode(project_data, getattr(args, "mode", None))
+
+        self.validate_mode(args, mode_name, mode_config)
+
+        # Apply mode-specific build configuration
+        build_args = self.get_effective_build_config(args, mode_config)
+
+        if mode_config:
+            print(f"Building {args.project} in '{mode_name}' mode")
+
         if args.local or os.environ.get("HOLOHUB_BUILD_LOCAL"):
             self.build_project_locally(
                 project_name=args.project,
                 language=args.language if hasattr(args, "language") else None,
                 build_type=args.build_type,
-                with_operators=args.with_operators,
+                with_operators=build_args.get("with_operators"),
                 dryrun=args.dryrun,
                 pkg_generator=getattr(args, "pkg_generator", "DEB"),
                 parallel=getattr(args, "parallel", None),
                 benchmark=getattr(args, "benchmark", False),
-                configure_args=getattr(args, "configure_args", None),
+                configure_args=build_args.get("configure_args"),
             )
         else:
             # Build in container
@@ -716,11 +860,14 @@ class HoloHubCLI:
                     base_img=args.base_img,
                     img=args.img,
                     no_cache=args.no_cache,
-                    build_args=args.build_args,
+                    build_args=build_args.get("build_args"),
                 )
 
             # Build command with all necessary arguments
-            build_cmd = f"{self.script_name} build {args.project} --local"
+            build_cmd = f"{self.script_name} build {args.project}"
+            if mode_name:
+                build_cmd += f" {mode_name}"
+            build_cmd += " --local"
             if args.build_type:
                 build_cmd += f" --build-type {args.build_type}"
             if args.with_operators:
@@ -740,7 +887,7 @@ class HoloHubCLI:
                     build_cmd += f" --configure-args={shlex.quote(configure_arg)}"
 
             img = getattr(args, "img", None) or container.image_name
-            docker_opts = getattr(args, "docker_opts", "")
+            docker_opts = build_args.get("docker_opts", "")
             docker_opts_extra, extra_args = holohub_cli_util.get_entrypoint_command_args(
                 img, build_cmd, docker_opts, dry_run=args.dryrun
             )
@@ -767,12 +914,26 @@ class HoloHubCLI:
         skip_docker_build, skip_local_build = holohub_cli_util.check_skip_builds(args)
         is_local_mode = args.local or os.environ.get("HOLOHUB_BUILD_LOCAL")
 
+        # Handle mode-specific configuration
+        project_data = self.find_project(args.project, language=args.language)
+        mode_name, mode_config = self.resolve_mode(project_data, getattr(args, "mode", None))
+
+        self.validate_mode(args, mode_name, mode_config)
+
+        # Apply mode-specific build configuration for build process
+        build_args = self.get_effective_build_config(args, mode_config)
+
+        # Apply mode-specific run configuration
+        run_args = self.get_effective_run_config(args, mode_config)
+
+        if mode_config:
+            print(f"Running {args.project} in '{mode_name}' mode")
+
         if is_local_mode:
             if args.docker_opts:
                 holohub_cli_util.fatal(
                     "Container arguments were provided with `--docker-opts` but a non-containerized build was requested."
                 )
-
             if skip_local_build:
                 # Skip building, but still need project metadata and build directory
                 project_data = self.find_project(
@@ -791,22 +952,25 @@ class HoloHubCLI:
                     project_name=args.project,
                     language=args.language if hasattr(args, "language") else None,
                     build_type=args.build_type or "Release",  # Default to Release for run
-                    with_operators=args.with_operators,
+                    with_operators=build_args.get("with_operators"),
                     dryrun=args.dryrun,
                     pkg_generator=getattr(args, "pkg_generator", "DEB"),
                     parallel=getattr(args, "parallel", None),
-                    configure_args=getattr(args, "configure_args", None),
+                    configure_args=build_args.get("configure_args"),
                 )
 
             language = holohub_cli_util.normalize_language(
                 project_data.get("metadata", {}).get("language", None)
             )
 
-            run_config = project_data.get("metadata", {}).get("run", {})
-            if not run_config:
-                holohub_cli_util.fatal(
-                    f"Project '{args.project}' does not have a run configuration"
-                )
+            if mode_config and "run" in mode_config:
+                run_config = mode_config["run"]  # Use mode-specific run configuration
+            else:  # Fall back to legacy run configuration
+                run_config = project_data.get("metadata", {}).get("run", {})
+                if not run_config:
+                    holohub_cli_util.fatal(
+                        f"Project '{args.project}' does not have a run configuration"
+                    )
 
             path_mapping = holohub_cli_util.build_holohub_path_mapping(
                 holohub_root=HoloHubCLI.HOLOHUB_ROOT,
@@ -826,8 +990,10 @@ class HoloHubCLI:
             # Process command template using the path mapping
             cmd = holohub_cli_util.replace_placeholders(run_config["command"], path_mapping)
 
-            if hasattr(args, "run_args") and args.run_args:
-                cmd_args = shlex.split(args.run_args)
+            # Use effective run args (which may come from mode or CLI)
+            effective_run_args = run_args.get("run_args")
+            if effective_run_args:
+                cmd_args = shlex.split(effective_run_args)
                 if isinstance(cmd, str):  # Ensure cmd is a list of arguments
                     cmd = shlex.split(cmd)
                 cmd.extend(cmd_args)
@@ -921,13 +1087,16 @@ class HoloHubCLI:
                     base_img=args.base_img,
                     img=args.img,
                     no_cache=args.no_cache,
-                    build_args=args.build_args,
+                    build_args=build_args.get("build_args"),
                 )
             language = holohub_cli_util.normalize_language(
                 container.project_metadata.get("metadata", {}).get("language", None)
             )
 
-            run_cmd = f"{self.script_name} run {args.project} --language {language} --local"
+            run_cmd = f"{self.script_name} run {args.project}"
+            if mode_name:
+                run_cmd += f" {mode_name}"
+            run_cmd += f" --language {language} --local"
             if args.verbose:
                 run_cmd += " --verbose"
             if args.build_type:
@@ -949,7 +1118,7 @@ class HoloHubCLI:
                     run_cmd += f" --configure-args={shlex.quote(configure_arg)}"
 
             img = getattr(args, "img", None) or container.image_name
-            docker_opts = getattr(args, "docker_opts", "")
+            docker_opts = build_args.get("docker_opts", "")
             docker_opts_extra, extra_args = holohub_cli_util.get_entrypoint_command_args(
                 img, run_cmd, docker_opts, dry_run=args.dryrun
             )
@@ -996,6 +1165,27 @@ class HoloHubCLI:
                 print(f'{project["project_name"]} {language}')
 
         print(f"\n{Color.white('=================================', bold=True)}\n")
+
+    def handle_modes(self, args: argparse.Namespace) -> None:
+        """Handle modes command"""
+        project_data = self.find_project(args.project, language=args.language)
+        modes = project_data.get("metadata", {}).get("modes", {})
+
+        if not modes:
+            print(f"No modes defined for {args.project}")
+            return
+
+        print(f"\n{Color.white(f'Available modes for {args.project}:', bold=True)}\n")
+
+        for mode_name, mode_config in modes.items():
+            description = mode_config.get("description", "No description")
+            print(f"  {Color.green(mode_name, bold=True)} - {description}")
+            requirements = mode_config.get("requirements", [])
+            if requirements:
+                req_list = ", ".join(requirements)
+                print(f"    Requirements: {req_list}")
+
+            print()  # Empty line between modes
 
     def handle_autocompletion_list(self, args: argparse.Namespace) -> None:
         """Handle autocompletion_list command - output project names and commands for bash completion"""
@@ -1339,16 +1529,26 @@ class HoloHubCLI:
     def handle_install(self, args: argparse.Namespace) -> None:
         """Handle install command"""
         skip_docker_build, _ = holohub_cli_util.check_skip_builds(args)
+
+        # Handle mode-specific configuration (if project has modes)
+        project_data = self.find_project(args.project, language=getattr(args, "language", None))
+        mode_name, mode_config = self.resolve_mode(project_data, getattr(args, "mode", None))
+        self.validate_mode(args, mode_name, mode_config)
+        build_args = self.get_effective_build_config(args, mode_config)
+
+        if mode_config:
+            print(f"Installing {args.project} in '{mode_name}' mode")
+
         if args.local or os.environ.get("HOLOHUB_BUILD_LOCAL"):
             # Build and install locally
             build_dir, project_data = self.build_project_locally(
                 project_name=args.project,
                 language=getattr(args, "language", None),
                 build_type=args.build_type,
-                with_operators=getattr(args, "with_operators", None),
+                with_operators=build_args.get("with_operators"),
                 dryrun=args.dryrun,
                 parallel=getattr(args, "parallel", None),
-                configure_args=getattr(args, "configure_args", None),
+                configure_args=build_args.get("configure_args"),
             )
             # Install the project
             holohub_cli_util.run_command(
@@ -1369,7 +1569,7 @@ class HoloHubCLI:
                     base_img=args.base_img,
                     img=args.img,
                     no_cache=args.no_cache,
-                    build_args=args.build_args,
+                    build_args=build_args.get("build_args"),
                 )
 
             # Install command with all necessary arguments
@@ -1389,7 +1589,7 @@ class HoloHubCLI:
                     install_cmd += f" --configure-args={shlex.quote(configure_arg)}"
 
             img = getattr(args, "img", None) or container.image_name
-            docker_opts = getattr(args, "docker_opts", "")
+            docker_opts = build_args.get("docker_opts", "")
             docker_opts_extra, extra_args = holohub_cli_util.get_entrypoint_command_args(
                 img, install_cmd, docker_opts, dry_run=args.dryrun
             )

--- a/utilities/cli/tests/CMakeLists.txt
+++ b/utilities/cli/tests/CMakeLists.txt
@@ -200,3 +200,25 @@ add_test(
 set_property(TEST test_cli_ambiguous_dash_prefixed_arguments PROPERTY
     PASS_REGULAR_EXPRESSION "ambiguous dash-prefixed arguments"
 )
+
+# test validate_mode conflict detection
+add_test(
+    NAME test_holohub_validate_mode_build_with_conflicts
+    COMMAND ${CMAKE_SOURCE_DIR}/holohub run holochat mcp --run-args "conflicting_operator" --dryrun
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_property(TEST test_holohub_validate_mode_build_with_conflicts PROPERTY
+    PASS_REGULAR_EXPRESSION "Cannot specify CLI parameters.*--run-args.*when using mode.*mcp"
+    WILL_FAIL TRUE
+)
+
+# test validate_mode multiple conflicts detection
+add_test(
+    NAME test_holohub_validate_mode_build_with_and_run_args_conflicts
+    COMMAND ${CMAKE_SOURCE_DIR}/holohub run holochat mcp --build-with "operator1" --run-args="--verbose" --dryrun
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_property(TEST test_holohub_validate_mode_build_with_and_run_args_conflicts PROPERTY
+    PASS_REGULAR_EXPRESSION "Cannot specify CLI parameters.*--run-args.*when using mode.*mcp"
+    WILL_FAIL TRUE
+)

--- a/utilities/cli/tests/test_cli.py
+++ b/utilities/cli/tests/test_cli.py
@@ -799,6 +799,81 @@ exec {holohub_script} "$@"
         self.assertIn("vscode://vscode-remote/dev-container", printed_output)
         mock_mkdir.assert_not_called()
 
+    def test_modes_functionality(self):
+        """Test mode resolution and configuration application"""
+        project_data = {
+            "metadata": {
+                "modes": {
+                    "default": {
+                        "description": "Default mode",
+                        "requirements": ["camera"],
+                        "build": {"depends": ["op1", "op2"]},
+                        "run": {"command": "python3 app.py"},
+                    }
+                }
+            }
+        }
+
+        # Test mode resolution
+        mode_name, mode_config = self.cli.resolve_mode(project_data)
+        self.assertEqual(mode_name, "default")
+        self.assertEqual(mode_config["description"], "Default mode")
+
+        # Test build config application with mock args
+        from argparse import Namespace
+
+        mock_args = Namespace(with_operators="existing", docker_opts="", configure_args=None)
+        enhanced = self.cli.get_effective_build_config(mock_args, mode_config)
+        # Mode config should replace CLI args entirely
+        self.assertEqual(enhanced["with_operators"], "op1;op2")
+
+        # Test run config application with mock args
+        mock_args = Namespace(run_args="", docker_opts="--net host")
+        enhanced = self.cli.get_effective_run_config(mock_args, mode_config)
+        self.assertEqual(enhanced["run_args"], "")  # CLI run_args
+        # Note: run config doesn't have docker_run_args, so CLI docker_opts should be preserved
+        self.assertEqual(enhanced["docker_opts"], "--net host")
+
+        # Test run config with docker_run_args replacement
+        mode_config_with_docker = {
+            "run": {"command": "python3 app.py", "docker_run_args": ["--privileged", "--net=host"]}
+        }
+        enhanced = self.cli.get_effective_run_config(mock_args, mode_config_with_docker)
+        # Mode docker_run_args should replace CLI docker_opts
+        self.assertEqual(enhanced["docker_opts"], "--privileged --net=host")
+
+    @patch("utilities.cli.holohub.HoloHubCLI.find_project")
+    @patch("builtins.print")
+    def test_modes_command(self, mock_print, mock_find_project):
+        """Test modes command execution"""
+        mock_find_project.return_value = {
+            "metadata": {
+                "modes": {
+                    "default": {"description": "Default mode", "requirements": ["camera"]},
+                    "gpu": {"description": "GPU mode"},
+                }
+            }
+        }
+
+        args = self.cli.parser.parse_args("modes test_app".split())
+        args.func(args)
+
+        print_calls = [call[0][0] for call in mock_print.call_args_list if call[0]]
+        output = " ".join(print_calls)
+        self.assertIn("Available modes", output)
+        self.assertIn("default", output)
+        self.assertIn("gpu", output)
+
+    def test_mode_argument_parsing(self):
+        """Test mode argument parsing for build/run commands"""
+        # Test with mode
+        args = self.cli.parser.parse_args("build test_app custom --local".split())
+        self.assertEqual(args.mode, "custom")
+
+        # Test without mode
+        args = self.cli.parser.parse_args("build test_app --local".split())
+        self.assertIsNone(args.mode)
+
 
 class TestRunCommand(unittest.TestCase):
     """Test the run_command function with explicit shell parameter"""

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -1109,6 +1109,16 @@ def collect_env_info() -> None:
     collect_environment_variables()
 
 
+def normalize_args_str(args):
+    """Convert arguments to string format, handling both string and array inputs"""
+    if isinstance(args, str):
+        return os.path.expandvars(args)
+    elif isinstance(args, list):
+        expanded_args = [os.path.expandvars(arg) for arg in args]
+        return " ".join(expanded_args)
+    return ""
+
+
 def get_ubuntu_codename() -> str:
     """Get Ubuntu codename from os-release"""
     try:

--- a/utilities/metadata/project.schema.json
+++ b/utilities/metadata/project.schema.json
@@ -133,7 +133,7 @@
         },
         "required": {
           "type": "boolean",
-          "default": "true"
+          "default": true
         }
       },
       "required": [
@@ -165,10 +165,96 @@
       "type": "object",
       "properties": {
         "command": {
-          "type": "string"
+          "type": "string",
+          "description": "Complete command to execute including all arguments"
         },
         "workdir": {
+          "type": "string",
+          "description": "Working directory for command execution"
+        },
+        "docker_run_args": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Docker run arguments as a single string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "Docker arguments"
+              },
+              "description": "Array of Docker run arguments"
+            }
+          ],
+          "description": "Docker run arguments - can be a single string or array of strings, equivalent to CLI `--docker-opts`"
+        }
+      },
+      "description": "Run command configuration"
+    },
+
+    "build_configuration": {
+      "type": "object",
+      "properties": {
+        "depends": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "docker_build_args": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Docker build arguments as a single string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "Docker arguments"
+              },
+              "description": "Array of Docker build arguments"
+            }
+          ],
+          "description": "Docker build arguments - can be a single string or array of strings, equivalent to CLI `--build-args`"
+        },
+        "cmake_options": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Additional cmake options to pass to the local build step"
+        }
+      }
+    },
+    "mode_definition": {
+      "type": "object",
+      "properties": {
+        "description": {
           "type": "string"
+        },
+        "requirements": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of dependency IDs required for this mode"
+        },
+        "build": {
+          "$ref": "#/$defs/build_configuration"
+        },
+        "run": {
+          "$ref": "#/$defs/run_command"
+        }
+      },
+      "required": ["description", "run"]
+    },
+    "modes": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z_][a-zA-Z0-9_]*$": {
+          "$ref": "#/$defs/mode_definition"
         }
       }
     }


### PR DESCRIPTION
This is an initial implementation of preset mode:

## Scope
- a viable CLI implementation of mode presets `./holohub run|build|install <app> [mode]`
- As an example, the following apps' metadata are updated for various use cases:
    - `applications/holochat/metadata.json`
    - `applications/isaac_holoscan_bridge/metadata.json`
- a new schema specification for the 'modes'
- (existing metadata.json continue to work)

## New commands
```
  # List available modes for an app
  ./holohub modes <app>

  # Build with mode
  ./holohub build <app> [mode]

  # Run with mode  
  ./holohub run <app> [mode]

```

## Dev experience benefits

- simplify the current complex command of building and running the apps, for example
`
  ./holohub run --docker-opts="-u root -e ACCEPT_EULA=Y -e PRIVACY_CONSENT=Y -v ${HOME}/docker/isaac-sim/cache/kit:/isaac-sim/kit/cache:rw ..." isaac_holoscan_bridge
`
is simplified to `
  ./holohub run isaac_holoscan_bridge interactive
`
- better discoverability: ./holohub modes <app> shows what's available about an app
- readable and maintainable: configurations/recipes are standardized in metadata.json




## Example
```
$ ./holohub modes body_pose_estimation

Available modes for body_pose_estimation:

  default - Real-time pose estimation using V4L2 camera (/dev/video0) for live demos, real-time processing, and webcam testing
    Requirements: camera, model

  replayer - Offline pose estimation using pre-recorded video file for testing without camera, batch processing, and reproducible demos
    Requirements: model, video

  dds - Distributed pose estimation via DDS video streaming
    Requirements: dds, model

  custom_camera - Pose estimation with user-specified camera device for multiple cameras, non-standard devices, and custom hardware
    Requirements: camera, model
```

## TODOS
- ~discussion about the metadata format~
- ~cross check with more use cases~
- ~parameter overriding~
- ~unit tests after discussions~