### PR TITLE
./holohub lint in a container

### DIFF
--- a/.github/workflows/check_docker.yml
+++ b/.github/workflows/check_docker.yml
@@ -2,7 +2,7 @@ name: Check Docker
 
 on:
   push:
-    branches: [main, holoscan-sdk-lws2]
+    branches: [main, holoscan-sdk-lws2, lint-docker]
 
 permissions:
   contents: read
@@ -42,6 +42,9 @@ jobs:
           ./holohub run-container --no-docker-build --add-volume "/tmp" | grep -q "/tmp" || { echo "add-volume test failed"; exit 1; }
           ./holohub run-container --no-docker-build -- echo hello > /tmp/trailing-args.log 2>&1
           grep -q "hello" /tmp/trailing-args.log || { echo "trailing args test failed"; cat /tmp/trailing-args.log; exit 1; }
+
+          # test linting in docker
+          ./holohub run-container --base-img ubuntu:${ubuntu_version} --no-docker-build -- "./holohub lint --install-dep; ./holohub lint"
 
   test-entrypoint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/check_docker.yml
+++ b/.github/workflows/check_docker.yml
@@ -44,7 +44,7 @@ jobs:
           grep -q "hello" /tmp/trailing-args.log || { echo "trailing args test failed"; cat /tmp/trailing-args.log; exit 1; }
 
           # test linting in docker
-          ./holohub run-container --base-img ubuntu:${ubuntu_version} --no-docker-build -- "./holohub lint --install-dep; ./holohub lint --fix; ./holohub lint"
+          ./holohub run-container --base-img ubuntu:${ubuntu_version} --no-docker-build -- "./holohub lint --install-dependencies; ./holohub lint --fix; ./holohub lint"
 
   test-entrypoint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/check_docker.yml
+++ b/.github/workflows/check_docker.yml
@@ -44,7 +44,7 @@ jobs:
           grep -q "hello" /tmp/trailing-args.log || { echo "trailing args test failed"; cat /tmp/trailing-args.log; exit 1; }
 
           # test linting in docker
-          ./holohub run-container --base-img ubuntu:${ubuntu_version} --no-docker-build -- "./holohub lint --install-dep; ./holohub lint --fix"
+          ./holohub run-container --base-img ubuntu:${ubuntu_version} --no-docker-build -- "./holohub lint --install-dep; ./holohub lint --fix; ./holohub lint"
 
   test-entrypoint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/check_docker.yml
+++ b/.github/workflows/check_docker.yml
@@ -2,7 +2,7 @@ name: Check Docker
 
 on:
   push:
-    branches: [main, holoscan-sdk-lws2, lint-docker]
+    branches: [main, holoscan-sdk-lws2]
 
 permissions:
   contents: read

--- a/.github/workflows/check_docker.yml
+++ b/.github/workflows/check_docker.yml
@@ -44,7 +44,7 @@ jobs:
           grep -q "hello" /tmp/trailing-args.log || { echo "trailing args test failed"; cat /tmp/trailing-args.log; exit 1; }
 
           # test linting in docker
-          ./holohub run-container --base-img ubuntu:${ubuntu_version} --no-docker-build -- "./holohub lint --install-dep; ./holohub lint"
+          ./holohub run-container --base-img ubuntu:${ubuntu_version} --no-docker-build -- "./holohub lint --install-dep; ./holohub lint --fix"
 
   test-entrypoint:
     runs-on: ubuntu-22.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ extend-exclude = '''
   | ^build*/*  # exclude build folders
   | ^install*/*  # exclude install folders
   | cmake/pybind11/*  # exclude the files under cmake/pybind11/
+  | .local/*  # exclude the files under .local/
 )
 '''
 
