### PR TITLE
Benchmark: Use matplotlib `Agg` backend by default in scripts

### DIFF
--- a/benchmarks/holoscan_flow_benchmarking/analyze.py
+++ b/benchmarks/holoscan_flow_benchmarking/analyze.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,9 @@
 import argparse
 import sys
 
+import matplotlib
+
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 from log_parser import parse_log_as_paths_latencies

--- a/benchmarks/holoscan_flow_benchmarking/bar_plot_avg_datewise.py
+++ b/benchmarks/holoscan_flow_benchmarking/bar_plot_avg_datewise.py
@@ -15,6 +15,9 @@
 
 import sys
 
+import matplotlib
+
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
 

--- a/benchmarks/holoscan_flow_benchmarking/bar_plot_generic_datewise.py
+++ b/benchmarks/holoscan_flow_benchmarking/bar_plot_generic_datewise.py
@@ -15,6 +15,9 @@
 
 import sys
 
+import matplotlib
+
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
 metric_names = {


### PR DESCRIPTION
Explicitly set `Agg` backend for writing plots in headless contexts on Linux systems.

Reference: https://matplotlib.org/stable/users/explain/figure/backends.html#selecting-a-backend

> The last, Agg, is a non-interactive backend that can only write to files. It is used on Linux, if Matplotlib cannot connect to either an X display or a Wayland display.

Follows original fix in 98745dae2b8e0e7a9c19f05548158ba20ccda0c0

Intended to address internally reported error when using `analyze.py`:
```
gi.repository.GLib.GError: gdk-pixbuf-error-quark: Couldn’t recognize the image file format for file “/usr/local/lib/python3.12/dist-packages/matplotlib/mpl-data/images/matplotlib.svg” (3)
```

**note**: Follows fix in 98745dae2b8e0e7a9c19f05548158ba20ccda0c0, but have not verified script output

cc @vani-nag 