### PR TITLE
CLI: Bump minimum CMake version check

### DIFF
--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -1120,7 +1120,7 @@ def get_ubuntu_codename() -> str:
         return "jammy"
 
 
-def setup_cmake(min_version: str = "3.24.0", dry_run: bool = False) -> None:
+def setup_cmake(min_version: str = "3.26.4", dry_run: bool = False) -> None:
     """Setup CMake from Kitware if needed"""
     cmake_ver = get_installed_package_version("cmake")
     if cmake_ver and parse_semantic_version(cmake_ver) >= parse_semantic_version(min_version):


### PR DESCRIPTION
Holoscan SDK v3.5.0 bumps the minimum CMake version from 3.24 to 3.26 to align with RAPIDS 24.04.00

See: https://github.com/nvidia-holoscan/holoscan-sdk/blob/main/Dockerfile#L333