### PR TITLE
Update README files for RTI Connext license

### DIFF
--- a/operators/dds/base/README.md
+++ b/operators/dds/base/README.md
@@ -3,8 +3,7 @@
 The DDS Base Operator provides a base class which can be inherited by any
 operator class which requires access to a DDS domain.
 
-This operator requires an installation of [RTI Connext](https://content.rti.com/l/983311/2024-04-30/pz1wms)
-to provide access to the DDS domain, as specified by the [OMG Data-Distribution Service](https://www.omg.org/omg-dds-portal/)
+This operator requires an installation of [RTI Connext Express](https://content.rti.com/l/983311/2025-07-08/q5x1n8) to provide access to the DDS domain, as specified by the [OMG Data-Distribution Service](https://www.omg.org/omg-dds-portal/). To obtain a license/activation key, please [click here](https://content.rti.com/l/983311/2025-07-25/q6729c). Please see the [usage rules](https://www.rti.com/products/connext-express) for Connext Express.
 
 #### `holoscan::ops::DDSOperatorBase`
 

--- a/operators/dds/dds_shapes_subscriber/README.md
+++ b/operators/dds/dds_shapes_subscriber/README.md
@@ -5,8 +5,7 @@ The DDS Shape Subscriber Operator subscribes to and reads from the `Square`, `Ci
 It will then translate the received shape data to an internal `Shape` datatype for output
 to downstream operators.
 
-This operator requires an installation of [RTI Connext](https://content.rti.com/l/983311/2024-04-30/pz1wms)
-to provide access to the DDS domain, as specified by the [OMG Data-Distribution Service](https://www.omg.org/omg-dds-portal/)
+This operator requires an installation of [RTI Connext Express](https://content.rti.com/l/983311/2025-07-08/q5x1n8) to provide access to the DDS domain, as specified by the [OMG Data-Distribution Service](https://www.omg.org/omg-dds-portal/). To obtain a license/activation key, please [click here](https://content.rti.com/l/983311/2025-07-25/q6729c). Please see the [usage rules](https://www.rti.com/products/connext-express) for Connext Express.
 
 #### `holoscan::ops::DDSShapesSubscriberOp`
 

--- a/operators/dds/video/README.md
+++ b/operators/dds/video/README.md
@@ -4,8 +4,7 @@ The DDS Video Operators allow applications to read or write video buffers
 to a DDS databus, enabling communication with other applications via the
 [VideoFrame](VideoFrame.idl) DDS topic.
 
-This operator requires an installation of [RTI Connext](https://content.rti.com/l/983311/2024-04-30/pz1wms)
-to provide access to the DDS domain, as specified by the [OMG Data-Distribution Service](https://www.omg.org/omg-dds-portal/)
+This operator requires an installation of [RTI Connext Express](https://content.rti.com/l/983311/2025-07-08/q5x1n8) to provide access to the DDS domain, as specified by the [OMG Data-Distribution Service](https://www.omg.org/omg-dds-portal/). To obtain a license/activation key, please [click here](https://content.rti.com/l/983311/2025-07-25/q6729c). Please see the [usage rules](https://www.rti.com/products/connext-express) for Connext Express.
 
 #### `holoscan::ops::DDSVideoPublisherOp`
 


### PR DESCRIPTION
Update README files to reflect the requirement for RTI Connext Express instead of RTI Connext, including links for license activation and usage rules.