### PR TITLE
NVC - Include CUDA/Driver Version Requirements

### DIFF
--- a/applications/nvidia_video_codec/nvc_decode/python/README.md
+++ b/applications/nvidia_video_codec/nvc_decode/python/README.md
@@ -14,7 +14,8 @@ This application demonstrates decoding H.264 elementary stream files using the N
 
 ## Requirements
 
-- [NVIDIA Video Codec SDK](https://developer.nvidia.com/video-codec-sdk)
+- NVIDIA Driver Version >= 570
+- CUDA Version >= 12.8
 - H.264 elementary stream file (`.h264`, `.264` extension)
 
 > 💡 **Note:** Tested on x86 + dGPU and NVIDIA IGX Orin + dGPU. NVIDIA IGX Orin with integrated GPU is not currently supported.

--- a/applications/nvidia_video_codec/nvc_encode_decode/python/README.md
+++ b/applications/nvidia_video_codec/nvc_encode_decode/python/README.md
@@ -7,8 +7,9 @@ This application demonstrates the use of NVIDIA Video Codec SDK. The application
 
 ### Requirements
 
+- NVIDIA Driver Version >= 570
+- CUDA Version >= 12.8
 - x86 and SBSA platforms with dedicated GPU
-- [NVIDIA Video Codec SDK](https://developer.nvidia.com/video-codec-sdk)
 
 > 💡 **Note:** NVIDIA IGX Orin with integrated GPU is not currently supported.
 

--- a/applications/nvidia_video_codec/nvc_encode_writer/python/README.md
+++ b/applications/nvidia_video_codec/nvc_encode_writer/python/README.md
@@ -4,8 +4,9 @@ This application demonstrates the use of NVIDIA Video Codec SDK. The application
 
 ### Requirements
 
+- NVIDIA Driver Version >= 570
+- CUDA Version >= 12.8
 - x86 and SBSA platforms with dedicated GPU
-- [NVIDIA Video Codec SDK](https://developer.nvidia.com/video-codec-sdk)
 
 > 💡 **Note:** NVIDIA IGX Orin with integrated GPU is not currently supported.
 

--- a/operators/nvidia_video_codec/README.md
+++ b/operators/nvidia_video_codec/README.md
@@ -9,6 +9,12 @@ memory, where they can be copied to another network streaming operator.
 > [!IMPORTANT]  
 > By using the NVIDIA Video Codec operators, you agree to the [NVIDIA Software Developer License Agreement](https://developer.nvidia.com/designworks/sdk-samples-tools-software-license-agreement). If you disagree with the EULA, please do not run this application.
 
+## Requirements
+
+- NVIDIA Driver Version >= 570
+- CUDA Version >= 12.8
+- x86 and SBSA platforms with dedicated GPU
+
 ## Sample Applications
 
 - [H.264 File Decoder](../../applications/nvidia_video_codec/nvc_decode/)


### PR DESCRIPTION
Update NVC-related applications and operators to include CUDA version and driver version requirements.

Remove the link to NVC as a requirement since it's downloaded automatically.