### PR TITLE
Arbitrary byte matching with flex parser

### DIFF
--- a/applications/adv_networking_bench/adv_networking_bench_rx_arb_match.yaml
+++ b/applications/adv_networking_bench/adv_networking_bench_rx_arb_match.yaml
@@ -1,0 +1,133 @@
+%YAML 1.2
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+scheduler:
+  check_recession_period_ms: 0
+  worker_thread_number: 5
+  stop_on_deadlock: true
+  stop_on_deadlock_timeout: 500
+  # max_duration_ms: 20000
+
+advanced_network:
+  cfg:
+    version: 1
+    manager: "dpdk"
+    master_core: 3
+    debug: false
+    log_level: "info"
+
+    memory_regions:
+    - name: "Data_RX_GPU0"
+      kind: "device"
+      affinity: 0
+      num_bufs: 51200
+      buf_size: 1064
+    - name: "Data_RX_GPU1"
+      kind: "device"
+      affinity: 0
+      num_bufs: 51200
+      buf_size: 1064   
+    - name: "Data_RX_GPU2"
+      kind: "device"
+      affinity: 0
+      num_bufs: 51200
+      buf_size: 1064   
+    - name: "Data_RX_GPU3"
+      kind: "device"
+      affinity: 0
+      num_bufs: 51200
+      buf_size: 1064   
+
+    interfaces:
+    - name: "rx_port"
+      address: 0005:03:00.0       # The BUS address of the interface doing Rx
+      rx:
+        flow_isolation: true
+        queues:
+        - name: "rq_q_0"
+          id: 0
+          cpu_core: 8
+          batch_size: 10240
+          memory_regions:
+            - "Data_RX_GPU0"
+        - name: "rq_q_1"
+          id: 1
+          cpu_core: 9
+          batch_size: 10240
+          memory_regions:
+            - "Data_RX_GPU1"            
+        - name: "rq_q_2"
+          id: 2
+          cpu_core: 10
+          batch_size: 10240
+          memory_regions:
+            - "Data_RX_GPU2"            
+        - name: "rq_q_3"
+          id: 3
+          cpu_core: 11
+          batch_size: 10240
+          memory_regions:
+            - "Data_RX_GPU3"            
+        flex_items:
+        - name: "flex_item_0"
+          id: 0
+          offset: 16
+          udp_dst_port: 4096
+        flows:
+        - name: "flow_0"
+          id: 0
+          action:
+            type: queue
+            id: 0
+          match:
+            flex_item_id: 0
+            val: 0x00000000
+            mask: 0x03000000
+        - name: "flow_1"
+          id: 1
+          action:
+            type: queue
+            id: 1
+          match:
+            flex_item_id: 0
+            val: 0x01000000
+            mask: 0x03000000
+        - name: "flow_2"
+          id: 2
+          action:
+            type: queue
+            id: 2
+          match:
+            flex_item_id: 0
+            val: 0x02000000
+            mask: 0x03000000  
+        - name: "flow_3"
+          id: 3
+          action:
+            type: queue
+            id: 3
+          match:
+            flex_item_id: 0
+            val: 0x03000000
+            mask: 0x03000000  
+
+bench_rx:
+  interface_name: "rx_port" # Name of the RX port from the advanced_network config
+  gpu_direct: true          # Set to true if using a GPU region for the Rx queues.
+  split_boundary: false     # Whether header and data is split (Header to CPU)
+  batch_size: 10240
+  max_packet_size: 1064
+  header_size: 64

--- a/applications/adv_networking_bench/cpp/CMakeLists.txt
+++ b/applications/adv_networking_bench/cpp/CMakeLists.txt
@@ -101,6 +101,12 @@ add_custom_target(adv_networking_bench_rivermax_tx_rx_yaml
 )
 add_dependencies(adv_networking_bench adv_networking_bench_rivermax_tx_rx_yaml)
 
+add_custom_target(adv_networking_bench_rx_arb_match_yaml
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/../adv_networking_bench_rx_arb_match.yaml" ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../adv_networking_bench_rx_arb_match.yaml"
+)
+add_dependencies(adv_networking_bench adv_networking_bench_rx_arb_match_yaml)
+
 # Installation
 install(TARGETS adv_networking_bench
         DESTINATION examples/adv_networking_bench

--- a/applications/adv_networking_bench/cpp/metadata.json
+++ b/applications/adv_networking_bench/cpp/metadata.json
@@ -31,7 +31,7 @@
 			}]
 		},
 		"run": {
-			"command": "<holohub_app_bin>/adv_networking_bench adv_networking_bench_default_tx_rx.yaml",
+			"command": "<holohub_app_bin>/adv_networking_bench",
 			"workdir": "holohub_bin"
 		}
 	}

--- a/operators/advanced_network/README.md
+++ b/operators/advanced_network/README.md
@@ -185,6 +185,17 @@ Too low means risk of dropped packets from NIC having nowhere to write (Rx) or h
 		type: `list`
 	- **`timeout_us`**: Timeout value that a batch will be sent on even if not enough packets to fill a batch were received
   		- type: `integer`
