### PR TITLE
Update Dockerfile to Avoid Unnecessary Warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,9 @@
 # Base image
 ############################################################
 
-ARG BASE_IMAGE
 ARG GPU_TYPE
-
+ARG BASE_SDK_VERSION
+ARG BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v${BASE_SDK_VERSION}-${GPU_TYPE}
 FROM ${BASE_IMAGE} AS base
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -83,12 +83,12 @@ RUN apt update \
 # For benchmarking
 RUN apt update \
     && apt install --no-install-recommends -y \
-    libcairo2-dev \
-    libgirepository1.0-dev \
-    gobject-introspection \
-    libgtk-3-dev \
-    libcanberra-gtk-module \
-    graphviz
+        libcairo2-dev \
+        libgirepository1.0-dev \
+        gobject-introspection \
+        libgtk-3-dev \
+        libcanberra-gtk-module \
+        graphviz
 
 RUN pip install meson
 

--- a/operators/advanced_network/Dockerfile
+++ b/operators/advanced_network/Dockerfile
@@ -16,7 +16,9 @@
 # limitations under the License.
 
 # Latest base image is overridden by the holohub tooling
-ARG BASE_IMAGE
+ARG GPU_TYPE
+ARG BASE_SDK_VERSION
+ARG BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v${BASE_SDK_VERSION}-${GPU_TYPE}
 
 # ==============================
 # Base layer

--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -373,6 +373,8 @@ class HoloHubContainer:
             "--build-arg",
             f"GPU_TYPE={gpu_type}",
             "--build-arg",
+            f"BASE_SDK_VERSION={base_sdk_version}",
+            "--build-arg",
             f"COMPUTE_CAPACITY={compute_capacity}",
             "--network=host",
         ]


### PR DESCRIPTION
Fixes #784 

This PR set a reasonable default value for BASE_IMAGE in Dockerfile to avoid the following warning:
```
InvalidDefaultArgInFrom: Default value for ARG ${BASE_IMAGE} results in empty or invalid base image name
```

It also makes it easier for the user to build the Dockerfile without the Holohub CLI by providing the SDK version and GPU type while maintaining a backward compatibility.