### PR TITLE
bugfix for 3.5 in object detection torch

### DIFF
--- a/applications/object_detection_torch/frcnn_resnet50_t.yaml
+++ b/applications/object_detection_torch/frcnn_resnet50_t.yaml
@@ -13,11 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
 inference:
   input_nodes:
-    input:
-      dim: "3 1080 1920"
+    detect_preprocessed:
+      dim: "1080 1920 3"
       dtype: kFloat32
   output_nodes:
     boxes:
@@ -26,3 +25,6 @@ inference:
       dtype: kInt64
     scores:
       dtype: kFloat32
+  input_format: [["detect_preprocessed"]]
+  output_format: [null, [{"boxes": "boxes", "labels": "labels", "scores": "scores"}]]
+

--- a/applications/object_detection_torch/generate_resnet_model.py
+++ b/applications/object_detection_torch/generate_resnet_model.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/applications/object_detection_torch/generate_resnet_model.py
+++ b/applications/object_detection_torch/generate_resnet_model.py
@@ -42,16 +42,14 @@ class RCNNWrapper(torch.nn.Module):
     def __init__(self, det_model: torch.nn.Module):
         super().__init__()
         self.model = det_model
-        # Get device from the model's parameters
-        self.device = next(det_model.parameters()).device
 
     def forward(self, x: List[torch.Tensor]):
         # Move input to model device and permute to expected format
         img = x[0]
         if img.shape[0] == 3:
-            y = [x[0].to(self.device)]
+            y = x
         else:
-            y = [x[0].permute(2, 0, 1).to(self.device)]
+            y = [x[0].permute(2, 0, 1)]
         result = self.model(y)
         return result
 

--- a/applications/object_detection_torch/generate_resnet_model.py
+++ b/applications/object_detection_torch/generate_resnet_model.py
@@ -36,7 +36,7 @@ det_model = detection.fasterrcnn_resnet50_fpn(
 ).to(DEVICE)
 
 
-# wrapps the model to incorporate a permutation operation.
+# Wraps the model to incorporate a permutation operation.
 # Holoscan expects the input to be in the format [H, W, C] while the model expects [C, H, W]
 class RCNNWrapper(torch.nn.Module):
     def __init__(self, det_model: torch.nn.Module):


### PR DESCRIPTION
This change supports changes in the torch backend made for HSDK3.5. These changes aim to unbreak some issues caused by api changes in the torch backend. These changes are not expected to break the current working version in HSDK3.4 but are not needed until HSDK3.5 is released.

Description

1. Updated yaml file descriptions to match the complex i/o structures that are being used to run fastrcnn.
2. Added the permutation that was previously removed back. this permute is now wrapped into the fastrcnn model. For details check changes in generate_resnet_model.py.

results:
<img width="484" height="268" alt="image" src="https://github.com/user-attachments/assets/22404a4c-a9d8-4c2c-aeb5-0974dff5f142" />
