### PR TITLE
Doc: Update tutorial READMEs for HoloHub CLI

### DIFF
--- a/tutorials/creating-multi-node-applications/README.md
+++ b/tutorials/creating-multi-node-applications/README.md
@@ -482,8 +482,8 @@ Before we start to launch the application, let's first run the original applicat
 > Build and run instructions may change in the future, please refer to the original application.
 ```sh
 # on the node that runs fragment 1, or a node that runs the entire app
-./run build multiai_endoscopy
-./run launch multiai_endoscopy python
+./holohub build multiai_endoscopy
+./holohub run multiai_endoscopy --language python
 ```
 Now we're ready to launch the distributed application in scenario 1.
 ```sh
@@ -515,11 +515,11 @@ Let's first run the original applications. In the dev container, make sure to bu
 > Build and run instructions may change in the future, please refer to the original applications.
 ```sh
 # On the node that runs fragment 1 or a node that runs the entire app
-./run build endoscopy_tool_tracking
-./run launch endoscopy_tool_tracking python
+./holohub build endoscopy_tool_tracking
+./holohub run endoscopy_tool_tracking --language python
 
 # On the node that runs fragment 2 or a node that runs the entire app
-./run build endoscopy_out_of_body_detection
+./holohub build endoscopy_out_of_body_detection
 cd build && applications/endoscopy_out_of_body_detection/endoscopy_out_of_body_detection --data ../data/endoscopy_out_of_body_detection
 ```
 Now we're ready to launch the distributed application in scenario 2. 

--- a/tutorials/debugging/cli_debugging/debug_legacy.sh
+++ b/tutorials/debugging/cli_debugging/debug_legacy.sh
@@ -38,7 +38,7 @@ git checkout ${holoscan_sdk_tag}
 # https://github.com/nvidia-holoscan/holoscan-sdk/issues/30
 git reset --hard HEAD
 git apply ${SCRIPT_DIR}/holoscan_sdk_20240723_1.diff
-./run build --type $build_type
+./holohub build --local --type $build_type
 INSTALL_DIR=$(realpath $(find . -type d -name "install-*"))
 popd
 

--- a/tutorials/windows_vm/README.md
+++ b/tutorials/windows_vm/README.md
@@ -408,7 +408,7 @@ frame on the screen using the RTX A4000 GPU with the help of OpenGL.
 In Linux host, run the Holoscan DDS app in `publisher` mode:
 
 ```bash
-./run launch dds_video --extra_args "-p"
+./holohub run --local dds_video --run-args="-p"
 ```
 
 In Windows VM, running the renderer application shows the camera input from Linux host:


### PR DESCRIPTION
Legacy `./run` and `dev_container` scripts are scheduled for deprecation

Followup to https://github.com/nvidia-holoscan/holohub/commit/e703e9a0820bd9b3011442ee4786e3c2c0e1abd7