### PR TITLE
CLI: Fix `setup` for non-CUDA-12 environments

### DIFF
--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -554,7 +554,7 @@ def install_packages_if_missing(
             packages_to_install.append(package_spec)
             info(f"Installing {package_spec}")
         else:
-            if get_installed_package_version(package_name) is not None:
+            if get_installed_package_version(package_name):
                 info(f"Package {package_name} is already installed")
             else:
                 packages_to_install.append(package_spec)


### PR DESCRIPTION
Changes:
- Fix observed issue where cuDNN install fails in environment with generic CUDA major version
- Fix false negative where `ffmpeg` was not installed but `./holohub setup` skipped installation due to `dpkg-query` returning an empty string