### PR TITLE
Update CMakeLists.txt:  FindThreads only works if either C or CXX lan…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 cmake_minimum_required(VERSION 3.20.1)
-project(Holohub NONE)
+project(Holohub CXX)
 
 # set CMAKE_MODULE_PATH
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,13 @@
 # limitations under the License.
 
 cmake_minimum_required(VERSION 3.20.1)
-project(Holohub CXX)
+# Check if we can find a CXX compiler before enabling it
+find_program(CXX_COMPILER_FOUND NAMES g++ clang++ c++)
+if(CXX_COMPILER_FOUND)
+  project(Holohub CXX)
+else()
+  project(Holohub NONE)
+endif()
 
 # set CMAKE_MODULE_PATH
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)


### PR DESCRIPTION
…guage is enabled

addressing errors:

```
-- Found CUDAToolkit: /usr/local/cuda/include (found version "12.8.93") 
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Found holoscan: /opt/nvidia/holoscan/lib/cmake/holoscan/holoscan-config.cmake (found suitable version "3.5.0", minimum required is "1.0") 
CMake Error at /usr/local/share/cmake-3.24/Modules/FindThreads.cmake:66 (message):
  FindThreads only works if either C or CXX language is enabled
Call Stack (most recent call first):
  /usr/local/share/cmake-3.24/Modules/FindCUDAToolkit.cmake:913 (find_package)
  /usr/local/share/cmake-3.24/Modules/CMakeFindDependencyMacro.cmake:47 (find_package)
  /opt/nvidia/holoscan/lib/cmake/holoscan/holoscan-dependencies.cmake:19 (find_dependency)
  /opt/nvidia/holoscan/lib/cmake/holoscan/holoscan-config.cmake:68 (include)
  applications/volume_rendering/python/CMakeLists.txt:19 (find_package)


-- Configuring incomplete, errors occurred!
See also "/workspace/holohub/build-volume_rendering/CMakeFiles/CMakeOutput.log".
```