### PR TITLE
Enhanced Slang shader support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1260,6 +1260,32 @@
                 "order": 1
             }
         },
+        {
+            "name": "(gdb) slang_shader_op test",
+            "type": "cppdbg",
+            "request": "launch",
+            "preLaunchTask": "Build slang_simple",
+            "program": "${workspaceFolder}/build/slang_simple/operators/slang_shader/test/slang_shader_test",
+            "args": [
+                "--gtest_filter=*"
+            ],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/build/slang_simple/operators/slang_shader/test/",
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ],
+            "presentation": {
+                "hidden": false,
+                "group": "slang",
+                "order": 2
+            }
+        },
         //#endregion slang
 
         //#region volume_rendering

--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -47,6 +47,7 @@ add_holohub_application(endoscopy_out_of_body_detection DEPENDS OPERATORS aja_so
 add_holohub_application(endoscopy_tool_tracking DEPENDS
                         OPERATORS lstm_tensor_rt_inference
                                   tool_tracking_postprocessor
+                                  slang_shader
                                   OPTIONAL deltacast_videomaster yuan_qcap vtk_renderer aja_source)
 
 add_subdirectory(h264)

--- a/applications/endoscopy_tool_tracking/cpp/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,6 +32,7 @@ target_link_libraries(endoscopy_tool_tracking
   holoscan::ops::holoviz
   lstm_tensor_rt_inference
   tool_tracking_postprocessor
+  holoscan::ops::slang_shader
 )
 
 target_link_libraries(endoscopy_tool_tracking PRIVATE $<TARGET_NAME_IF_EXISTS:holoscan::aja>)
@@ -49,8 +50,9 @@ endif()
 add_custom_target(endoscopy_tool_tracking_deps
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/endoscopy_tool_tracking.yaml" ${CMAKE_CURRENT_BINARY_DIR}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/endoscopy_tool_tracking_aja_overlay.yaml" ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS "endoscopy_tool_tracking.yaml" "endoscopy_tool_tracking_aja_overlay.yaml"
-  BYPRODUCTS "endoscopy_tool_tracking.yaml" "endoscopy_tool_tracking_aja_overlay.yaml"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/postprocessor.slang" ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS "endoscopy_tool_tracking.yaml" "endoscopy_tool_tracking_aja_overlay.yaml" "postprocessor.slang"
+  BYPRODUCTS "endoscopy_tool_tracking.yaml" "endoscopy_tool_tracking_aja_overlay.yaml" "postprocessor.slang"
 )
 add_dependencies(endoscopy_tool_tracking endoscopy_tool_tracking_deps)
 
@@ -167,5 +169,10 @@ install(
 
 install(
   FILES endoscopy_tool_tracking_aja_overlay.yaml
+  DESTINATION bin/endoscopy_tool_tracking/cpp
+)
+
+install(
+  FILES postprocessor.slang
   DESTINATION bin/endoscopy_tool_tracking/cpp
 )

--- a/applications/endoscopy_tool_tracking/cpp/README.md
+++ b/applications/endoscopy_tool_tracking/cpp/README.md
@@ -59,13 +59,21 @@ In your `build` directory, run the commands of your choice:
     sed -i -e 's#^source:.*#source: deltacast#' applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
     applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking
     ```
+
 * Using a Yuan card
     ```bash
     sed -i -e '/^#.*yuan_qcap/s/^#//' applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
     sed -i -e 's#^source:.*#source: yuan#' applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
     applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking
     ```
+
 * Using an AJA card with hardware keying overlay (Only specific cards support this feature)
     ```bash
     ./holohub run endoscopy_tool_tracking --language=cpp --run-args=-capplications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking_aja_overlay.yaml
+    ```
+
+* Using the Slang shader operator for post-processing
+    ```bash
+    sed -i -e 's#^postprocessor:.*#postprocessor: slang_shader#' applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
+    applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking
     ```

--- a/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
+++ b/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml
@@ -1,5 +1,5 @@
 %YAML 1.2
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,6 +36,7 @@ extensions:
 #  - lib/gxf_extensions/libgxf_qcap_source.so
 
 source: "replayer"    # "replayer" or "aja" or "deltacast" or "yuan"
+postprocessor: "tool_tracking_postprocessor" # "slang_shader" or "tool_tracking_postprocessor"
 visualizer: "holoviz"  # "holoviz" or "vtk"
 record_type: "none"   # or "input" if you want to record input video stream, or "visualizer" if you want
                       # to record the visualizer output.

--- a/applications/endoscopy_tool_tracking/cpp/postprocessor.slang
+++ b/applications/endoscopy_tool_tracking/cpp/postprocessor.slang
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import holoscan;
+
+[holoscan::input("in:probs")]
+StructuredBuffer<float> probs;
+
+[holoscan::input("in:scaled_coords")]
+StructuredBuffer<float2> scaled_coords;
+
+[holoscan::input("in:binary_masks")]
+StructuredBuffer<float> binary_masks;
+
+[holoscan::output("out:scaled_coords")]
+[holoscan::alloc::size_of("in:scaled_coords.x")]
+RWStructuredBuffer<float3> filtered_scaled_coords;
+
+[holoscan::output("out:mask")]
+// The inference operator omits the component count for single component buffers, e.g. the mask has
+// a shape of (width, height). Therefore the swizzle is `cx` resulting in a allocation size of
+// (4, width, height) (the 4 is automatically added by the operator since the data is a float4).
+[holoscan::alloc::size_of("in:binary_masks.cx")]
+[holoscan::zeros()]
+RWStructuredBuffer<float4> colored_mask;
+
+[holoscan::parameter("min_prob=0.5")]
+float min_prob;
+
+[holoscan::size_of("out:mask")]
+uint3 binary_mask_size;
+
+static const float3 colors[12] = {
+  float3(0.12f, 0.47f, 0.71f),
+  float3(0.20f, 0.63f, 0.17f),
+  float3(0.89f, 0.10f, 0.11f),
+  float3(1.00f, 0.50f, 0.00f),
+  float3(0.42f, 0.24f, 0.60f),
+  float3(0.69f, 0.35f, 0.16f),
+  float3(0.65f, 0.81f, 0.89f),
+  float3(0.70f, 0.87f, 0.54f),
+  float3(0.98f, 0.60f, 0.60f),
+  float3(0.99f, 0.75f, 0.44f),
+  float3(0.79f, 0.70f, 0.84f),
+  float3(1.00f, 1.00f, 0.60f),
+};
+
+// Apply the same workaround here as for the `colored_mask` buffer, see above.
+[holoscan::invocations::size_of("in:binary_masks.cxy")]
+[shader("compute")]
+void filter_binary_mask_kernel(uint3 gid: SV_DispatchThreadID) {
+  if ((gid.x >= binary_mask_size.x) || (gid.y >= binary_mask_size.y) ||
+      (gid.z >= binary_mask_size.z)) {
+    return;
+  }
+
+  const uint index = gid.z;
+
+  // check if the probability meets the minimum probability
+  if (probs[index] < min_prob) {
+    return;
+  }
+
+  const uint offset = (gid.y * binary_mask_size.x) + gid.x;
+  float value = binary_masks[offset];
+
+  const float minV = 0.3f;
+  const float maxV = 0.99f;
+  const float range = maxV - minV;
+  value = min(max(value, minV), maxV);
+  value -= minV;
+  value /= range;
+  value *= 0.7f;
+
+  const float4 dst = colored_mask[offset];
+  colored_mask[offset] = float4((1.0f - value) * dst.x + colors[index].x * value,
+                                (1.0f - value) * dst.y + colors[index].y * value,
+                                (1.0f - value) * dst.z + colors[index].z * value,
+                                (1.0f - value) * dst.w + 1.f * value);
+}
+
+[holoscan::invocations::size_of("in:scaled_coords")]
+[shader("compute")]
+void filter_coordinates_kernel(uint3 gid: SV_DispatchThreadID) {
+  // the third component of the coordinate is the size of the crosses and the text
+  constexpr float ITEM_SIZE = 0.05f;
+
+  // check if the probability meets the minimum probability
+  if (probs[gid.x] > min_prob) {
+    filtered_scaled_coords[gid.x] =
+        float3(scaled_coords[gid.x].x, scaled_coords[gid.x].y, ITEM_SIZE);
+  } else {
+    // move outside of the screen
+    filtered_scaled_coords[gid.x] = float3(-1.f, -1.f, ITEM_SIZE);
+  }
+}

--- a/applications/endoscopy_tool_tracking/python/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,14 +21,15 @@ add_custom_target(python_endoscopy_tool_tracking ALL
 )
 
 # Copy config files
-add_custom_target(python_endoscopy_tool_tracking_yaml
+add_custom_target(python_endoscopy_tool_tracking_deps
   COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/endoscopy_tool_tracking.yaml" ${CMAKE_CURRENT_BINARY_DIR}
   COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/endoscopy_tool_tracking_aja_overlay.yaml" ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS "endoscopy_tool_tracking.yaml" "endoscopy_tool_tracking_aja_overlay.yaml"
-  BYPRODUCTS "endoscopy_tool_tracking.yaml" "endoscopy_tool_tracking_aja_overlay.yaml"
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/postprocessor.slang" ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS "endoscopy_tool_tracking.yaml" "endoscopy_tool_tracking_aja_overlay.yaml" "postprocessor.slang"
+  BYPRODUCTS "endoscopy_tool_tracking.yaml" "endoscopy_tool_tracking_aja_overlay.yaml" "postprocessor.slang"
 )
 
-add_dependencies(python_endoscopy_tool_tracking python_endoscopy_tool_tracking_yaml)
+add_dependencies(python_endoscopy_tool_tracking python_endoscopy_tool_tracking_deps)
 
 # Add testing
 if(BUILD_TESTING)
@@ -61,7 +62,7 @@ if(BUILD_TESTING)
                "PYTHONPATH=${GXF_LIB_DIR}/../python/lib:${CMAKE_BINARY_DIR}/python/lib")
 
   set_tests_properties(endoscopy_tool_tracking_python_test PROPERTIES
-                DEPENDS python_endoscopy_tool_tracking_yaml
+                DEPENDS python_endoscopy_tool_tracking_deps
                 PASS_REGULAR_EXPRESSION "Reach end of file or playback count reaches to the limit. Stop ticking.;"
                 FAIL_REGULAR_EXPRESSION "[^a-z]Error;ERROR;Failed")
 
@@ -94,5 +95,10 @@ install(
 
 install(
   FILES endoscopy_tool_tracking_aja_overlay.yaml
+  DESTINATION bin/endoscopy_tool_tracking/python
+)
+
+install(
+  FILES postprocessor.slang
   DESTINATION bin/endoscopy_tool_tracking/python
 )

--- a/applications/endoscopy_tool_tracking/python/README.md
+++ b/applications/endoscopy_tool_tracking/python/README.md
@@ -58,7 +58,13 @@ the working directory.
     cd <HOLOHUB_BUILD_DIR>
     python3  <HOLOHUB_SOURCE_DIR>/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py --source=yuan
     ```
+
 * Using an AJA card with hardware keying overlay (Only specific cards support this feature)
     ```bash
     ./holohub run endoscopy_tool_tracking --language python --run-args="-c=applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking_aja_overlay.yaml -s=aja"
+    ```
+
+* Using the Slang shader operator for post-processing
+    ```bash
+    ./holohub run endoscopy_tool_tracking --language python --run-args="-p=slang_shader"
     ```

--- a/applications/endoscopy_tool_tracking/python/postprocessor.slang
+++ b/applications/endoscopy_tool_tracking/python/postprocessor.slang
@@ -1,0 +1,1 @@
+../cpp/postprocessor.slang

--- a/applications/slang/slang_simple/README.md
+++ b/applications/slang/slang_simple/README.md
@@ -74,12 +74,12 @@ RWStructuredBuffer<int> input_buffer;
 [holoscan::alloc::size_of("input_buffer")]
 RWStructuredBuffer<int> output_buffer;
 
-// Create a parameter named "offset"
-[holoscan::parameter("offset")]
+// Create a parameter named "offset" with a default value of "1"
+[holoscan::parameter("offset=1")]
 uniform int offset;
 
 // Use the size of the input buffer to set the grid size
-[holoscan::grid::size_of("input_buffer")]
+[holoscan::invocations::size_of("input_buffer")]
 [shader("compute")]
 void add(uint3 gid : SV_DispatchThreadID)
 {
@@ -115,7 +115,7 @@ Received value: 20
 You can modify the `simple.slang` file to implement different computations:
 
 1. Change the computation in the `add` function
-2. Add more parameters using `[holoscan::parameter("name")]`
+2. Add more parameters using `[holoscan::parameter("name=default_value")]`
 3. Modify buffer types and sizes
 4. Add more complex GPU algorithms
 

--- a/applications/slang/slang_simple/cpp/simple.slang
+++ b/applications/slang/slang_simple/cpp/simple.slang
@@ -20,7 +20,7 @@ import holoscan;
 
 // Create an input port named "input_buffer"
 [holoscan::input("input_buffer")]
-RWStructuredBuffer<int> input_buffer;
+StructuredBuffer<int> input_buffer;
 
 // Create an output port named "output_buffer"
 [holoscan::output("output_buffer")]
@@ -33,7 +33,7 @@ RWStructuredBuffer<int> output_buffer;
 uniform int offset;
 
 // Use the size of the input buffer to set the grid size
-[holoscan::grid::size_of("input_buffer")]
+[holoscan::invocations::size_of("input_buffer")]
 [shader("compute")]
 void add(uint3 gid : SV_DispatchThreadID)
 {

--- a/applications/slang/slang_simple/cpp/slang_simple.cpp
+++ b/applications/slang/slang_simple/cpp/slang_simple.cpp
@@ -61,7 +61,7 @@ class SourceOp : public Operator {
     auto gxf_allocator = nvidia::gxf::Handle<nvidia::gxf::Allocator>::Create(
         context.context(), allocator_.get()->gxf_cid());
     tensor->reshape<int>(
-        nvidia::gxf::Shape({1}), nvidia::gxf::MemoryStorageType::kHost, gxf_allocator.value());
+        nvidia::gxf::Shape({1, 1}), nvidia::gxf::MemoryStorageType::kHost, gxf_allocator.value());
 
     auto value = index_++;
     std::memcpy(tensor->pointer(), &value, sizeof(value));

--- a/applications/slang/slang_simple/python/simple.slang
+++ b/applications/slang/slang_simple/python/simple.slang
@@ -33,7 +33,7 @@ RWStructuredBuffer<int> output_buffer;
 uniform int offset;
 
 // Use the size of the input buffer to set the grid size
-[holoscan::grid::size_of("input_buffer")]
+[holoscan::invocations::size_of("input_buffer")]
 [shader("compute")]
 void add(uint3 gid : SV_DispatchThreadID)
 {

--- a/operators/slang_shader/CMakeLists.txt
+++ b/operators/slang_shader/CMakeLists.txt
@@ -81,3 +81,8 @@ if(HOLOHUB_BUILD_PYTHON)
     add_subdirectory(python)
 endif()
 
+# Add test subdirectory if testing is enabled
+if(BUILD_TESTING)
+    add_subdirectory(test)
+endif()
+

--- a/operators/slang_shader/command.cpp
+++ b/operators/slang_shader/command.cpp
@@ -19,96 +19,418 @@
 
 #include "slang_shader.hpp"
 
+namespace {
+
+/**
+ * Converts a shape to a uint3. The shape is expected to have the least varying dimension first, for
+ * example an grayscale image with a width of 1024 and a height of 768 has a shape of (768, 1024,
+ * 1).
+ *
+ * @param shape The shape to convert
+ * @param skip_element_count If true, the element count is not included in the shape
+ * @return A uint3
+ */
+uint3 shape_to_uint3(const nvidia::gxf::Shape& shape, bool skip_element_count) {
+  uint3 result = make_uint3(1, 1, 1);
+  uint32_t offset = skip_element_count ? 1 : 0;
+  if (shape.rank() > 0 + offset) {
+    result.x = shape.dimension(shape.rank() - 1 - offset);
+    if (shape.rank() > 1 + offset) {
+      result.y = shape.dimension(shape.rank() - 2 - offset);
+      if (shape.rank() > 2 + offset) {
+        result.z = shape.dimension(shape.rank() - 3 - offset);
+        if (shape.rank() > 3 + offset) {
+          throw std::runtime_error(
+              fmt::format("Only tensors of rank <= {} are supported, found rank '{}'.",
+                          3 + offset,
+                          shape.rank()));
+        }
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Swizzles a shape based on a string. The string is a sequence of characters that specify the
+ * dimensions of the shape. The characters are:
+ * - 'c': the component count
+ * - 'x': the first dimension
+ * - 'y': the second dimension
+ * - 'z': the third dimension
+ * - 'w': the fourth dimension
+ * - '0-9': the dimension number
+ *
+ * @param shape The shape to swizzle
+ * @param swizzle The swizzle string
+ * @return The swizzled shape
+ */
+nvidia::gxf::Shape swizzle_shape(const nvidia::gxf::Shape& shape, const std::string& swizzle) {
+  // If the swizzle is not empty, we need to create a new shape based on the swizzle
+  if (!swizzle.empty()) {
+    std::vector<int32_t> result;
+
+    for (auto item : swizzle) {
+      if (item == 'c') {
+        if (shape.rank() < 1) {
+          throw std::runtime_error(
+              fmt::format("Swizzle '{}' not supported, reference resource has rank < 1.", swizzle));
+        }
+        result.insert(result.begin(), shape.dimension(shape.rank() - 1));
+      } else if (item == 'x') {
+        if (shape.rank() < 2) {
+          throw std::runtime_error(
+              fmt::format("Swizzle '{}' not supported, reference resource has rank < 2.", swizzle));
+        }
+        result.insert(result.begin(), shape.dimension(shape.rank() - 2));
+      } else if (item == 'y') {
+        if (shape.rank() < 3) {
+          throw std::runtime_error(
+              fmt::format("Swizzle '{}' not supported, reference resource has rank < 3.", swizzle));
+        }
+        result.insert(result.begin(), shape.dimension(shape.rank() - 3));
+      } else if (item == 'z') {
+        if (shape.rank() < 4) {
+          throw std::runtime_error(
+              fmt::format("Swizzle '{}' not supported, reference resource has rank < 4.", swizzle));
+        }
+        result.insert(result.begin(), shape.dimension(shape.rank() - 4));
+      } else if (item == 'w') {
+        if (shape.rank() < 5) {
+          throw std::runtime_error(
+              fmt::format("Swizzle '{}' not supported, reference resource has rank < 5.", swizzle));
+        }
+        result.insert(result.begin(), shape.dimension(shape.rank() - 5));
+      } else if ((item > '0') && (item <= '9')) {
+        result.insert(result.begin(), item - '0');
+      } else {
+        throw std::runtime_error(fmt::format("Swizzle '{}' not supported.", swizzle));
+      }
+    }
+
+    return nvidia::gxf::Shape(result);
+  }
+
+  // Return the original shape if no swizzle is provided
+  return shape;
+}
+
+}  // namespace
+
 namespace holoscan::ops {
+
+/**
+ * Retrieves the shape, strides, and storage type of a reference input from the workspace based on
+ * the reference name.
+ * The reference name can be in the format "port_name" or "port_name:item_name".
+ *
+ * @param workspace The command workspace containing entities
+ * @param reference_name The name of the reference input (format: "port_name" or
+ * "port_name:item_name")
+ * @param attribute_name The name of the attribute for error reporting
+ * @return A tuple containing the shape, strides, and storage type of the reference input
+ * @throws std::runtime_error if the reference input is not found or is not a tensor or video buffer
+ */
+static std::tuple<nvidia::gxf::Shape, std::vector<uint64_t>, nvidia::gxf::MemoryStorageType>
+get_reference_specs(CommandWorkspace& workspace, const std::string& reference_name,
+                    const std::string& attribute_name) {
+  nvidia::gxf::Shape shape;
+  std::vector<uint64_t> strides;
+  nvidia::gxf::MemoryStorageType storage_type;
+
+  auto [reference_port_name, reference_item_name] = split(reference_name, ':');
+
+  auto reference_port_info_it = workspace.port_info_.find(reference_port_name);
+  if (reference_port_info_it == workspace.port_info_.end()) {
+    throw std::runtime_error(
+        fmt::format("Attribute '{}': input '{}' not found.", attribute_name, reference_name));
+  }
+  auto maybe_reference_tensor =
+      static_cast<nvidia::gxf::Entity&>(reference_port_info_it->second.entity_)
+          .get<nvidia::gxf::Tensor>(reference_item_name.empty() ? nullptr
+                                                                : reference_item_name.c_str());
+  if (maybe_reference_tensor) {
+    shape = maybe_reference_tensor.value()->shape();
+    strides.resize(shape.rank());
+    for (uint32_t i = 0; i < shape.rank(); ++i) {
+      strides[i] = maybe_reference_tensor.value()->stride(i);
+    }
+    storage_type = maybe_reference_tensor.value()->storage_type();
+  } else {
+    auto maybe_reference_video_buffer =
+        static_cast<nvidia::gxf::Entity&>(reference_port_info_it->second.entity_)
+            .get<nvidia::gxf::VideoBuffer>(
+                reference_item_name.empty() ? nullptr : reference_item_name.c_str());
+    if (maybe_reference_video_buffer) {
+      const nvidia::gxf::VideoBufferInfo& video_frame_info =
+          maybe_reference_video_buffer.value()->video_frame_info();
+      if (video_frame_info.color_planes.size() != 1) {
+        throw std::runtime_error(
+            fmt::format("Attribute '{}': input '{}' VideoBuffer with multiple color planes is not "
+                        "supported.",
+                        attribute_name,
+                        reference_name));
+      }
+
+      auto maybe_primitive_type =
+          nvidia::gxf::VideoBuffer::getPlanarPrimitiveType(video_frame_info.color_format);
+      if (!maybe_primitive_type) {
+        throw std::runtime_error(
+            fmt::format("Attribute '{}': input '{}' VideoBuffer with invalid format.",
+                        attribute_name,
+                        reference_name));
+      }
+
+      const nvidia::gxf::ColorPlane& color_plane = video_frame_info.color_planes[0];
+
+      const uint64_t element_size = nvidia::gxf::PrimitiveTypeSize(maybe_primitive_type.value());
+
+      shape =
+          nvidia::gxf::Shape({static_cast<int32_t>(video_frame_info.height),
+                              static_cast<int32_t>(video_frame_info.width),
+                              static_cast<int32_t>(color_plane.bytes_per_pixel / element_size)});
+
+      strides.resize(shape.rank());
+      strides[2] = static_cast<uint64_t>(color_plane.bytes_per_pixel);
+      strides[1] = static_cast<uint64_t>(color_plane.stride);
+      strides[0] = strides[1] * static_cast<uint64_t>(video_frame_info.height);
+      storage_type = maybe_reference_video_buffer.value()->storage_type();
+    } else {
+      throw std::runtime_error(
+          fmt::format("Attribute '{}': input '{}' has no tensor or video buffer.",
+                      attribute_name,
+                      reference_name));
+    }
+  }
+
+  return {shape, strides, storage_type};
+}
 
 CommandWorkspace::CommandWorkspace(InputContext& op_input, OutputContext& op_output,
                                    ExecutionContext& context)
     : op_input_(op_input), op_output_(op_output), context_(context) {}
 
-CommandInput::CommandInput(const std::string& port_name, const std::string& resource_name,
-                           size_t parameter_offset)
-    : port_name_(port_name), resource_name_(resource_name), parameter_offset_(parameter_offset) {}
+CommandInput::CommandInput(const std::string& port_name, const std::string& item_name,
+                           const std::string& resource_name, size_t parameter_offset)
+    : port_name_(port_name),
+      item_name_(item_name),
+      resource_name_(resource_name),
+      parameter_offset_(parameter_offset) {}
 
 void CommandInput::execute(CommandWorkspace& workspace) {
   // Receive the entity from the input port
-  HOLOSCAN_LOG_DEBUG("CommandInput: {} {}", port_name_, resource_name_);
-  auto maybe_entity = workspace.op_input_.receive<gxf::Entity>(port_name_.c_str());
-  if (!maybe_entity.has_value()) {
-    throw std::runtime_error(
-        fmt::format("Failed to receive entity from input port {}.", port_name_));
-  }
-  workspace.entities_[resource_name_] = maybe_entity.value();
+  HOLOSCAN_LOG_DEBUG("CommandInput: {}{} {}",
+                     port_name_,
+                     item_name_.empty() ? "" : ":" + item_name_,
+                     resource_name_);
 
-  // Get the pointer to the data
-  void* pointer = nullptr;
+  // Receive the entity from the input port, it maybe cached in the workspace if the received entity
+  // is expected to contain several items.
+  auto port_info_it = workspace.port_info_.find(port_name_);
+  if (port_info_it == workspace.port_info_.end()) {
+    auto maybe_entity = workspace.op_input_.receive<gxf::Entity>(port_name_.c_str());
+    if (!maybe_entity.has_value()) {
+      throw std::runtime_error(
+          fmt::format("Failed to receive entity from input port {}.", port_name_));
+    }
+    // Receive the CUDA stream from the input port (this always should return the same internal
+    // stream so we can just assign it to the workspace)
+    workspace.cuda_stream_ = workspace.op_input_.receive_cuda_stream(port_name_.c_str());
+    port_info_it = workspace.port_info_.insert({port_name_, {maybe_entity.value()}}).first;
+  }
+
+  // Get the pointer and size of the data
+  void* pointer;
+  size_t size;
 
   auto maybe_tensor =
-      static_cast<nvidia::gxf::Entity&>(maybe_entity.value()).get<nvidia::gxf::Tensor>();
+      static_cast<nvidia::gxf::Entity&>(port_info_it->second.entity_)
+          .get<nvidia::gxf::Tensor>(item_name_.empty() ? nullptr : item_name_.c_str());
   if (maybe_tensor) {
     // The entity is a tensor
     auto tensor = maybe_tensor.value();
     pointer = tensor->pointer();
+    size = tensor->size();
   } else {
     auto maybe_video_buffer =
-        static_cast<nvidia::gxf::Entity&>(maybe_entity.value()).get<nvidia::gxf::VideoBuffer>();
+        static_cast<nvidia::gxf::Entity&>(port_info_it->second.entity_)
+            .get<nvidia::gxf::VideoBuffer>(item_name_.empty() ? nullptr : item_name_.c_str());
     if (!maybe_video_buffer) {
-      throw std::runtime_error(fmt::format(
-          "Attribute 'input': input '{}' is neither a tensor nor a video buffer.", port_name_));
+      throw std::runtime_error(fmt::format("Attribute 'input': input '{}{}' not found.",
+                                           port_name_,
+                                           item_name_.empty() ? "" : ":" + item_name_));
     }
     // The entity is a video buffer
     auto video_buffer = maybe_video_buffer.value();
     pointer = video_buffer->pointer();
+    size = video_buffer->size();
   }
+
+  // Add the pointer to the CUDA resource pointers
+  workspace.cuda_resource_pointers_[resource_name_] = {pointer, size};
 
   // Copy the tensor pointer to the shader parameters array
   workspace.shader_parameters_.resize(parameter_offset_ + sizeof(void*));
   memcpy(workspace.shader_parameters_.data() + parameter_offset_, &pointer, sizeof(void*));
 }
 
-CommandOutput::CommandOutput(const std::string& port_name, const std::string& resource_name)
-    : port_name_(port_name), resource_name_(resource_name) {}
+CommandOutput::CommandOutput(const std::string& port_name, const std::string& item_name,
+                             const std::string& resource_name)
+    : port_name_(port_name), item_name_(item_name), resource_name_(resource_name) {}
 
 void CommandOutput::execute(CommandWorkspace& workspace) {
-  HOLOSCAN_LOG_DEBUG("CommandOutput: {} {}", port_name_, resource_name_);
-  workspace.op_output_.emit(workspace.entities_[resource_name_], port_name_.c_str());
+  HOLOSCAN_LOG_DEBUG("CommandOutput: {}{} {}",
+                     port_name_,
+                     item_name_.empty() ? "" : ":" + item_name_,
+                     resource_name_);
+  auto port_info_it = workspace.port_info_.find(port_name_);
+  if (port_info_it == workspace.port_info_.end()) {
+    throw std::runtime_error(
+        fmt::format("Attribute 'output': output '{}' not found, "
+                    "did you forget to allocate memory for it?",
+                    port_name_));
+  }
+  // Make sure to emit the entity only once (we might have several items in the entity)
+  if (!port_info_it->second.has_been_emitted_) {
+    workspace.op_output_.emit(port_info_it->second.entity_, port_name_.c_str());
+    port_info_it->second.has_been_emitted_ = true;
+  }
 }
 
-CommandAllocSizeOf::CommandAllocSizeOf(const std::string& name, const std::string& size_of_name,
-                                       const Parameter<std::shared_ptr<Allocator>>& allocator,
-                                       size_t parameter_offset)
-    : name_(name),
-      size_of_name_(size_of_name),
+CommandAlloc::CommandAlloc(const std::string& port_name, const std::string& item_name,
+                           const std::string& resource_name, const std::string& reference_name,
+                           uint32_t size_x, uint32_t size_y, uint32_t size_z,
+                           const std::string& element_type, uint32_t element_count,
+                           const Parameter<std::shared_ptr<Allocator>>& allocator,
+                           size_t parameter_offset)
+    : port_name_(port_name),
+      item_name_(item_name),
+      resource_name_(resource_name),
+      reference_name_(reference_name),
+      size_x_(size_x),
+      size_y_(size_y),
+      size_z_(size_z),
+      element_type_(element_type),
+      element_count_(element_count),
       allocator_(allocator),
       parameter_offset_(parameter_offset) {}
 
-void CommandAllocSizeOf::execute(CommandWorkspace& workspace) {
-  HOLOSCAN_LOG_DEBUG("CommandAllocSizeOf: {} {}", name_, size_of_name_);
-  auto reference_entity = workspace.entities_.find(size_of_name_);
-  if (reference_entity == workspace.entities_.end()) {
-    throw std::runtime_error(
-        fmt::format("Attribute 'size_of': input '{}' not found.", size_of_name_));
-  }
-  auto maybe_reference_tensor =
-      static_cast<nvidia::gxf::Entity&>(reference_entity->second).get<nvidia::gxf::Tensor>();
-  if (!maybe_reference_tensor) {
-    throw std::runtime_error(
-        fmt::format("Attribute 'size_of': input '{}' is not a tensor.", size_of_name_));
-  }
-  auto reference_tensor = maybe_reference_tensor.value();
+void CommandAlloc::execute(CommandWorkspace& workspace) {
+  HOLOSCAN_LOG_DEBUG("CommandAlloc: {}{} {} {} {}x{}x{} {}{}",
+                     port_name_,
+                     item_name_.empty() ? "" : ":" + item_name_,
+                     resource_name_,
+                     reference_name_,
+                     size_x_,
+                     size_y_,
+                     size_z_,
+                     element_type_,
+                     element_count_);
 
-  auto entity = gxf::Entity::New(&workspace.context_);
-  auto tensor = static_cast<nvidia::gxf::Entity&>(entity).add<nvidia::gxf::Tensor>().value();
+  nvidia::gxf::Shape alloc_shape;
+  std::string swizzle;
+  nvidia::gxf::MemoryStorageType storage_type;
+
+  if (!reference_name_.empty()) {
+    // If we have a reference name, we need to get the shape of the reference resource
+    std::string reference_remainder;
+    std::tie(reference_remainder, swizzle) = split(reference_name_, '.');
+    auto [reference_shape, reference_strides, reference_storage_type] =
+        get_reference_specs(workspace, reference_remainder, "alloc/alloc_size_of");
+    alloc_shape = reference_shape;
+    storage_type = reference_storage_type;
+  } else {
+    std::vector<int32_t> dimensions;
+    if (size_z_ > 1) {
+      dimensions.push_back(static_cast<int32_t>(size_z_));
+    }
+    if (size_y_ > 1) {
+      dimensions.push_back(static_cast<int32_t>(size_y_));
+    }
+    if (size_x_ > 1) {
+      dimensions.push_back(static_cast<int32_t>(size_x_));
+    }
+    dimensions.push_back(element_count_);
+
+    // Create a new shape and set the storage type to device
+    alloc_shape = nvidia::gxf::Shape(dimensions);
+    storage_type = nvidia::gxf::MemoryStorageType::kDevice;
+  }
+
+  // Create the port info if it does not exist
+  auto port_info_it = workspace.port_info_.find(port_name_);
+  if (port_info_it == workspace.port_info_.end()) {
+    holoscan::expected<gxf::Entity, holoscan::RuntimeError> maybe_entity =
+        gxf::Entity::New(&workspace.context_);
+    if (!maybe_entity.has_value()) {
+      throw std::runtime_error(
+          fmt::format("Failed to create entity for output port {}.", port_name_));
+    }
+    port_info_it = workspace.port_info_.insert({port_name_, {maybe_entity.value()}}).first;
+  }
+
+  // Add a tensor to the entity
+  auto tensor = static_cast<nvidia::gxf::Entity&>(port_info_it->second.entity_)
+                    .add<nvidia::gxf::Tensor>(item_name_.empty() ? nullptr : item_name_.c_str())
+                    .value();
+
   // Get Handle to underlying nvidia::gxf::Allocator from std::shared_ptr<Allocator>
   auto gxf_allocator = nvidia::gxf::Handle<nvidia::gxf::Allocator>::Create(
       workspace.context_.context(), allocator_.get()->gxf_cid());
-  tensor->reshape<int>(
-      reference_tensor->shape(), nvidia::gxf::MemoryStorageType::kHost, gxf_allocator.value());
 
-  workspace.entities_[name_] = entity;
+  std::vector<int32_t> result;
+  if (!swizzle.empty()) {
+    // Apply the swizzle to the reference resource shape
+    const nvidia::gxf::Shape swizzled_shape = swizzle_shape(alloc_shape, swizzle);
+    for (int i = 0; i < swizzled_shape.rank(); ++i) {
+      result.push_back(swizzled_shape.dimension(i));
+    }
+  } else {
+    // Copy anything but the last dimension which is the element count
+    if (alloc_shape.rank() > 0) {
+      for (int i = 0; i < alloc_shape.rank() - 1; ++i) {
+        result.push_back(alloc_shape.dimension(i));
+      }
+    }
+  }
+  // Replace the element count of the reference resource with the element count of the shader
+  // resource
+  result.push_back(element_count_);
+
+  alloc_shape = nvidia::gxf::Shape(result);
+
+  // Reshape the tensor to the size of the reference resource
+  if (element_type_ == "int8") {
+    tensor->reshape<int8_t>(alloc_shape, storage_type, gxf_allocator.value());
+  } else if (element_type_ == "uint8") {
+    tensor->reshape<uint8_t>(alloc_shape, storage_type, gxf_allocator.value());
+  } else if (element_type_ == "int16") {
+    tensor->reshape<int16_t>(alloc_shape, storage_type, gxf_allocator.value());
+  } else if (element_type_ == "uint16") {
+    tensor->reshape<uint16_t>(alloc_shape, storage_type, gxf_allocator.value());
+  } else if (element_type_ == "int32") {
+    tensor->reshape<int32_t>(alloc_shape, storage_type, gxf_allocator.value());
+  } else if (element_type_ == "uint32") {
+    tensor->reshape<uint32_t>(alloc_shape, storage_type, gxf_allocator.value());
+  } else if (element_type_ == "int64") {
+    tensor->reshape<int64_t>(alloc_shape, storage_type, gxf_allocator.value());
+  } else if (element_type_ == "uint64") {
+    tensor->reshape<uint64_t>(alloc_shape, storage_type, gxf_allocator.value());
+  } else if (element_type_ == "float32") {
+    tensor->reshape<float>(alloc_shape, storage_type, gxf_allocator.value());
+  } else if (element_type_ == "float64") {
+    tensor->reshape<double>(alloc_shape, storage_type, gxf_allocator.value());
+  } else {
+    throw std::runtime_error(fmt::format("Element type '{}' not supported.", element_type_));
+  }
+
+  void* const pointer = tensor->pointer();
+
+  // Add the pointer to the CUDA resource pointers
+  workspace.cuda_resource_pointers_[resource_name_] = {pointer, tensor->size()};
 
   // Copy the tensor pointer to the shader parameters array
   workspace.shader_parameters_.resize(parameter_offset_ + sizeof(void*));
-  void* pointer = tensor->pointer();
   memcpy(workspace.shader_parameters_.data() + parameter_offset_, &pointer, sizeof(void*));
 }
 
@@ -119,101 +441,154 @@ void CommandParameter::execute(CommandWorkspace& workspace) {
   memcpy(workspace.shader_parameters_.data() + parameter_offset_, value_pointer, size_);
 }
 
-CommandSizeOf::CommandSizeOf(const std::string& name, const std::string& size_of_name,
-                             size_t parameter_offset)
-    : name_(name), size_of_name_(size_of_name), parameter_offset_(parameter_offset) {}
+CommandSizeOf::CommandSizeOf(const std::string& parameter_name,
+                             const std::string& reference_port_name, size_t parameter_offset)
+    : parameter_name_(parameter_name),
+      reference_port_name_(reference_port_name),
+      parameter_offset_(parameter_offset) {}
 
 void CommandSizeOf::execute(CommandWorkspace& workspace) {
-  HOLOSCAN_LOG_DEBUG("CommandSizeOf: {} {}", name_, size_of_name_);
-  auto reference_entity = workspace.entities_.find(size_of_name_);
-  if (reference_entity == workspace.entities_.end()) {
-    throw std::runtime_error(
-        fmt::format("Attribute 'size_of': input '{}' not found.", size_of_name_));
+  HOLOSCAN_LOG_DEBUG("CommandSizeOf: {} {}", parameter_name_, reference_port_name_);
+
+  // Get the shape of the reference resource and copy it to the shader parameters array
+  auto [shape, strides, storage_type] =
+      get_reference_specs(workspace, reference_port_name_, "size_of");
+
+  workspace.shader_parameters_.resize(parameter_offset_ + sizeof(uint3));
+  uint3* param_data =
+      reinterpret_cast<uint3*>(workspace.shader_parameters_.data() + parameter_offset_);
+  *param_data = shape_to_uint3(shape, true);
+}
+
+CommandStrideOf::CommandStrideOf(const std::string& parameter_name,
+                                 const std::string& reference_port_name, size_t parameter_offset)
+    : parameter_name_(parameter_name),
+      reference_port_name_(reference_port_name),
+      parameter_offset_(parameter_offset) {}
+
+void CommandStrideOf::execute(CommandWorkspace& workspace) {
+  HOLOSCAN_LOG_DEBUG("CommandStrideOf: {} {}", parameter_name_, reference_port_name_);
+
+  // Get the strides of the reference resource and copy it to the shader parameters array
+  auto [reference_shape, reference_strides, reference_storage_type] =
+      get_reference_specs(workspace, reference_port_name_, "strides_of");
+
+  workspace.shader_parameters_.resize(parameter_offset_ + sizeof(ulonglong3));
+  ulonglong3 strides = make_ulonglong3(1, 1, 1);
+  if (reference_strides.size() > 1) {
+    strides.x = reference_strides[reference_strides.size() - 2];
+    if (reference_strides.size() > 2) {
+      strides.y = reference_strides[reference_strides.size() - 3];
+      if (reference_strides.size() > 3) {
+        strides.z = reference_strides[reference_strides.size() - 4];
+        if (reference_strides.size() > 4) {
+          throw std::runtime_error(fmt::format(
+              "Attribute 'strides_of': Only tensors of rank <= 4 are supported, found rank '{}'.",
+              reference_shape.rank()));
+        }
+      } else {
+        strides.z = strides.y;
+      }
+    } else {
+      strides.y = strides.x;
+    }
   }
-  auto maybe_reference_tensor =
-      static_cast<nvidia::gxf::Entity&>(reference_entity->second).get<nvidia::gxf::Tensor>();
-  if (!maybe_reference_tensor) {
-    throw std::runtime_error(
-        fmt::format("Attribute 'size_of': input '{}' is not a tensor.", size_of_name_));
-  }
-  auto reference_tensor = maybe_reference_tensor.value();
-
-  if (reference_tensor->rank() > 3) {
-    throw std::runtime_error(fmt::format("Only tensors of rank < 4 are supported, found rank '{}'.",
-                                         reference_tensor->rank()));
-  }
-
-  workspace.shader_parameters_.resize(parameter_offset_ + sizeof(int) * 3);
-
-  // Get the shape of the reference tensor and copy it to the shader parameters array
-  auto shape = reference_tensor->shape();
-
-  if (reference_tensor->rank() > 3) {
-    throw std::runtime_error(fmt::format("Only tensors of rank <4 are supported, found rank '{}'.",
-                                         reference_tensor->rank()));
-  }
-
-  int32_t* param_data =
-      reinterpret_cast<int32_t*>(workspace.shader_parameters_.data() + parameter_offset_);
-  param_data[0] = shape.dimension(0);
-  param_data[1] = shape.dimension(1);
-  param_data[2] = shape.dimension(2);
+  memcpy(workspace.shader_parameters_.data() + parameter_offset_, &strides, sizeof(ulonglong3));
 }
 
 void CommandReceiveCudaStream::execute(CommandWorkspace& workspace) {
-  workspace.cuda_stream_ = workspace.op_input_.receive_cuda_stream();
+  // If there are inputs, we receive the CUDA stream from the input port, else we allocate a new
+  // stream
+  if (!workspace.cuda_stream_) {
+    auto maybe_cuda_stream = workspace.context_.allocate_cuda_stream();
+    if (!maybe_cuda_stream) {
+      throw std::runtime_error(
+          fmt::format("Failed to allocate CUDA stream: {}", maybe_cuda_stream.error().what()));
+    }
+    workspace.cuda_stream_ = maybe_cuda_stream.value();
+  }
 }
 
-CommandLaunch::CommandLaunch(const std::string& name, SlangShader* shader, dim3 block_size,
-                             const std::string& grid_size_of_name, dim3 grid_size)
+CommandLaunch::CommandLaunch(const std::string& name, SlangShader* shader, dim3 thread_group_size,
+                             const std::string& invocations_size_of_name, dim3 invocations)
     : name_(name),
       shader_(shader),
-      block_size_(block_size),
-      grid_size_of_name_(grid_size_of_name),
-      grid_size_(grid_size) {
+      thread_group_size_(thread_group_size),
+      invocations_size_of_name_(invocations_size_of_name),
+      invocations_(invocations) {
   // Get the kernel for the entry point
   kernel_ = shader_->get_kernel(name_);
+
+  if ((thread_group_size_.x == 1) && (thread_group_size_.y == 1) && (thread_group_size_.z == 1)) {
+    int min_threads_per_block, min_blocks_per_grid;
+    CUDA_CALL(
+        cudaOccupancyMaxPotentialBlockSize(&min_blocks_per_grid, &min_threads_per_block, kernel_));
+    /// @todo this assumes a 2D kernel, add a way for the user to specify dimensionality
+    thread_group_size_ = dim3(1, 1, 1);
+    while (static_cast<int>(thread_group_size_.x * thread_group_size_.y * 2) <=
+           min_threads_per_block) {
+      if (thread_group_size_.x > thread_group_size_.y) {
+        thread_group_size_.y *= 2;
+      } else {
+        thread_group_size_.x *= 2;
+      }
+    }
+    HOLOSCAN_LOG_DEBUG("CommandLaunch: Autodetected thread group size: {}x{}x{}",
+                       thread_group_size_.x,
+                       thread_group_size_.y,
+                       thread_group_size_.z);
+  }
 }
 
 void CommandLaunch::execute(CommandWorkspace& workspace) {
   HOLOSCAN_LOG_DEBUG("CommandLaunch: {}", name_);
 
-  // Setup the grid size
-  dim3 grid_size(1, 1, 1);
-  if (!grid_size_of_name_.empty()) {
-    auto reference_entity = workspace.entities_.find(grid_size_of_name_);
-    if (reference_entity == workspace.entities_.end()) {
-      throw std::runtime_error(
-          fmt::format("Attribute 'grid_size_of': input '{}' not found.", grid_size_of_name_));
-    }
-    auto maybe_reference_tensor =
-        static_cast<nvidia::gxf::Entity&>(reference_entity->second).get<nvidia::gxf::Tensor>();
-    if (!maybe_reference_tensor) {
-      throw std::runtime_error(
-          fmt::format("Attribute 'grid_size_of': input '{}' is not a tensor.", grid_size_of_name_));
-    }
-    auto reference_tensor = maybe_reference_tensor.value();
-    auto shape = reference_tensor->shape();
-    grid_size.x = shape.dimension(0);
-    if (shape.rank() > 1) {
-      grid_size.y = shape.dimension(1);
-      if (shape.rank() > 2) {
-        grid_size.z = shape.dimension(2);
-      }
-    }
+  // Setup the invocation size
+  dim3 invocations;
+  if (!invocations_size_of_name_.empty()) {
+    auto [invocations_size_of_remainder, swizzle] = split(invocations_size_of_name_, '.');
+
+    auto [reference_shape, reference_strides, reference_storage_type] =
+        get_reference_specs(workspace, invocations_size_of_remainder, "invocations_size_of");
+    const auto swizzled_shape = swizzle_shape(reference_shape, swizzle);
+    // If we don't swizzle, we need to skip the element count, else the user is responsible for
+    // setting the swizzle correctly
+    invocations = shape_to_uint3(swizzled_shape, swizzle.empty());
   } else {
-    grid_size = grid_size_;
+    invocations = invocations_;
   }
 
-  grid_size = dim3((grid_size.x + block_size_.x - 1) / block_size_.x,
-                   (grid_size.y + block_size_.y - 1) / block_size_.y,
-                   (grid_size.z + block_size_.z - 1) / block_size_.z);
+  // limit thread group size to invocations
+  const dim3 actual_thread_group_size = dim3(std::min(thread_group_size_.x, invocations.x),
+                                             std::min(thread_group_size_.y, invocations.y),
+                                             std::min(thread_group_size_.z, invocations.z));
+
+  // Calculate the grid size
+  const dim3 grid_size =
+      dim3((invocations.x + actual_thread_group_size.x - 1) / actual_thread_group_size.x,
+           (invocations.y + actual_thread_group_size.y - 1) / actual_thread_group_size.y,
+           (invocations.z + actual_thread_group_size.z - 1) / actual_thread_group_size.z);
 
   // Set the global params
-  shader_->update_global_params(workspace.shader_parameters_);
+  if (!workspace.shader_parameters_.empty()) {
+    shader_->update_global_params(name_, workspace.shader_parameters_, workspace.cuda_stream_);
+  }
 
   // Launch the kernel
-  CUDA_CALL(cudaLaunchKernel(kernel_, grid_size, block_size_, nullptr, 0, workspace.cuda_stream_));
+  CUDA_CALL(cudaLaunchKernel(
+      kernel_, grid_size, actual_thread_group_size, nullptr, 0, workspace.cuda_stream_));
+}
+
+CommandZeros::CommandZeros(const std::string& resource_name) : resource_name_(resource_name) {}
+
+void CommandZeros::execute(CommandWorkspace& workspace) {
+  HOLOSCAN_LOG_DEBUG("CommandZeros: {}", resource_name_);
+
+  // Get the pointer and size of the data
+  auto resource_info = workspace.cuda_resource_pointers_[resource_name_];
+
+  // Initialize the data to zero
+  CUDA_CALL(cudaMemsetAsync(resource_info.pointer, 0, resource_info.size, workspace.cuda_stream_));
 }
 
 }  // namespace holoscan::ops

--- a/operators/slang_shader/cuda_utils.hpp
+++ b/operators/slang_shader/cuda_utils.hpp
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CUDA_UTILS_HPP
+#define CUDA_UTILS_HPP
+
+#include <cuda_runtime.h>
+#include <memory>
+#include <fmt/format.h>
+
+namespace holoscan::ops {
+
+/**
+ * @brief Macro for safe CUDA Runtime API calls with automatic error handling
+ *
+ * This macro executes a CUDA Runtime statement and automatically checks for errors.
+ * If the call fails, it throws a std::runtime_error with detailed information
+ * including the statement, line number, file name, and CUDA error description.
+ *
+ * Usage:
+ *   CUDA_CALL(cudaMalloc(&ptr, size));
+ *
+ * @param stmt The CUDA Runtime statement to execute
+ * @param ... Additional parameters (unused, kept for compatibility)
+ * @throws std::runtime_error if the CUDA call fails
+ */
+#define CUDA_CALL(stmt, ...)                                                               \
+  ({                                                                                       \
+    cudaError_t _holoscan_cuda_err = stmt;                                                 \
+    if (cudaSuccess != _holoscan_cuda_err) {                                               \
+      throw std::runtime_error(                                                            \
+          fmt::format("CUDA Runtime call {} in line {} of file {} failed with '{}' ({}).", \
+                      #stmt,                                                               \
+                      __LINE__,                                                            \
+                      __FILE__,                                                            \
+                      cudaGetErrorString(_holoscan_cuda_err),                              \
+                      static_cast<int>(_holoscan_cuda_err)));                              \
+    }                                                                                      \
+  })
+
+/**
+ * @brief Custom deleter for CUDA objects managed by unique_ptr
+ *
+ * This template provides a custom deleter for CUDA objects that need
+ * to be properly cleaned up when managed by std::unique_ptr. It calls
+ * the specified cleanup function when the unique_ptr goes out of scope.
+ *
+ * @tparam T The CUDA object type
+ * @tparam func The cleanup function to call (e.g., cudaLibraryUnload)
+ */
+template <typename T, cudaError_t func(T)>
+struct Deleter {
+  typedef T pointer;
+  /**
+   * @brief Operator to call the cleanup function
+   *
+   * @param value The CUDA object to clean up
+   */
+  void operator()(T value) const { func(value); }
+};
+
+/**
+ * @brief Type alias for a unique_ptr that manages CUDA library handles
+ *
+ * This type provides automatic cleanup of CUDA library handles using
+ * cudaLibraryUnload when the unique_ptr goes out of scope.
+ */
+using UniqueCudaLibrary =
+    std::unique_ptr<cudaLibrary_t, Deleter<cudaLibrary_t, &cudaLibraryUnload>>;
+
+/**
+ * @brief Type alias for a unique_ptr that manages CUDA host memory
+ *
+ * This type provides automatic cleanup of CUDA host memory using cudaFreeHost
+ * when the unique_ptr goes out of scope.
+ */
+using UniqueCudaHostMemory = std::unique_ptr<void, Deleter<void*, &cudaFreeHost>>;
+
+}  // namespace holoscan::ops
+
+#endif /* CUDA_UTILS_HPP */

--- a/operators/slang_shader/holoscan.slang
+++ b/operators/slang_shader/holoscan.slang
@@ -21,6 +21,36 @@
  * This file defines custom attributes used by the Holoscan framework to annotate
  * Slang shader code for GPU compute operations. These attributes help the Holoscan
  * runtime understand how to bind resources and configure compute kernels.
+ *
+ * Resource Name String Construction
+ *
+ * Resource names in Holoscan attributes follow a specific format to identify and bind
+ * resources to shader variables. The name string can take several forms:
+ *
+ * 1. Simple Resource Name:
+ *    - Format: "resource_name"
+ *    - Example: "input_buffer", "output_tensor"
+ *    - Used when referencing a single resource directly
+ *
+ * 2. Tensor Map Reference:
+ *    - Format: "tensor_map_name:tensor_name"
+ *    - Example: "model:weights", "data:input_image"
+ *    - Used when the resource is part of a named tensor map, where the part before
+ *      the colon identifies the tensor map and the part after identifies the specific
+ *      tensor within that map
+ *
+ * 3. \anchor swizzle Resource with swizzle (for allocation and invocations size attributes):
+ *    - Format: "resource_name.swizzle_string"
+ *    - Example: "input_tensor:image.cx", "output_buffer.xy"
+ *    - The swizzle string selects specific dimensions of the resource for size matching
+ *    - Allowed characters: "x", "y", "z", "c", "0" - "9"
+ *      where "c" is the component count and "0" - "9" static values.
+ *
+ * Examples:
+ * - [holoscan_input("input_data")] - Binds to a resource named "input_data"
+ * - [holoscan_output("model:output")] - Binds to the "output" tensor in the "model" tensor map
+ * - [holoscan_alloc_size_of("input_tensor.cx")] - Allocates based on the x dimension of
+ * "input_tensor"
  */
 
 /**
@@ -31,9 +61,8 @@
  *             to bind the appropriate data source.
  */
 [__AttributeUsage(_AttributeTargets.Var)]
-public struct holoscan_inputAttribute
-{
-    string name;
+public struct holoscan_inputAttribute {
+  string name;
 };
 
 /**
@@ -44,9 +73,8 @@ public struct holoscan_inputAttribute
  *             to bind the appropriate data destination.
  */
 [__AttributeUsage(_AttributeTargets.Var)]
-public struct holoscan_outputAttribute
-{
-    string name;
+public struct holoscan_outputAttribute {
+  string name;
 };
 
 /**
@@ -54,61 +82,97 @@ public struct holoscan_outputAttribute
  * Used for values that can be modified without recompiling the shader.
  *
  * @param name The identifier for the parameter, used by the Holoscan runtime
- *             to set the parameter value dynamically.
+ *             to set the parameter value dynamically. The name can be followed by an equals sign
+ *             and a default value. The default value must be a string which can be converted to
+ *             the type of the parameter. If the default value is not provided, the parameter is
+ *             required to be set at runtime, e.g. in the operator spec.
  */
 [__AttributeUsage(_AttributeTargets.Var)]
-public struct holoscan_parameterAttribute
-{
-    string name;
+public struct holoscan_parameterAttribute {
+  string name;
 };
 
 /**
- * Set the value of a parameter to the size of a resource.
+ * Set the value of a parameter to the size of a resource. The parameter must be a uint3.
  *
  * @param name The name of the reference resource whose size will be set to the parameter.
  */
 [__AttributeUsage(_AttributeTargets.Var)]
-public struct holoscan_size_ofAttribute
-{
-    string name;
+public struct holoscan_size_ofAttribute {
+  string name;
+};
+
+/**
+ * Set the value of a parameter to the strides of a resource. The parameter must be a uint64_t3. The
+ * strides are the number of bytes between elements in each dimension. E.g. the x component of the
+ * strides is the number of bytes between elements in the x dimension.
+ *
+ * @param name The name of the reference resource whose strides will be set to the parameter.
+ */
+[__AttributeUsage(_AttributeTargets.Var)]
+public struct holoscan_strides_ofAttribute {
+  string name;
 };
 
 /**
  * Specifies the allocation size of a resource based on another resource's dimensions.
  * Used when allocating memory for a resource that needs to match another resource's size.
+ * The storage type of the allocated resource is set to the storage type of the reference resource.
  *
- * @param name The name of the reference resource whose allocation size should be matched.
+ * @param name The name of the reference resource whose allocation size should be matched. Supports
+ * a swizzle string after a dot. See \ref swizzle "Resource with swizzle" section above for format
+ * details.
  */
 [__AttributeUsage(_AttributeTargets.Var)]
-public struct holoscan_alloc_size_ofAttribute
-{
-    string name;
+public struct holoscan_alloc_size_ofAttribute {
+  string name;
 };
 
 /**
- * Specifies the grid dimensions for a compute kernel.
- * Defines how many threads will be launched in each dimension.
+ * Specifies the allocation size of a resource. The storage type is set to device.
  *
- * @param x Number of threads in the X dimension
- * @param y Number of threads in the Y dimension
- * @param z Number of threads in the Z dimension
+ * @param x Number of elements in the X dimension
+ * @param y Number of elements in the Y dimension
+ * @param z Number of elements in the Z dimension
  */
-[__AttributeUsage(_AttributeTargets.Function)]
-public struct holoscan_grid_sizeAttribute
-{
-    int x;
-    int y;
-    int z;
+[__AttributeUsage(_AttributeTargets.Var)]
+public struct holoscan_allocAttribute {
+  uint x;
+  uint y;
+  uint z;
 };
 
 /**
- * Specifies the grid dimensions for a compute kernel based on a resource's size.
- * The grid size is automatically calculated based on the dimensions of the specified resource.
+ * Specifies the invocation size for a compute kernel.
+ * Defines how many invocations will be launched in each dimension.
  *
- * @param name The name of the resource whose dimensions should be used to calculate grid size.
+ * @param x Number of invocations in the X dimension
+ * @param y Number of invocations in the Y dimension
+ * @param z Number of invocations in the Z dimension
  */
 [__AttributeUsage(_AttributeTargets.Function)]
-public struct holoscan_grid_size_ofAttribute
-{
-    string name;
+public struct holoscan_invocationsAttribute {
+  uint x;
+  uint y;
+  uint z;
 };
+
+/**
+ * Specifies the invocation size for a compute kernel based on a resource's size.
+ * The invocation size is automatically calculated based on the dimensions of the specified
+ * resource.
+ *
+ * @param name The name of the resource whose size should be used to calculate invocation size.
+ *             Supports swizzle string after a dot. See \ref swizzle "Resource with swizzle" section
+ * above for format details.
+ */
+[__AttributeUsage(_AttributeTargets.Function)]
+public struct holoscan_invocations_size_ofAttribute {
+  string name;
+};
+
+/**
+ * Specifies that the resource should be initialized to zero.
+ */
+[__AttributeUsage(_AttributeTargets.Var)]
+public struct holoscan_zerosAttribute {};

--- a/operators/slang_shader/slang_utils.cpp
+++ b/operators/slang_shader/slang_utils.cpp
@@ -1,12 +1,12 @@
 /*
- * SPDXFileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDXLicenseIdentifier: Apache2.0
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 #include "slang_utils.hpp"
 
@@ -52,6 +53,151 @@ const char* get_error_string(Slang::Result result) {
     default:
       return "Unknown Slang error";
   }
+}
+
+std::pair<std::string, std::string> split(const std::string& s, char separator) {
+  auto colon_pos = s.find(separator);
+  if (colon_pos != std::string::npos) {
+    return {s.substr(0, colon_pos), s.substr(colon_pos + 1)};
+  } else {
+    return {s, ""};
+  }
+}
+
+std::string to_lower(const std::string& s) {
+  std::string s_lower = s;
+  std::transform(s_lower.begin(), s_lower.end(), s_lower.begin(), [](unsigned char c) {
+    return std::tolower(c);
+  });
+  return s_lower;
+}
+
+/**
+ * @brief Converts a string to a boolean
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+bool from_string(const std::string& s) {
+  const std::string s_lower = to_lower(s);
+  if (s_lower == "true") {
+    return true;
+  } else if (s_lower == "false") {
+    return false;
+  } else {
+    throw std::runtime_error(fmt::format("Invalid boolean value: {}", s));
+  }
+}
+
+/**
+ * @brief Converts a string to an int8_t
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+int8_t from_string(const std::string& s) {
+  return static_cast<int8_t>(std::stoi(s));
+}
+
+/**
+ * @brief Converts a string to a uint8_t
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+uint8_t from_string(const std::string& s) {
+  return static_cast<uint8_t>(std::stoul(s));
+}
+
+/**
+ * @brief Converts a string to an int16_t
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+int16_t from_string(const std::string& s) {
+  return static_cast<int16_t>(std::stoi(s));
+}
+
+/**
+ * @brief Converts a string to a uint16_t
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+uint16_t from_string(const std::string& s) {
+  return static_cast<uint16_t>(std::stoul(s));
+}
+
+/**
+ * @brief Converts a string to an int32_t
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+int32_t from_string(const std::string& s) {
+  return static_cast<int32_t>(std::stoi(s));
+}
+
+/**
+ * @brief Converts a string to a uint32_t
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+uint32_t from_string(const std::string& s) {
+  return static_cast<uint32_t>(std::stoul(s));
+}
+
+/**
+ * @brief Converts a string to an int64_t
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+int64_t from_string(const std::string& s) {
+  return static_cast<int64_t>(std::stoll(s));
+}
+
+/**
+ * @brief Converts a string to a uint64_t
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+uint64_t from_string(const std::string& s) {
+  return static_cast<uint64_t>(std::stoull(s));
+}
+
+/**
+ * @brief Converts a string to a float
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+float from_string(const std::string& s) {
+  return static_cast<float>(std::stof(s));
+}
+
+/**
+ * @brief Converts a string to a double
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+double from_string(const std::string& s) {
+  return static_cast<double>(std::stod(s));
 }
 
 }  // namespace holoscan::ops

--- a/operators/slang_shader/slang_utils.hpp
+++ b/operators/slang_shader/slang_utils.hpp
@@ -18,10 +18,8 @@
 #ifndef SLANG_UTILS_HPP
 #define SLANG_UTILS_HPP
 
-#include <cuda_runtime.h>
 #include <slang-com-helper.h>
 #include <holoscan/logger/logger.hpp>
-#include <memory>
 
 namespace holoscan::ops {
 
@@ -112,62 +110,130 @@ const char* get_error_string(Slang::Result result);
   }
 
 /**
- * @brief Macro for safe CUDA Runtime API calls with automatic error handling
+ * Splits a string into a pair of strings, separated by a separator.
  *
- * This macro executes a CUDA Runtime statement and automatically checks for errors.
- * If the call fails, it throws a std::runtime_error with detailed information
- * including the statement, line number, file name, and CUDA error description.
- *
- * Usage:
- *   CUDA_CALL(cudaMalloc(&ptr, size));
- *
- * @param stmt The CUDA Runtime statement to execute
- * @param ... Additional parameters (unused, kept for compatibility)
- * @throws std::runtime_error if the CUDA call fails
+ * @param s The string to split
+ * @param separator The separator to use
+ * @return A pair of strings, the first is the part before the colon, the second is the part after
  */
-#define CUDA_CALL(stmt, ...)                                                               \
-  ({                                                                                       \
-    cudaError_t _holoscan_cuda_err = stmt;                                                 \
-    if (cudaSuccess != _holoscan_cuda_err) {                                               \
-      throw std::runtime_error(                                                            \
-          fmt::format("CUDA Runtime call {} in line {} of file {} failed with '{}' ({}).", \
-                      #stmt,                                                               \
-                      __LINE__,                                                            \
-                      __FILE__,                                                            \
-                      cudaGetErrorString(_holoscan_cuda_err),                              \
-                      static_cast<int>(_holoscan_cuda_err)));                              \
-    }                                                                                      \
-  })
+std::pair<std::string, std::string> split(const std::string& s, char separator);
 
 /**
- * @brief Custom deleter for CUDA objects managed by unique_ptr
+ * @brief Converts a string to lowercase
  *
- * This template provides a custom deleter for CUDA objects that need
- * to be properly cleaned up when managed by std::unique_ptr. It calls
- * the specified cleanup function when the unique_ptr goes out of scope.
- *
- * @tparam T The CUDA object type
- * @tparam func The cleanup function to call (e.g., cudaLibraryUnload)
+ * @param s The string to convert
+ * @return The lowercase string
  */
-template <typename T, cudaError_t func(T)>
-struct Deleter {
-  typedef T pointer;
-  /**
-   * @brief Operator to call the cleanup function
-   *
-   * @param value The CUDA object to clean up
-   */
-  void operator()(T value) const { func(value); }
-};
+std::string to_lower(const std::string& s);
 
 /**
- * @brief Type alias for a unique_ptr that manages CUDA library handles
+ * @brief Converts a string to a specific type
  *
- * This type provides automatic cleanup of CUDA library handles using
- * cudaLibraryUnload when the unique_ptr goes out of scope.
+ * @tparam typeT The type to convert to
+ * @param s The string to convert
+ * @return The converted value
  */
-using UniqueCudaLibrary =
-    std::unique_ptr<cudaLibrary_t, Deleter<cudaLibrary_t, &cudaLibraryUnload>>;
+template <typename typeT>
+typeT from_string(const std::string& s);
+
+/**
+ * @brief Converts a string to a boolean
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+bool from_string(const std::string& s);
+
+/**
+ * @brief Converts a string to an int8_t
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+int8_t from_string(const std::string& s);
+
+/**
+ * @brief Converts a string to a uint8_t
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+uint8_t from_string(const std::string& s);
+
+/**
+ * @brief Converts a string to an int16_t
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+int16_t from_string(const std::string& s);
+
+/**
+ * @brief Converts a string to a uint16_t
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+uint16_t from_string(const std::string& s);
+
+/**
+ * @brief Converts a string to an int32_t
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+int32_t from_string(const std::string& s);
+
+/**
+ * @brief Converts a string to a uint32_t
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+uint32_t from_string(const std::string& s);
+
+/**
+ * @brief Converts a string to an int64_t
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+int64_t from_string(const std::string& s);
+
+/**
+ * @brief Converts a string to a uint64_t
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+uint64_t from_string(const std::string& s);
+
+/**
+ * @brief Converts a string to a float
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+float from_string(const std::string& s);
+
+/**
+ * @brief Converts a string to a double
+ *
+ * @param s The string to convert
+ * @return The converted value
+ */
+template <>
+double from_string(const std::string& s);
 
 }  // namespace holoscan::ops
 

--- a/operators/slang_shader/test/CMakeLists.txt
+++ b/operators/slang_shader/test/CMakeLists.txt
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fetch GoogleTest
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+)
+FetchContent_MakeAvailable(googletest)
+
+# Create test executable
+add_executable(slang_shader_test
+  test_slang_shader_op.cpp
+)
+
+# Link libraries
+target_link_libraries(slang_shader_test
+  holoscan::core
+  GXF::multimedia
+  holoscan::ops::slang_shader
+  GTest::gtest_main
+  GTest::gmock
+)
+
+# Include directories
+target_include_directories(slang_shader_test
+  PRIVATE
+    ${CMAKE_SOURCE_DIR}/operators/slang_shader
+)
+
+# Add test to CTest
+add_test(NAME slang_shader_test COMMAND slang_shader_test)

--- a/operators/slang_shader/test/test_slang_shader_op.cpp
+++ b/operators/slang_shader/test/test_slang_shader_op.cpp
@@ -1,0 +1,819 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+
+#include <holoscan/holoscan.hpp>
+
+#include "slang_shader_op.hpp"
+
+#include "cuda_utils.hpp"
+
+using namespace holoscan::ops;
+
+class SlangShaderOpTest : public ::testing::Test {
+ protected:
+  void SetUp() override { fragment_ = std::make_shared<holoscan::Fragment>(); }
+
+  void TearDown() override { fragment_.reset(); }
+
+  std::shared_ptr<holoscan::Fragment> fragment_;
+};
+
+static const char g_simple_shader[] = R"(
+  import holoscan;
+
+  [holoscan::input("input_buffer")]
+  StructuredBuffer<int> input_buffer;
+
+  [holoscan::output("output_buffer")]
+  [holoscan::alloc::size_of("input_buffer")]
+  RWStructuredBuffer<int> output_buffer;
+
+  [shader("compute")]
+  void compute(uint3 gid : SV_DispatchThreadID) {
+    output_buffer[gid.x] = input_buffer[gid.x];
+  }
+)";
+
+// Test basic operator construction
+TEST_F(SlangShaderOpTest, Construction) {
+  EXPECT_NO_THROW({
+    auto op = fragment_->make_operator<SlangShaderOp>(
+        "slang_shader_op", holoscan::Arg("shader_source", g_simple_shader));
+    EXPECT_NE(op, nullptr);
+  });
+}
+
+// Test operator setup with empty shader source (should throw)
+TEST_F(SlangShaderOpTest, SetupWithEmptyShaderSource) {
+  EXPECT_THROW(fragment_->make_operator<SlangShaderOp>("slang_shader_op",
+                                                       holoscan::Arg("shader_source", "")),
+               std::runtime_error);
+}
+
+// Test operator setup with invalid shader file (should throw)
+TEST_F(SlangShaderOpTest, SetupWithInvalidShaderFile) {
+  EXPECT_THROW(fragment_->make_operator<SlangShaderOp>(
+                   "slang_shader_op", holoscan::Arg("shader_source_file", "some_file.slang")),
+               std::runtime_error);
+}
+
+// Test operator setup with both shader_source and shader_source_file (should throw)
+TEST_F(SlangShaderOpTest, SetupWithBothShaderSources) {
+  EXPECT_THROW(fragment_->make_operator<SlangShaderOp>(
+                   "slang_shader_op",
+                   holoscan::Arg("shader_source", "some shader code"),
+                   holoscan::Arg("shader_source_file", "some_file.slang")),
+               std::runtime_error);
+}
+
+namespace holoscan::ops {
+
+class SourceOp : public Operator {
+ public:
+  HOLOSCAN_OPERATOR_FORWARD_ARGS(SourceOp)
+  SourceOp() = default;
+
+  void setup(OperatorSpec& spec) override {
+    spec.param(allocator_,
+               "allocator",
+               "Allocator for output buffers.",
+               "Allocator for output buffers.",
+               std::static_pointer_cast<Allocator>(
+                   fragment()->make_resource<UnboundedAllocator>("allocator")));
+    spec.output<nvidia::gxf::Entity>("output");
+  }
+
+  void initialize() override {
+    // Add the allocator to the operator so that it is initialized
+    add_arg(allocator_.default_value());
+
+    // Call the base class initialize function
+    Operator::initialize();
+  }
+
+  void compute(InputContext& op_input, OutputContext& op_output,
+               ExecutionContext& context) override {
+    auto entity = gxf::Entity::New(&context);
+    auto tensor =
+        static_cast<nvidia::gxf::Entity&>(entity).add<nvidia::gxf::Tensor>("item").value();
+    // Get Handle to underlying nvidia::gxf::Allocator from std::shared_ptr<Allocator>
+    auto gxf_allocator = nvidia::gxf::Handle<nvidia::gxf::Allocator>::Create(
+        context.context(), allocator_.get()->gxf_cid());
+    tensor->reshape<int>(
+        nvidia::gxf::Shape({1, 1}), nvidia::gxf::MemoryStorageType::kHost, gxf_allocator.value());
+
+    int value = 42;
+    std::memcpy(tensor->pointer(), &value, sizeof(value));
+
+    op_output.emit(entity, "output");
+  };
+
+ private:
+  Parameter<std::shared_ptr<Allocator>> allocator_;
+};
+
+class VideoBufferSourceOp : public Operator {
+ public:
+  HOLOSCAN_OPERATOR_FORWARD_ARGS(VideoBufferSourceOp)
+  VideoBufferSourceOp() = default;
+
+  void setup(OperatorSpec& spec) override {
+    spec.param(allocator_,
+               "allocator",
+               "Allocator for output buffers.",
+               "Allocator for output buffers.",
+               std::static_pointer_cast<Allocator>(
+                   fragment()->make_resource<UnboundedAllocator>("allocator")));
+    spec.output<nvidia::gxf::Entity>("output");
+  }
+
+  void initialize() override {
+    // Add the allocator to the operator so that it is initialized
+    add_arg(allocator_.default_value());
+
+    // Call the base class initialize function
+    Operator::initialize();
+  }
+
+  void compute(InputContext& op_input, OutputContext& op_output,
+               ExecutionContext& context) override {
+    auto entity = gxf::Entity::New(&context);
+    auto video_buffer =
+        static_cast<nvidia::gxf::Entity&>(entity).add<nvidia::gxf::VideoBuffer>("item").value();
+    // Get Handle to underlying nvidia::gxf::Allocator from std::shared_ptr<Allocator>
+    auto gxf_allocator = nvidia::gxf::Handle<nvidia::gxf::Allocator>::Create(
+        context.context(), allocator_.get()->gxf_cid());
+    video_buffer->resize<nvidia::gxf::VideoFormat::GXF_VIDEO_FORMAT_RGBA>(
+        2,
+        3,
+        nvidia::gxf::SurfaceLayout::GXF_SURFACE_LAYOUT_PITCH_LINEAR,
+        nvidia::gxf::MemoryStorageType::kHost,
+        gxf_allocator.value(),
+        false /* stride_align */);
+
+    uint8_t value[2 * 3 * 4];
+    for (int i = 0; i < 2 * 3 * 4; i++) { value[i] = 42 + i; }
+    std::memcpy(video_buffer->pointer(), value, sizeof(value));
+
+    op_output.emit(entity, "output");
+  };
+
+ private:
+  Parameter<std::shared_ptr<Allocator>> allocator_;
+};
+
+class SinkOp : public Operator {
+ public:
+  HOLOSCAN_OPERATOR_FORWARD_ARGS(SinkOp)
+
+  SinkOp() = default;
+
+  void setup(OperatorSpec& spec) override { spec.input<gxf::Entity>("input"); }
+
+  void compute([[maybe_unused]] InputContext& op_input, OutputContext& op_output,
+               [[maybe_unused]] ExecutionContext& context) override {
+    auto tensor = op_input.receive<std::shared_ptr<holoscan::Tensor>>("input").value();
+    EXPECT_GE(tensor->nbytes(), sizeof(int));
+    int value = 0;
+    CUDA_CALL(cudaMemcpy(&value, tensor->data(), sizeof(value), cudaMemcpyDefault));
+    std::cout << value << std::endl;
+  };
+};
+
+}  // namespace holoscan::ops
+
+/**
+ * Test application for SlangShaderOp integration testing.
+ * Supports flexible pipeline composition with optional source/sink operators.
+ */
+class SlangShaderApp : public holoscan::Application {
+ public:
+  /** Constructs app with shader source and optional args for SlangShaderOp */
+  explicit SlangShaderApp(const std::string& shader_source, const holoscan::ArgList& args = {})
+      : args_(args) {
+    args_.add(holoscan::Arg("shader_source", shader_source));
+  }
+  SlangShaderApp() = delete;
+
+  /** Enables source operator that generates test data (tensor with value 42) */
+  void add_source_op(const std::string& input = "input") { source_ops_.push_back(input); }
+
+  /** Enables source operator that generates test data (video buffer with value 42) */
+  void add_video_buffer_source_op() { add_video_buffer_source_op_ = true; }
+
+  /** Enables sink operator that validates SlangShaderOp output */
+  void add_sink_op(const std::string& input = "input") { sink_ops_.push_back(input); }
+
+  /**
+   * Composes pipeline based on enabled flags:
+   * - SourceOp -> SlangShaderOp (if add_source_op_)
+   * - SlangShaderOp -> SinkOp (if add_sink_op_)
+   * - SourceOp -> SlangShaderOp -> SinkOp (if both)
+   * - SlangShaderOp only (if neither)
+   */
+  void compose() override {
+    auto op = make_operator<SlangShaderOp>(
+        "slang_shader_op", args_, make_condition<holoscan::CountCondition>(1));
+    if (source_ops_.size() == 1) {
+      auto source_op = make_operator<SourceOp>(fmt::format("source_op"));
+      add_flow(source_op, op);
+    } else {
+      for (const auto& input : source_ops_) {
+        auto source_op = make_operator<SourceOp>(fmt::format("source_op_{}", input));
+        add_flow(source_op, op, {{"output", input}});
+      }
+    }
+    if (add_video_buffer_source_op_) {
+      auto source_op = make_operator<VideoBufferSourceOp>("video_buffer_source_op");
+      add_flow(source_op, op);
+    }
+    if (sink_ops_.size() == 1) {
+      auto sink_op = make_operator<SinkOp>(fmt::format("sink_op"));
+      add_flow(op, sink_op);
+    } else {
+      for (const auto& output : sink_ops_) {
+        auto sink_op = make_operator<SinkOp>(fmt::format("sink_op_{}", output));
+        add_flow(op, sink_op, {{output, "input"}});
+      }
+    }
+    if (source_ops_.empty() && sink_ops_.empty()) {
+      add_operator(op);
+    }
+  }
+
+  /**
+   * Runs app and validates expected output in stdout.
+   * Captures both stdout/stderr and checks for expected output and no errors.
+   */
+  void check_output(std::string expected_output) {
+    // capture output so that we can check that the expected value is present
+    testing::internal::CaptureStderr();
+    testing::internal::CaptureStdout();
+
+    EXPECT_NO_THROW(run());
+
+    // Synchronize to ensure that the output is captured
+    CUDA_CALL(cudaDeviceSynchronize());
+
+    std::string stdout_output = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(stdout_output, testing::Eq(expected_output));
+
+    std::string stderr_output = testing::internal::GetCapturedStderr();
+    EXPECT_THAT(stderr_output, testing::Not(testing::HasSubstr("error")));
+  }
+
+  holoscan::ArgList args_;               ///< Arguments passed to the SlangShaderOp
+  std::vector<std::string> source_ops_;  ///< Flag to enable source operator in pipeline
+  bool add_video_buffer_source_op_ =
+      false;                           ///< Flag to enable video buffer source operator in pipeline
+  std::vector<std::string> sink_ops_;  ///< Flag to enable sink operator in pipeline
+};
+
+// Test operator execution
+TEST(SlangShaderAppTest, HelloWorld) {
+  const std::string shader_source = R"(
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      printf("Hello, world!");
+    }
+  )";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+  application->check_output("Hello, world!");
+}
+
+TEST(SlangShaderAppTest, Parameter) {
+  const std::string shader_source = R"(
+    import holoscan;
+
+    [holoscan::parameter("parameter")]
+    float parameter;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      printf("%f", parameter);
+    }
+  )";
+
+  auto application = holoscan::make_application<SlangShaderApp>(
+      shader_source, holoscan::ArgList({holoscan::Arg("parameter", 1.0f)}));
+
+  application->check_output("1.000000");
+}
+
+TEST(SlangShaderAppTest, ParameterWithDefault) {
+  const std::string shader_source = R"(
+    import holoscan;
+
+    [holoscan::parameter("parameter=12")]
+    int parameter;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      printf("%d", parameter);
+    }
+  )";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+
+  application->check_output("12");
+}
+
+TEST(SlangShaderAppTest, InputTensor) {
+  const std::string shader_source = R"(
+    import holoscan;
+
+    [holoscan::input("input_buffer")]
+    StructuredBuffer<int> input_buffer;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      printf("%d", input_buffer[gid.x]);
+    }
+  )";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+  application->add_source_op();
+
+  application->check_output("42");
+}
+
+TEST(SlangShaderAppTest, InputMultipleTensors) {
+  const std::string shader_source = R"(
+    import holoscan;
+
+    [holoscan::input("input_buffer_1")]
+    StructuredBuffer<int> input_buffer_1;
+
+    [holoscan::input("input_buffer_2")]
+    StructuredBuffer<int> input_buffer_2;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      printf("%d %d", input_buffer_1[gid.x], input_buffer_2[gid.x]);
+    }
+  )";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+  application->add_source_op("input_buffer_1");
+  application->add_source_op("input_buffer_2");
+
+  application->check_output("42 42");
+}
+
+TEST(SlangShaderAppTest, InputTensorMap) {
+  const std::string shader_source = R"(
+    import holoscan;
+
+    [holoscan::input("input_buffer:item")]
+    StructuredBuffer<int> input_buffer;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      printf("%d", input_buffer[gid.x]);
+    }
+  )";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+  application->add_source_op();
+
+  application->check_output("42");
+}
+
+TEST(SlangShaderAppTest, InputVideoBuffer) {
+  const std::string shader_source = R"(
+    import holoscan;
+
+    [holoscan::input("input_buffer:item")]
+    StructuredBuffer<uint8_t4> input_buffer;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      printf("%d %d %d %d", input_buffer[gid.x].x, input_buffer[gid.x].y, input_buffer[gid.x].z,
+             input_buffer[gid.x].w);
+    }
+  )";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+  application->add_video_buffer_source_op();
+
+  application->check_output("42 43 44 45");
+}
+
+TEST(SlangShaderAppTest, OutputMultiple) {
+  const std::string shader_source = R"(
+    import holoscan;
+
+    [holoscan::output("output_buffer_1")]
+    [holoscan::alloc(1, 1, 1)]
+    RWStructuredBuffer<int> output_buffer_1;
+
+    [holoscan::output("output_buffer_2")]
+    [holoscan::alloc(1, 1, 1)]
+    RWStructuredBuffer<int> output_buffer_2;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      output_buffer_1[gid.x] = 4711;
+      output_buffer_2[gid.x] = 4712;
+    }
+  )";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+  application->add_sink_op("output_buffer_1");
+  application->add_sink_op("output_buffer_2");
+
+  application->check_output("4711\n4712\n");
+}
+
+TEST(SlangShaderAppTest, OutputAlloc) {
+  const std::string shader_source = R"(
+    import holoscan;
+
+    [holoscan::output("output_buffer")]
+    [holoscan::alloc(1, 1, 1)]
+    RWStructuredBuffer<int> output_buffer;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      output_buffer[gid.x] = 4711;
+    }
+  )";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+  application->add_sink_op();
+
+  application->check_output("4711\n");
+}
+
+TEST(SlangShaderAppTest, OutputAllocSizeOf) {
+  const std::string shader_source = R"(
+    import holoscan;
+
+    [holoscan::input("input_buffer")]
+    StructuredBuffer<int> input_buffer;
+
+    [holoscan::output("output_buffer")]
+    [holoscan::alloc::size_of("input_buffer")]
+    RWStructuredBuffer<int> output_buffer;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      output_buffer[gid.x] = input_buffer[gid.x];
+    }
+  )";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+  application->add_source_op();
+  application->add_sink_op();
+
+  application->check_output("42\n");
+}
+
+TEST(SlangShaderAppTest, OutputAllocSizeOfWithSwizzle) {
+  const std::string shader_source = R"(
+    import holoscan;
+
+    [holoscan::input("input_buffer")]
+    StructuredBuffer<int> input_buffer;
+
+    [holoscan::output("output_buffer")]
+    [holoscan::alloc::size_of("input_buffer.2x3")]
+    RWStructuredBuffer<int> output_buffer;
+
+    [holoscan::size_of("output_buffer")]
+    uint3 size;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      output_buffer[gid.x] = input_buffer[gid.x];
+      printf("%d %d %d\n", size.x, size.y, size.z);
+    }
+  )";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+  application->add_source_op();
+  application->add_sink_op();
+
+  application->check_output("2 1 3\n42\n");
+}
+
+TEST(SlangShaderAppTest, ParameterSizeOf) {
+  const std::string shader_source = R"(
+    import holoscan;
+
+    [holoscan::output("output_buffer")]
+    [holoscan::alloc(4, 5, 6)]
+    RWStructuredBuffer<int3> output_buffer;
+
+    [holoscan::size_of("output_buffer")]
+    uint3 size;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      printf("%d %d %d\n", size.x, size.y, size.z);
+    }
+  )";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+  application->add_sink_op();
+
+  application->check_output("4 5 6\n0\n");
+}
+
+TEST(SlangShaderAppTest, ParameterSizeOfError) {
+  std::list<std::pair<std::string, std::string>> shader_sources = {
+      {R"(
+    import holoscan;
+
+    [holoscan::output("output_buffer")]
+    [holoscan::alloc(4, 5, 6)]
+    RWStructuredBuffer<int3> output_buffer;
+
+    [holoscan::size_of("input_buffer")]
+    uint3 size;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+    }
+  )",
+       "Attribute 'size_of': input 'input_buffer' not found."},
+
+      {R"(
+    import holoscan;
+
+    [holoscan::output("output_buffer")]
+    [holoscan::alloc(4, 5, 6)]
+    RWStructuredBuffer<int3> output_buffer;
+
+    [holoscan::size_of("output_buffer")]
+    float size;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+    }
+  )",
+       "Attribute 'size_of' supports a three component uint32 vector (`uint3`) uniforms only and "
+       "cannot be applied to 'size'."},
+  };
+
+  for (const auto& [shader_source, expected_error] : shader_sources) {
+    auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+    application->add_sink_op();
+
+    testing::internal::CaptureStderr();
+    bool failed = false;
+
+    try {
+      application->run();
+    } catch (const std::runtime_error& e) {
+      failed = (e.what() != expected_error);
+      EXPECT_THAT(e.what(), testing::Eq(expected_error));
+    }
+
+    std::string stderr_output = testing::internal::GetCapturedStderr();
+    if (failed) {
+      std::cout << stderr_output;
+    }
+  }
+}
+
+TEST(SlangShaderAppTest, ParameterStridesOf) {
+  const std::string shader_source = R"(
+    import holoscan;
+
+    [holoscan::output("output_buffer")]
+    [holoscan::alloc(4, 5, 6)]
+    RWStructuredBuffer<int3> output_buffer;
+
+    [holoscan::strides_of("output_buffer")]
+    uint64_t3 strides;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      printf("%llu %llu %llu\n", strides.x, strides.y, strides.z);
+    }
+  )";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+  application->add_sink_op();
+
+  application->check_output("12 48 240\n0\n");
+}
+
+TEST(SlangShaderAppTest, ParameterStridesOfVideoBuffer) {
+  const std::string shader_source = R"(
+    import holoscan;
+
+    [holoscan::input("input_buffer")]
+    StructuredBuffer<uint8_t4> input_buffer;
+
+    [holoscan::strides_of("input_buffer")]
+    uint64_t3 strides;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      printf("%llu %llu %llu\n", strides.x, strides.y, strides.z);
+    }
+  )";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+  application->add_video_buffer_source_op();
+
+  // The video source has 4 bytes per pixel, a width of 2 and a height of 3
+  // This results in a x stride of 2 * 4 = 8, a y stride of 3 * 8 = 24 and a z stride of also 24.
+  application->check_output("8 24 24\n");
+}
+
+TEST(SlangShaderAppTest, ParameterStridesOfError) {
+  std::list<std::pair<std::string, std::string>> shader_sources = {
+      {R"(
+    import holoscan;
+
+    [holoscan::output("output_buffer")]
+    [holoscan::alloc(4, 5, 6)]
+    RWStructuredBuffer<int3> output_buffer;
+
+    [holoscan::strides_of("input_buffer")]
+    uint64_t3 strides;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+    }
+  )",
+       "Attribute 'strides_of': input 'input_buffer' not found."},
+
+      {R"(
+    import holoscan;
+
+    [holoscan::output("output_buffer")]
+    [holoscan::alloc(4, 5, 6)]
+    RWStructuredBuffer<int3> output_buffer;
+
+    [holoscan::strides_of("output_buffer")]
+    float strides;
+
+    [shader("compute")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+    }
+  )",
+       "Attribute 'strides_of' supports a three component uint64 vector (`uint64_t3`) uniforms "
+       "only and cannot be applied to 'strides'."},
+  };
+
+  for (const auto& [shader_source, expected_error] : shader_sources) {
+    auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+    application->add_sink_op();
+
+    testing::internal::CaptureStderr();
+    bool failed = false;
+
+    try {
+      application->run();
+    } catch (const std::runtime_error& e) {
+      failed = e.what() != expected_error;
+      EXPECT_THAT(e.what(), testing::Eq(expected_error));
+    }
+
+    std::string stderr_output = testing::internal::GetCapturedStderr();
+    if (failed) {
+      std::cout << stderr_output;
+    }
+  }
+}
+
+TEST(SlangShaderAppTest, Invocations) {
+  const std::string shader_source = R"r(
+    import holoscan;
+
+    uint3 get_invocations() {
+      __intrinsic_asm "make_uint3(blockDim.x * gridDim.x, blockDim.y * gridDim.y, blockDim.z * gridDim.z)";
+    }
+
+    [shader("compute")]
+    [holoscan::invocations(6, 5, 4)]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      if (gid.x == 0 && gid.y == 0 && gid.z == 0) {
+        uint3 invocations = get_invocations();
+        printf("%d %d %d", invocations.x, invocations.y, invocations.z);
+      }
+    }
+  )r";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+
+  application->check_output("6 5 4");
+}
+
+TEST(SlangShaderAppTest, InvocationsSizeOf) {
+  const std::string shader_source = R"r(
+    import holoscan;
+
+    [holoscan::output("output_buffer")]
+    [holoscan::alloc(4, 3, 2)]
+    RWStructuredBuffer<int3> output_buffer;
+
+    uint3 get_invocations() {
+      __intrinsic_asm "make_uint3(blockDim.x * gridDim.x, blockDim.y * gridDim.y, blockDim.z * gridDim.z)";
+    }
+
+    [shader("compute")]
+    [holoscan::invocations::size_of("output_buffer")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      output_buffer[gid.x] = gid.x;
+      if (gid.x == 0 && gid.y == 0 && gid.z == 0) {
+        uint3 invocations = get_invocations();
+        printf("%d %d %d\n", invocations.x, invocations.y, invocations.z);
+      }
+    }
+  )r";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+  application->add_sink_op();
+
+  application->check_output("4 3 2\n0\n");
+}
+
+TEST(SlangShaderAppTest, InvocationsSizeOfWithSwizzle) {
+  const std::string shader_source = R"r(
+    import holoscan;
+
+    [holoscan::output("output_buffer")]
+    [holoscan::alloc(4, 3, 2)]
+    RWStructuredBuffer<int3> output_buffer;
+
+    uint3 get_invocations() {
+      __intrinsic_asm "make_uint3(blockDim.x * gridDim.x, blockDim.y * gridDim.y, blockDim.z * gridDim.z)";
+    }
+
+    [shader("compute")]
+    [holoscan::invocations::size_of("output_buffer.zx1")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      output_buffer[gid.x] = gid.x;
+      if (gid.x == 0 && gid.y == 0 && gid.z == 0) {
+        uint3 invocations = get_invocations();
+        printf("%d %d %d\n", invocations.x, invocations.y, invocations.z);
+      }
+    }
+  )r";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+  application->add_sink_op();
+
+  application->check_output("2 4 1\n0\n");
+}
+
+TEST(SlangShaderAppTest, InvocationsSizeOfVideoBuffer) {
+  const std::string shader_source = R"r(
+    import holoscan;
+
+    [holoscan::input("input_buffer")]
+    StructuredBuffer<uint8_t4> input_buffer;
+
+    [holoscan::output("output_buffer")]
+    [holoscan::alloc::size_of("input_buffer")]
+    RWStructuredBuffer<uint8_t4> output_buffer;
+
+    uint3 get_invocations() {
+      __intrinsic_asm "make_uint3(blockDim.x * gridDim.x, blockDim.y * gridDim.y, blockDim.z * gridDim.z)";
+    }
+
+    [shader("compute")]
+    [holoscan::invocations::size_of("input_buffer")]
+    void compute(uint3 gid : SV_DispatchThreadID) {
+      output_buffer[gid.x] = input_buffer[gid.x];
+      if (gid.x == 0 && gid.y == 0 && gid.z == 0) {
+        uint3 invocations = get_invocations();
+        printf("%d %d %d\n", invocations.x, invocations.y, invocations.z);
+      }
+    }
+  )r";
+
+  auto application = holoscan::make_application<SlangShaderApp>(shader_source);
+  application->add_video_buffer_source_op();
+  application->add_sink_op();
+
+  // 757869354 is the value of the first pixel in the input video buffer (42, 43, 44, 45)
+  application->check_output("2 3 1\n757869354\n");
+}


### PR DESCRIPTION
Could not launch kernels from kernels with slang so implemented two
kernels. Nevertheless, performance is actually even slightly better
than the non-Slang implementation.

Add required features to SlangShaderOp and add tests.