+- **`flex_items`**: Flexible parser flow items
+	type: `list`
+	full path: `cfg\interfaces\rx\flex_items`
+	- **`name`**: Name of flow item
+  		- type: `string`	
+	- **`id`**: ID of the flow item
+  		- type: `integer`	
+	- **`offset`**: Offset in bytes of where to match after the UDP header. Must be a multiple of 4 and < 28
+  		- type: `integer`
+	- **`udp_dst_port`**: UDP destination port for flex item match
+			- type: `integer`
 
 - **`flows`**: List of flows - rules to apply to packets, mostly to divert to the right queue. (<mark>Not in use for Rivermax manager</mark>)
   type: `list`
@@ -207,6 +218,13 @@ Too low means risk of dropped packets from NIC having nowhere to write (Rx) or h
 	  	- type: `integer`
 		- **`ipv4_len`**: IPv4 payload length
 	  	- type: `integer`
+		- **`flex_item_id`**: Flex item ID from RX section. Flex items cannot be applied if UDP or IP matching above are used
+	  	- type: `integer`
+		- **`val`**: 32b value to match on
+	  	- type: `integer`
+		- **`mask`**: 32b mask to apply before the match
+	  	- type: `integer`	
+			
 
 ##### Extended Receive Configuration for Rivermax manager
 

--- a/operators/advanced_network/advanced_network/common.cpp
+++ b/operators/advanced_network/advanced_network/common.cpp
@@ -345,6 +345,8 @@ bool YAML::convert<holoscan::advanced_network::NetworkConfig>::parse_flow_config
     return false;
   }
 
+  flow.match_.type_ = holoscan::advanced_network::FlowMatchType::NORMAL;
+
   try {
     flow.match_.udp_src_ = flow_item["match"]["udp_src"].as<uint16_t>();
     flow.match_.udp_dst_ = flow_item["match"]["udp_dst"].as<uint16_t>();
@@ -357,6 +359,44 @@ bool YAML::convert<holoscan::advanced_network::NetworkConfig>::parse_flow_config
     flow.match_.ipv4_len_ = flow_item["match"]["ipv4_len"].as<uint16_t>();
   } catch (const std::exception& e) {
     flow.match_.ipv4_len_ = 0;
+  }
+
+  if (flow.match_.udp_src_ == 0 && flow.match_.udp_dst_ == 0 && flow.match_.ipv4_len_ == 0) {
+    // No match criteria defined, use flex item match
+    flow.match_.flex_item_match_.flex_item_id_ = flow_item["match"]["flex_item_id"].as<uint16_t>();
+    flow.match_.flex_item_match_.val_ = flow_item["match"]["val"].as<uint32_t>();
+    flow.match_.flex_item_match_.mask_ = flow_item["match"]["mask"].as<uint32_t>();
+    flow.match_.type_ = holoscan::advanced_network::FlowMatchType::FLEX_ITEM;
+    HOLOSCAN_LOG_INFO("Using flex item match: flex_item_id={}, val={}, mask={}",
+                       flow.match_.flex_item_match_.flex_item_id_,
+                       flow.match_.flex_item_match_.val_,
+                       flow.match_.flex_item_match_.mask_);
+  }
+
+  return true;
+}
+
+/**
+ * @brief Parse flex item configuration from a YAML node.
+ *
+ * @param flex_item The YAML node containing the flex item configuration.
+ * @param flex_item_config The FlexItemConfig object to populate.
+ * @return true if parsing was successful, false otherwise.
+ */
+bool YAML::convert<holoscan::advanced_network::NetworkConfig>::parse_flex_item_config(
+    const YAML::Node& flex_item, holoscan::advanced_network::FlexItemConfig& flex_item_config) {
+  try {
+    flex_item_config.name_ = flex_item["name"].as<std::string>();
+    flex_item_config.id_ = flex_item["id"].as<uint16_t>();
+    flex_item_config.udp_dst_port_ = flex_item["udp_dst_port"].as<uint16_t>();
+    flex_item_config.offset_ = flex_item["offset"].as<uint16_t>();
+    if ((flex_item_config.offset_ % 4) != 0 || flex_item_config.offset_ > 28) {
+      HOLOSCAN_LOG_CRITICAL("Flex item offset (in bytes) must be a multiple of 4 and less than 28");
+      return false;
+    }
+  } catch (const std::exception& e) {
+    HOLOSCAN_LOG_ERROR("Error parsing FlexItemConfig: {}", e.what());
+    return false;
   }
   return true;
 }

