### PR TITLE
CLI add local-sdk-root path

### DIFF
--- a/.github/workflows/check_cli.yml
+++ b/.github/workflows/check_cli.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Set up Python

--- a/.github/workflows/check_docker.yml
+++ b/.github/workflows/check_docker.yml
@@ -2,7 +2,7 @@ name: Check Docker
 
 on:
   push:
-    branches: [main, holoscan-sdk-lws2, fixes-sdk-path]
+    branches: [main, holoscan-sdk-lws2]
 
 permissions:
   contents: read

--- a/.github/workflows/check_docker.yml
+++ b/.github/workflows/check_docker.yml
@@ -2,7 +2,7 @@ name: Check Docker
 
 on:
   push:
-    branches: [main, holoscan-sdk-lws2]
+    branches: [main, holoscan-sdk-lws2, fixes-sdk-path]
 
 permissions:
   contents: read

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -127,7 +127,7 @@ $ ./holohub run-container --img holohub:local-sdk-latest --local-sdk-root <path_
 where `<path_to_holoscan_sdk>` is the path to the Holoscan SDK root directory containing the build directory.
 Please refer to the [Holoscan SDK Developer Guide](https://github.com/nvidia-holoscan/holoscan-sdk/blob/main/DEVELOP.md) for more details on how to build the Holoscan SDK from source.
 
-In the container, to verify the build directory is mounted correctly, run the following command:
+In the container, to verify the build directory (with a python build) is mounted correctly, run the following command:
 ```bash
 $ python -c "import holoscan; print(holoscan.__file__)"
 ```
@@ -135,6 +135,9 @@ The output should be something like:
 ```bash
 /workspace/holoscan-sdk/build-x86_64/python/lib/holoscan/__init__.py
 ```
+
+If Python supported is not enabled, `/workspace/holoscan-sdk` can be manually inspected to confirm the mount.
+The directory should contain a non-empty `build-<arch>-<gpu_type>` or `install-<arch>-<gpu_type>` directory.
 
 ### Launch a Named HoloHub Container
 

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -127,6 +127,15 @@ $ ./holohub run-container --img holohub:local-sdk-latest --local-sdk-root <path_
 where `<path_to_holoscan_sdk>` is the path to the Holoscan SDK root directory containing the build directory.
 Please refer to the [Holoscan SDK Developer Guide](https://github.com/nvidia-holoscan/holoscan-sdk/blob/main/DEVELOP.md) for more details on how to build the Holoscan SDK from source.
 
+In the container, to verify the build directory is mounted correctly, run the following command:
+```bash
+$ python -c "import holoscan; print(holoscan.__file__)"
+```
+The output should be something like:
+```bash
+/workspace/holoscan-sdk/build-x86_64/python/lib/holoscan/__init__.py
+```
+
 ### Launch a Named HoloHub Container
 
 To launch custom HoloHub container with fully qualified name, e.g. "holohub:ngc-sdk-sample-app"

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -124,6 +124,9 @@ To use a HoloHub container image built with a local Holoscan SDK container:
 $ ./holohub run-container --img holohub:local-sdk-latest --local-sdk-root <path_to_holoscan_sdk>
 ```
 
+where `<path_to_holoscan_sdk>` is the path to the Holoscan SDK root directory containing the build directory.
+Please refer to the [Holoscan SDK Developer Guide](https://github.com/nvidia-holoscan/holoscan-sdk/blob/main/DEVELOP.md) for more details on how to build the Holoscan SDK from source.
+
 ### Launch a Named HoloHub Container
 
 To launch custom HoloHub container with fully qualified name, e.g. "holohub:ngc-sdk-sample-app"

--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -30,7 +30,7 @@ from .util import (
     check_nvidia_ctk,
     docker_args_to_devcontainer_format,
     fatal,
-    find_build_dir,
+    find_hsdk_build_rel_dir,
     get_compute_capacity,
     get_group_id,
     get_host_gpu,
@@ -594,7 +594,7 @@ class HoloHubContainer:
         """Get PYTHONPATH configuration"""
         benchmarking_path = "/workspace/holohub/benchmarks/holoscan_flow_benchmarking"
         if local_sdk_root:
-            build_dir = find_build_dir(local_sdk_root)
+            build_dir = find_hsdk_build_rel_dir(local_sdk_root)
             sdk_paths = f"/workspace/holoscan-sdk/{build_dir}/python/lib:{benchmarking_path}"
         else:
             sdk_paths = f"/opt/nvidia/holoscan/python/lib:{benchmarking_path}"
@@ -609,7 +609,7 @@ class HoloHubContainer:
 
     def get_local_sdk_options(self, local_sdk_root: Path) -> List[str]:
         """Get Holoscan SDK-related options"""
-        build_dir = find_build_dir(local_sdk_root)
+        build_dir = find_hsdk_build_rel_dir(local_sdk_root)
         return [
             "-v",
             f"{local_sdk_root}:/workspace/holoscan-sdk",

--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -432,7 +432,7 @@ class HoloHubContainer:
         cmd.extend(self.get_nsys_options(nsys_profile, nsys_location))
         cmd.extend(self.get_pythonpath_options(local_sdk_root, img))
 
-        if local_sdk_root:
+        if local_sdk_root or os.environ.get("HOLOSCAN_SDK_ROOT"):
             cmd.extend(self.get_local_sdk_options(local_sdk_root))
 
         if docker_opts:
@@ -593,9 +593,10 @@ class HoloHubContainer:
     ) -> List[str]:
         """Get PYTHONPATH configuration"""
         benchmarking_path = "/workspace/holohub/benchmarks/holoscan_flow_benchmarking"
-        if local_sdk_root:
-            build_dir = find_hsdk_build_rel_dir(local_sdk_root)
-            sdk_paths = f"/workspace/holoscan-sdk/{build_dir}/python/lib:{benchmarking_path}"
+
+        if local_sdk_root or os.environ.get("HOLOSCAN_SDK_ROOT"):
+            sdk_dir = find_hsdk_build_rel_dir(local_sdk_root)
+            sdk_paths = f"/workspace/holoscan-sdk/{sdk_dir}/python/lib:{benchmarking_path}"
         else:
             sdk_paths = f"/opt/nvidia/holoscan/python/lib:{benchmarking_path}"
         all_paths = []

--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -30,6 +30,7 @@ from .util import (
     check_nvidia_ctk,
     docker_args_to_devcontainer_format,
     fatal,
+    find_build_dir,
     get_compute_capacity,
     get_group_id,
     get_host_gpu,
@@ -593,7 +594,8 @@ class HoloHubContainer:
         """Get PYTHONPATH configuration"""
         benchmarking_path = "/workspace/holohub/benchmarks/holoscan_flow_benchmarking"
         if local_sdk_root:
-            sdk_paths = f"/workspace/holoscan-sdk/build/python/lib:{benchmarking_path}"
+            build_dir = find_build_dir(local_sdk_root)
+            sdk_paths = f"/workspace/holoscan-sdk/{build_dir}/python/lib:{benchmarking_path}"
         else:
             sdk_paths = f"/opt/nvidia/holoscan/python/lib:{benchmarking_path}"
         all_paths = []
@@ -607,11 +609,12 @@ class HoloHubContainer:
 
     def get_local_sdk_options(self, local_sdk_root: Path) -> List[str]:
         """Get Holoscan SDK-related options"""
+        build_dir = find_build_dir(local_sdk_root)
         return [
             "-v",
             f"{local_sdk_root}:/workspace/holoscan-sdk",
             "-e",
-            "HOLOSCAN_LIB_PATH=/workspace/holoscan-sdk/build/lib",
+            f"HOLOSCAN_LIB_PATH=/workspace/holoscan-sdk/{build_dir}/lib",
             "-e",
             "HOLOSCAN_SAMPLE_DATA_PATH=/workspace/holoscan-sdk/data",
             "-e",

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -329,7 +329,7 @@ def get_arch_gpu_str() -> str:
     return arch
 
 
-def find_build_dir(local_sdk_root: Optional[Union[str, Path]] = None) -> str:
+def find_hsdk_build_rel_dir(local_sdk_root: Optional[Union[str, Path]] = None) -> str:
     """
     find a suitable build directory in the SDK root
     https://github.com/nvidia-holoscan/holoscan-sdk/blob/9c5b3c3d4831f2e65ebda6b79ae9b1c5517c6a7c/run#L226-L228

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -315,10 +315,9 @@ def get_host_arch() -> str:
     machine = platform.machine()
     if machine in ["x86_64", "amd64"]:
         return "x86_64"
-    elif machine in ["aarch64", "arm64"]:
+    if machine in ["aarch64", "arm64"]:
         return "aarch64"
-    else:
-        return machine
+    return machine
 
 
 def get_arch_gpu_str() -> str:
@@ -327,18 +326,20 @@ def get_arch_gpu_str() -> str:
     if arch == "aarch64":
         gpu = get_host_gpu()
         return f"{arch}-{gpu}"
-    else:
-        return arch
+    return arch
 
 
-def find_build_dir(local_sdk_root: Optional[Path] = None) -> str:
+def find_build_dir(local_sdk_root: Optional[Union[str, Path]] = None) -> str:
     """
     find a suitable build directory in the SDK root
     https://github.com/nvidia-holoscan/holoscan-sdk/blob/9c5b3c3d4831f2e65ebda6b79ae9b1c5517c6a7c/run#L226-L228
     """
     search_paths = []
-    if local_sdk_root and local_sdk_root.exists():
-        search_paths.append(local_sdk_root)
+    if local_sdk_root:
+        if isinstance(local_sdk_root, str):
+            local_sdk_root = Path(local_sdk_root)
+        if local_sdk_root.exists():
+            search_paths.append(local_sdk_root)
     if os.environ.get("HOLOSCAN_SDK_ROOT"):
         env_path = Path(os.environ["HOLOSCAN_SDK_ROOT"])
         if env_path.exists():

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -353,7 +353,7 @@ def find_build_dir(local_sdk_root: Optional[Union[str, Path]] = None) -> str:
             return build_dirs[0]  # Use first one found
         if (sdk_path / "build").exists():
             return "build"
-    return f"build-{get_arch_gpu_str()}"
+    raise RuntimeError(f"No valid build directory found in SDK root. Fallback path 'build-{get_arch_gpu_str()}' does not exist.")
 
 
 def get_compute_capacity() -> str:

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -329,32 +329,78 @@ def get_arch_gpu_str() -> str:
     return arch
 
 
+def _is_valid_sdk_installation(path: Union[str, Path]) -> bool:
+    """
+    Validate if a directory contains a valid Holoscan SDK installation.
+    """
+    path = Path(path) if isinstance(path, str) else path
+    if not path.exists() or not path.is_dir() or not (path / "lib").exists():
+        return False
+    # Check for at least one of these to confirm it's a Holoscan SDK
+    return (path / "include" / "holoscan").exists() or (
+        path / "lib" / "cmake" / "holoscan"
+    ).exists()
+
+
 def find_hsdk_build_rel_dir(local_sdk_root: Optional[Union[str, Path]] = None) -> str:
     """
-    find a suitable build directory in the SDK root
+    Find a suitable SDK installation or build directory.
     https://github.com/nvidia-holoscan/holoscan-sdk/blob/9c5b3c3d4831f2e65ebda6b79ae9b1c5517c6a7c/run#L226-L228
+
+    Search order:
+    1. Direct SDK installation directory
+    2. Environment variable `HOLOSCAN_SDK_ROOT` SDK root directory
+    3. Assuming the direct or env var is the src code root, searching for immediate subdirectories:
+        3.1 Install directory (prefer)
+        3.2 Build directory (fallback)
+
+    Args:
+        local_sdk_root: Path to SDK root directory, or direct SDK installation/build directory
+
+    Returns:
+        Relative path to the SDK directory from the root, or absolute path if passed directly
     """
     search_paths = []
+
+    # Handle user-provided path
     if local_sdk_root:
-        if isinstance(local_sdk_root, str):
-            local_sdk_root = Path(local_sdk_root)
+        local_sdk_root = Path(local_sdk_root) if isinstance(local_sdk_root, str) else local_sdk_root
         if local_sdk_root.exists():
-            search_paths.append(local_sdk_root)
+            # Check if this is a direct SDK installation directory
+            if _is_valid_sdk_installation(local_sdk_root):
+                return str(local_sdk_root)
+            else:
+                # Treat as SDK root directory to search
+                search_paths.append(local_sdk_root)
+
+    # Add environment variable path
     if os.environ.get("HOLOSCAN_SDK_ROOT"):
         env_path = Path(os.environ["HOLOSCAN_SDK_ROOT"])
         if env_path.exists():
-            search_paths.append(env_path)
+            if _is_valid_sdk_installation(env_path):
+                return str(env_path)
+            else:
+                search_paths.append(env_path)
+
+    # Search within SDK root directories
     for sdk_path in search_paths:
-        expected_build = f"build-{get_arch_gpu_str()}"
-        if (sdk_path / expected_build).exists():
-            return expected_build
-        build_dirs = sorted([d.name for d in sdk_path.glob("build-*") if d.is_dir()])
-        if build_dirs:
-            return build_dirs[0]  # Use first one found
-        if (sdk_path / "build").exists():
-            return "build"
-    info(f"Build directory not found in SDK root. 'build-{get_arch_gpu_str()}' doesn't exist.")
-    return f"build-{get_arch_gpu_str()}"
+        arch_gpu = get_arch_gpu_str()
+        for install_dir in [f"install-{arch_gpu}", "install"]:
+            if _is_valid_sdk_installation(sdk_path / install_dir):
+                return install_dir
+        for install_dir in sorted([d.name for d in sdk_path.glob("install-*") if d.is_dir()]):
+            if _is_valid_sdk_installation(sdk_path / install_dir):
+                return install_dir
+        for build_dir in [f"build-{arch_gpu}", "build"]:
+            if _is_valid_sdk_installation(sdk_path / build_dir):
+                return build_dir
+        for build_dir in sorted([d.name for d in sdk_path.glob("build-*") if d.is_dir()]):
+            if _is_valid_sdk_installation(sdk_path / build_dir):
+                return build_dir
+    info(
+        f"Valid SDK installation not found. Looking for 'install-{arch_gpu}' or 'build-{arch_gpu}'."
+    )
+    return f"build-{arch_gpu}"
 
 
 def get_compute_capacity() -> str:

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -312,7 +312,7 @@ def get_host_gpu() -> str:
 
 def get_host_arch() -> str:
     """Get host architecture"""
-    machine = platform.machine()
+    machine = platform.machine().lower()
     if machine in ["x86_64", "amd64"]:
         return "x86_64"
     if machine in ["aarch64", "arm64"]:

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -337,8 +337,8 @@ def _is_valid_sdk_installation(path: Union[str, Path]) -> bool:
     if not path.exists() or not path.is_dir() or not (path / "lib").exists():
         return False
     # Check for at least one of these to confirm it's a Holoscan SDK
-    return (path / "include" / "holoscan").exists() or (
-        path / "lib" / "cmake" / "holoscan"
+    return (path / "lib" / "cmake" / "holoscan" / "holoscan-config.cmake").exists() or (
+        path / "lib" / "cmake" / "holoscan" / "HoloscanConfig.cmake"
     ).exists()
 
 

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -353,7 +353,8 @@ def find_build_dir(local_sdk_root: Optional[Union[str, Path]] = None) -> str:
             return build_dirs[0]  # Use first one found
         if (sdk_path / "build").exists():
             return "build"
-    raise RuntimeError(f"No valid build directory found in SDK root. Fallback path 'build-{get_arch_gpu_str()}' does not exist.")
+    info(f"Build directory not found in SDK root. 'build-{get_arch_gpu_str()}' doesn't exist.")
+    return f"build-{get_arch_gpu_str()}"
 
 
 def get_compute_capacity() -> str:

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -333,9 +333,8 @@ def get_arch_gpu_str() -> str:
 
 def find_build_dir(local_sdk_root: Optional[Path] = None) -> str:
     """
-    Find the build directory name by searching existing directories on the host.
-    This runs before Docker starts, so we search the actual host filesystem.
-    The local_sdk_root will be mounted as /workspace/holoscan-sdk in the container.
+    find a suitable build directory in the SDK root
+    https://github.com/nvidia-holoscan/holoscan-sdk/blob/9c5b3c3d4831f2e65ebda6b79ae9b1c5517c6a7c/run#L226-L228
     """
     search_paths = []
     if local_sdk_root and local_sdk_root.exists():

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -383,8 +383,8 @@ def find_hsdk_build_rel_dir(local_sdk_root: Optional[Union[str, Path]] = None) -
                 search_paths.append(env_path)
 
     # Search within SDK root directories
+    arch_gpu = get_arch_gpu_str()
     for sdk_path in search_paths:
-        arch_gpu = get_arch_gpu_str()
         for install_dir in [f"install-{arch_gpu}", "install"]:
             if _is_valid_sdk_installation(sdk_path / install_dir):
                 return install_dir


### PR DESCRIPTION
the build directory of local sdk by default would be something like `/workspace/holoscan-sdk/build-x86_64/` according to https://github.com/nvidia-holoscan/holoscan-sdk/blob/9c5b3c3d4831f2e65ebda6b79ae9b1c5517c6a7c/run#L226-L228

this PR revise the hard-coded `HOLOSCAN_LIB_PATH=/workspace/holoscan-sdk/build/lib` to allow for the build folder name variants.