### PR TITLE
App: Update H.264 script for GXF 5.0 / GXF MM 4.1.1 extensions

### DIFF
--- a/applications/h264/Dockerfile
+++ b/applications/h264/Dockerfile
@@ -21,7 +21,7 @@
 ARG BASE_IMAGE
 ARG GPU_TYPE
 
-FROM nvcr.io/nvidia/clara-holoscan/holoscan:v3.2.0-dgpu as base
+FROM ${BASE_IMAGE} as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/applications/h264/install_dependencies.sh
+++ b/applications/h264/install_dependencies.sh
@@ -17,6 +17,7 @@
 
 # This scripts installs gxf multimedia libraries and corresponding dependencies
 # required for H264 Encode / Decode applications.
+set -e
 
 # URL of the DeepStream dependencies required for gxf-mm extensions above
 DS_DEPS_URL="https://api.ngc.nvidia.com/v2/resources/org/nvidia/gxf_and_gc/4.0.0/files?redirect=true&path=nvv4l2_x86_ds-7.0.deb"
@@ -38,19 +39,23 @@ gxf_mm_extensions=(["decoderio"]="45081ccb-982e-4946-96f9-0d684f2cfbd0" \
                    ["encoder"]="ea5c44e4-15db-4448-a3a6-f32004303338")
 mkdir -p gxf-mm
 mkdir -p ${HOLOSCAN_LIBS_DIR}
-CUDA_VERSION=12.6
+MM_VERSION=1.4.1
+CUDA_VERSION=12.8
+UBUNTU_VERSION=24.04
 for extension in "${!gxf_mm_extensions[@]}"; do
   if [[ $extension == "decoderio" ]] || [[ $extension == "encoderio" ]]; then
-    extension_url="https://api.ngc.nvidia.com/v2/resources/org/nvidia/team/graph-composer/video${extension}extension/1.3.0-linux-${ARCH}-ubuntu_22.04/files?redirect=true&path=${gxf_mm_extensions[${extension}]}.tar.gz"
+    extension_url="https://api.ngc.nvidia.com/v2/resources/org/nvidia/team/graph-composer/video${extension}extension/${MM_VERSION}-linux-${ARCH}-ubuntu_${UBUNTU_VERSION}/files?redirect=true&path=${gxf_mm_extensions[${extension}]}.tar.gz"
   else
-    extension_url="https://api.ngc.nvidia.com/v2/resources/org/nvidia/team/graph-composer/video${extension}extension/1.3.0-linux-${ARCH}-ubuntu_22.04-cuda-${CUDA_VERSION}/files?redirect=true&path=${gxf_mm_extensions[${extension}]}.tar.gz"
+    extension_url="https://api.ngc.nvidia.com/v2/resources/org/nvidia/team/graph-composer/video${extension}extension/${MM_VERSION}-linux-${ARCH}-ubuntu_${UBUNTU_VERSION}-cuda-${CUDA_VERSION}/files?redirect=true&path=${gxf_mm_extensions[${extension}]}.tar.gz"
   fi
   extension_tar=${gxf_mm_extensions[$extension]}.tar.gz
+  set -x
   wget --content-disposition ${extension_url} -O ${extension_tar}
   tar -xvf ${extension_tar} -C gxf-mm/
   rm ${extension_tar}
   extensions_lib="libgxf_video${extension}.so"
   cp ./gxf-mm/${extensions_lib} ${HOLOSCAN_LIBS_DIR}/
+  set +x
 done
 rm -rf gxf-mm
 


### PR DESCRIPTION
Update to fetch GXF MM dependencies from NGC:
https://catalog.ngc.nvidia.com/orgs/nvidia/teams/graph-composer/resources/videodecoderextension/version

GXF MM 4.1.1 supports GXF 5.0 / Ubuntu >= 24.04 (glibc >= 2.39).

Changes:
- Update to use latest Holoscan SDK >= 3.3.0 dev container (based on Ubuntu 24.04)
- Update to fetch latest GXF MM extensions
- Script updates to 1) exit container build with failure if GXF MM installation fails, 2) log installation for easier debugging

**Needs attention**: h264_video_decode Python test fails with default run command:
```
[warning] [type_registry.cpp:57] Unknown type: nvidia::gxf::VideoReadBitStream
[error] [gxf_codelet.cpp:44] Unable to find the GXF type name ('nvidia::gxf::VideoReadBitStream') for the codelet
```
However, the symbol is defined in `/opt/nvidia/holoscan/lib/libgxf_core.so` and running the test with LD_PRELOAD succeeds:
```
LD_PRELOAD=/opt/nvidia/holoscan/lib/libgxf_core.so xvfb-run -a ctest -C Release --output-on-failure -R python -VV
...
The following tests passed:
        h264_video_decode_python_test

100% tests passed, 0 tests failed out of 1
```