--- a/operators/advanced_network/advanced_network/common.h
+++ b/operators/advanced_network/advanced_network/common.h
@@ -1,5 +1,9 @@
 /*
+<<<<<<< HEAD
  * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+=======
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+>>>>>>> 332dabe5 (Arbitrary byte matching with flex parser)
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -511,6 +515,16 @@ struct YAML::convert<holoscan::advanced_network::NetworkConfig> {
                                 holoscan::advanced_network::FlowConfig& flow);
 
   /**
+   * @brief Parse flex item configuration from a YAML node.
+   *
+   * @param flex_item The YAML node containing the flex item configuration.
+   * @param flex_item_config The FlexItemConfig object to populate.
+   * @return true if parsing was successful, false otherwise.
+   */
+  static bool parse_flex_item_config(const YAML::Node& flex_item,
+                                     holoscan::advanced_network::FlexItemConfig& flex_item_config);
+
+  /**
    * @brief Parse memory region configuration from a YAML node.
    *
    * @param mr The YAML node containing the memory region configuration.
@@ -687,6 +701,17 @@ struct YAML::convert<holoscan::advanced_network::NetworkConfig> {
               }
               rx_cfg.flows_.emplace_back(std::move(flow));
             }
+
+            try {
+              for (const auto& flex_item : rx["flex_items"]) {
+                holoscan::advanced_network::FlexItemConfig flex_item_config;
+                if (!parse_flex_item_config(flex_item, flex_item_config)) {
+                  HOLOSCAN_LOG_ERROR("Failed to parse FlexItemConfig");
+                  return false;
+                }
+                rx_cfg.flex_items_.emplace_back(std::move(flex_item_config));
+              }
+            } catch (const std::exception& e) {}  // No flex_items defined for this interface.
 
             ifcfg.rx_ = rx_cfg;
           } catch (const std::exception& e) {}  // No RX queues defined for this interface.

--- a/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.h
+++ b/operators/advanced_network/advanced_network/managers/dpdk/adv_network_dpdk_mgr.h
@@ -1,5 +1,9 @@
 /*
+<<<<<<< HEAD
  * SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+=======
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+>>>>>>> 332dabe5 (Arbitrary byte matching with flex parser)
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -219,11 +223,16 @@ class DpdkMgr : public Manager {
   struct rte_flow* add_modify_flow_set(int port, int queue, const char* buf, int len,
                                        Direction direction);
 
+  static struct rte_flow_item_flex_handle *create_flex_flow_rule(
+    int port, int offset, struct rte_flow_item *udp_item, struct rte_flow_item *end_pattern);
+  struct rte_flow* add_flex_item_flow(int port, const FlexItemMatch& match, uint16_t queue_id);
+
   void apply_tx_offloads(int port);
 
   std::array<struct rte_ether_addr, MAX_IFS> mac_addrs;
   std::unordered_map<uint32_t, struct rte_ring*> rx_rings;
   struct rte_ether_addr conf_ports_eth_addr[RTE_MAX_ETHPORTS];
+  std::unordered_map<uint16_t, struct rte_flow_item_flex_handle*> flex_item_handles_;
   std::unordered_map<uint32_t, struct rte_ring*> tx_rings;
   std::unordered_map<uint32_t, struct rte_mempool*> tx_burst_buffers;
   std::unordered_map<std::string, std::shared_ptr<struct rte_pktmbuf_extmem>> ext_pktmbufs_;

--- a/operators/advanced_network/advanced_network/types.h
+++ b/operators/advanced_network/advanced_network/types.h
@@ -357,10 +357,23 @@ struct FlowAction {
   uint16_t id_;
 };
 
+struct FlexItemMatch {
+  uint16_t flex_item_id_;
+  uint32_t val_;
+  uint32_t mask_;
+};
+
+enum class FlowMatchType {
+  NORMAL,
+  FLEX_ITEM,
+};
+
 struct FlowMatch {
+  FlowMatchType type_;
   uint16_t udp_src_;
   uint16_t udp_dst_;
   uint16_t ipv4_len_;
+  FlexItemMatch flex_item_match_;
 };
 struct FlowConfig {
   std::string name_;
@@ -378,10 +391,18 @@ struct CommonConfig {
   LoopbackType loopback_;
 };
 
+struct FlexItemConfig {
+  std::string name_;
+  uint16_t id_;
+  uint16_t udp_dst_port_;
+  uint16_t offset_;
+};
+
 struct RxConfig {
   bool flow_isolation_;
   std::vector<RxQueueConfig> queues_;
   std::vector<FlowConfig> flows_;
+  std::vector<FlexItemConfig> flex_items_;
 };
 
 struct TxConfig {


### PR DESCRIPTION
Allows users to match any arbitrary 32b word after a UDP header up to 8 bytes away. Both a mask and value are used to allow any bits/bytes to be matched in any order. A UDP header is only required for this PR, but in the future this can be more flexible. An example config in the RX section is as follows:

```
        flex_items:
        - name: "flex_item_0"
          id: 0
          offset: 16
          udp_dst_port: 4096
        flows:
        - name: "flow_0"
          id: 0
          action:
            type: queue
            id: 0
          match:
            flex_item_id: 0
            val: 0x00000000
            mask: 0x03000000
```

The `flex_items` section specifies a new flexible parsing match based on a UDP destination port and byte offset after the UDP header. The matches in each flow section allow a 32b value and mask to be computed, and if a match hits, the action for the flow is taken.