### PR TITLE
Infra: Relax `test_holohub_setup` regex pass condition

### DIFF
--- a/utilities/cli/tests/CMakeLists.txt
+++ b/utilities/cli/tests/CMakeLists.txt
@@ -59,7 +59,7 @@ add_test(
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 set_tests_properties(test_holohub_setup PROPERTIES
-    PASS_REGULAR_EXPRESSION "wget.*xvfb.*git.*unzip.*ffmpeg.*ninja-build.*v4l-dev"
+    PASS_REGULAR_EXPRESSION "(already installed|apt install)"
     FAIL_REGULAR_EXPRESSION "returned non-zero exit status;failed;Traceback;Error"
 )
 
@@ -67,7 +67,7 @@ find_package(CUDAToolkit QUIET)
 if(CUDAToolkit_FOUND)
     get_test_property(test_holohub_setup PASS_REGULAR_EXPRESSION pass_expression)
     set_tests_properties(test_holohub_setup PROPERTIES
-        PASS_REGULAR_EXPRESSION "${pass_expression}.*cudnn.*nvinfer.*nvonnxparsers"
+        PASS_REGULAR_EXPRESSION "${pass_expression}.*(cudnn|nvinfer|nvonnxparsers)"
         FAIL_REGULAR_EXPRESSION "returned non-zero exit status;failed;Traceback;Error checking available versions"
     )
 endif()


### PR DESCRIPTION
Fix test failure in dGPU environment due to out of order package installations

Previous CLI setup test PASS_REGULAR_EXPRESSION condition assumes ordered package output with all required packages already installed in the environment. This causes a test failure when one package in the initial list, such as "ffmpeg", is not initially installed and then is cited for installation after all packages in the list have been checked.

CMake / CTest regex does not appear to support matching multiple patterns in any order. Instead we relax the condition to ensure some package check is performed, and rely on failure conditions to emit any issues with installation.

See CMake regex doc:
https://cmake.org/cmake/help/latest/command/string.html#regex-specification