### PR TITLE
Fix docker dependencies for colonoscopy segmentation application

### DIFF
--- a/applications/colonoscopy_segmentation/Dockerfile
+++ b/applications/colonoscopy_segmentation/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         cmake \
         make \
+        xvfb \
+        ninja-build \
         patch \
         ffmpeg \
         libnpp-12-9 \


### PR DESCRIPTION
Add xvfb-run and ninja-build to Dockerfile dependencies for colonoscopy segmentation application