@@ -52,7 +53,9 @@ exclude = [
   "install*",
   ".git",
   "xml",
-  "cmake/pybind11"
+  "cmake/pybind11",
+  ".ruff_cache",
+  ".local"
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@
 profile = "black"
 line_length = 100
 known_first_party = "holohub"
-skip_glob = ["build*/*", "install*/*", ".cache/*"]
+skip_glob = ["build*/*", "install*/*", ".cache/*", ".ruff_cache/*", ".local/*"]
 
 [tool.black]
 line-length = 100

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -1029,13 +1029,13 @@ class HoloHubCLI:
         local_bin_path = Path.home() / ".local" / "bin"
         if str(local_bin_path) not in env.get("PATH", ""):
             env["PATH"] = str(local_bin_path) + ":" + env.get("PATH", "")
-            print(f"Added {local_bin_path} to PATH, env: {env['PATH']}")
+            print(f"Added {local_bin_path} to PATH.")
 
         # Set cache directories to /tmp when in Docker container to avoid permission issues
         if holohub_cli_util.is_running_in_docker():
             env["RUFF_CACHE_DIR"] = "/tmp/.ruff_cache"
             env["BLACK_CACHE_DIR"] = "/tmp/.black_cache"
-            print(f"Set CACHE_DIR to {env['RUFF_CACHE_DIR']} and {env['BLACK_CACHE_DIR']}")
+            print(f"Set cache directories to {env['RUFF_CACHE_DIR']} and {env['BLACK_CACHE_DIR']}")
 
         # Change to script directory
         print(
@@ -1100,7 +1100,7 @@ class HoloHubCLI:
                     args.path,
                 ]
                 if args.dryrun:
-                    holohub_cli_util.run_command(cmd, dry_run=True, env=env)
+                    holohub_cli_util.run_command(cmd, dry_run=True)
                     cpp_files = ""
                 else:
                     cpp_files = subprocess.check_output(

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -1024,6 +1024,19 @@ class HoloHubCLI:
 
         exit_code = 0
 
+        # Add ~/.local/bin to PATH for pip-installed executables
+        env = os.environ.copy()
+        local_bin_path = Path.home() / ".local" / "bin"
+        if str(local_bin_path) not in env.get("PATH", ""):
+            env["PATH"] = str(local_bin_path) + ":" + env.get("PATH", "")
+            print(f"Added {local_bin_path} to PATH, env: {env['PATH']}")
+
+        # Set cache directories to /tmp when in Docker container to avoid permission issues
+        if holohub_cli_util.is_running_in_docker():
+            env["RUFF_CACHE_DIR"] = "/tmp/.ruff_cache"
+            env["BLACK_CACHE_DIR"] = "/tmp/.black_cache"
+            print(f"Set CACHE_DIR to {env['RUFF_CACHE_DIR']} and {env['BLACK_CACHE_DIR']}")
+
         # Change to script directory
         print(
             holohub_cli_util.format_cmd("cd " + str(HoloHubCLI.HOLOHUB_ROOT), is_dryrun=args.dryrun)
@@ -1037,9 +1050,14 @@ class HoloHubCLI:
                 ["ruff", "check", "--fix", "--ignore", "E712", args.path],
                 check=False,
                 dry_run=args.dryrun,
+                env=env,
             )
-            holohub_cli_util.run_command(["isort", args.path], check=False, dry_run=args.dryrun)
-            holohub_cli_util.run_command(["black", args.path], check=False, dry_run=args.dryrun)
+            holohub_cli_util.run_command(
+                ["isort", args.path], check=False, dry_run=args.dryrun, env=env
+            )
+            holohub_cli_util.run_command(
+                ["black", args.path], check=False, dry_run=args.dryrun, env=env
+            )
             holohub_cli_util.run_command(
                 [
                     "codespell",
@@ -1055,6 +1073,7 @@ class HoloHubCLI:
                 ],
                 check=False,
                 dry_run=args.dryrun,
+                env=env,
             )
 
             # Fix C++ with clang-format
@@ -1073,14 +1092,20 @@ class HoloHubCLI:
                     "install-*",
                     "--exclude",
                     "applications/holoviz/template/cookiecutter*",
+                    "--exclude",
+                    ".ruff_cache",
+                    "--exclude",
+                    ".local",
                     "--recursive",
                     args.path,
                 ]
                 if args.dryrun:
-                    holohub_cli_util.run_command(cmd, dry_run=True)
+                    holohub_cli_util.run_command(cmd, dry_run=True, env=env)
                     cpp_files = ""
                 else:
-                    cpp_files = subprocess.check_output(cmd, stderr=subprocess.PIPE, text=True)
+                    cpp_files = subprocess.check_output(
+                        cmd, stderr=subprocess.PIPE, text=True, env=env
+                    )
 
                 for file in cpp_files.splitlines():
                     if ":" in file:  # Only process files with issues
@@ -1096,6 +1121,7 @@ class HoloHubCLI:
                             ],
                             check=False,
                             dry_run=args.dryrun,
+                            env=env,
                         )
             except subprocess.CalledProcessError:
                 pass
