### PR TITLE
Fix docker file Colonoscopy Segmentation

### DIFF
--- a/applications/colonoscopy_segmentation/Dockerfile
+++ b/applications/colonoscopy_segmentation/Dockerfile
@@ -70,5 +70,5 @@ RUN if ! python3 -m pip --version >/dev/null 2>&1; then \
     ; fi
 
 RUN pip3 install holoscan cupy-cuda12x \
-    && chmod -R a+w /usr/local/lib/python3.12/dist-packages/holoscan-3.4.0.dist-info/ \
+    && chmod -R a+w /usr/local/lib/python3.12/dist-packages/holoscan-*.dist-info/ \
     && chmod -R a+rw /usr/local/lib/python3.12/dist-packages/holoscan


### PR DESCRIPTION
Update Dockerfile for colonoscopy segmentation application to allow for flexible versioning of holoscan dependencies by modifying permissions for the dist-info directory.