### PR TITLE
App: Update VTK run instructions for Endoscopy Tool Tracking

### DIFF
--- a/applications/endoscopy_tool_tracking/README.md
+++ b/applications/endoscopy_tool_tracking/README.md
@@ -66,24 +66,6 @@ sed -i -e 's#^visualizer:.*#visualizer: "vtk"#' applications/endoscopy_tool_trac
 ./holohub run endoscopy_tool_tracking --build-with="vtk_renderer" --docker-file="operators/vtk_renderer/vtk.Dockerfile" --img holohub:endoscopy_tool_tracking_vtk --language="python"
 ```
 
-> 💡 Note: To enable VTK renderer in the Python version of the application, open [endoscopy_tool_tracking.py](./python/endoscopy_tool_tracking.py#L41) and uncomment the following lines:
->
-> ```python
->  # Line 41
->  from holohub.vtk_renderer import VtkRendererOp
->  
->  # Lines 213-221
->  else:
->       visualizer = VtkRendererOp(
->           self,
->           name="vtk",
->           width=width,
->           height=height,
->           window_name="VTK (Kitware) Python",
->           **self.kwargs("vtk_op"),
->       )
-> ```
-
 Arguments:
 
 - `--build-with` : instructs the script to build the application with the `vtk_renderer` operator


### PR DESCRIPTION
Remove outdated instructions requiring source updates to use VTK renderer in Endoscopy Tool Tracking Python app.

As of f84d88e5cf4d260571bdebcdfef208fecc3cffdf the app supports lazy import of the VTK operator module if it is selected in the YAML configuration. Python source updates are not required in order to use VTK.

cc @vicentebolea 