@@ -1108,20 +1134,21 @@ class HoloHubCLI:
                     ["ruff", "check", "--ignore", "E712", args.path],
                     check=False,
                     dry_run=args.dryrun,
+                    env=env,
                 ).returncode
                 != 0
             ):
                 exit_code = 1
             if (
                 holohub_cli_util.run_command(
-                    ["isort", "-c", args.path], check=False, dry_run=args.dryrun
+                    ["isort", "-c", args.path], check=False, dry_run=args.dryrun, env=env
                 ).returncode
                 != 0
             ):
                 exit_code = 1
             if (
                 holohub_cli_util.run_command(
-                    ["black", "--check", args.path], check=False, dry_run=args.dryrun
+                    ["black", "--check", args.path], check=False, dry_run=args.dryrun, env=env
                 ).returncode
                 != 0
             ):
@@ -1147,11 +1174,16 @@ class HoloHubCLI:
                         ".vscode-server",
                         "--exclude",
                         "applications/holoviz/template/cookiecutter*",
+                        "--exclude",
+                        ".ruff_cache",
+                        "--exclude",
+                        ".local",
                         "--recursive",
                         args.path,
                     ],
                     check=False,
                     dry_run=args.dryrun,
+                    env=env,
                 ).returncode
                 != 0
             ):
@@ -1171,6 +1203,7 @@ class HoloHubCLI:
                     ],
                     check=False,
                     dry_run=args.dryrun,
+                    env=env,
                 ).returncode
                 != 0
             ):
@@ -1201,6 +1234,7 @@ class HoloHubCLI:
                             ],
                             check=False,
                             dry_run=args.dryrun,
+                            env=env,
                         ).returncode
                         != 0
                     ):
@@ -1229,10 +1263,6 @@ class HoloHubCLI:
                 "-r",
                 str(HoloHubCLI.HOLOHUB_ROOT / "utilities/requirements.lint.txt"),
             ],
-            dry_run=dry_run,
-        )
-        holohub_cli_util.run_command(
-            ["apt", "install", "--no-install-recommends", "-y", "clang-format=1:14.0*"],
             dry_run=dry_run,
         )
 

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -875,6 +875,17 @@ def collect_environment_variables() -> None:
         print(f"  {var}: {os.environ.get(var) or '(not set)'}")
 
 
+def is_running_in_docker() -> bool:
+    """Check if the current process is inside a Docker container"""
+    try:
+        if os.path.exists("/.dockerenv"):
+            return True
+        with open("/proc/1/cgroup", "r") as f:
+            return "docker" in f.read()
+    except (OSError, IOError):
+        return False
+
+
 def collect_env_info() -> None:
     """Collect and display comprehensive environment information"""
     collect_system_info()

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -878,10 +878,11 @@ def collect_environment_variables() -> None:
 def is_running_in_docker() -> bool:
     """Check if the current process is inside a Docker container"""
     try:
-        if os.path.exists("/.dockerenv"):
+        if os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv"):
             return True
         with open("/proc/1/cgroup", "r") as f:
-            return "docker" in f.read()
+            return any(indicator in f.read() for indicator in ["docker", "containerd", "kubepods"])
+
     except (OSError, IOError):
         return False
 

--- a/utilities/requirements.lint.txt
+++ b/utilities/requirements.lint.txt
@@ -5,3 +5,4 @@ cpplint==1.6.1
 isort==5.13.2
 mypy==1.11.1
 ruff==0.6.0
+clang-format==14.*

--- a/utilities/requirements.lint.txt
+++ b/utilities/requirements.lint.txt
@@ -2,7 +2,7 @@ black==24.8.0
 cmakelint==1.4.3
 codespell==2.3.0
 cpplint==1.6.1
-isort==6.*
+isort==5.13.2
 mypy==1.11.1
 ruff==0.6.0
 clang-format==14.*

--- a/utilities/requirements.lint.txt
+++ b/utilities/requirements.lint.txt
@@ -2,7 +2,7 @@ black==24.8.0
 cmakelint==1.4.3
 codespell==2.3.0
 cpplint==1.6.1
-isort==5.13.2
+isort==6.*
 mypy==1.11.1
 ruff==0.6.0
 clang-format==14.*


### PR DESCRIPTION
this adds support `./holohub lint` in a container
- include `.local/bin` path for the pip installed bins during linting
- change RUFF_CACHE_DIR, BLACK_CACHE_DIR to avoid permission issue when in a container
- use pip version of clang-format instead of the apt install to avoid the `sudo` requirement