### PR TITLE
Add CUDA::cuda_driver to target link libraries

### DIFF
--- a/operators/slang_shader/CMakeLists.txt
+++ b/operators/slang_shader/CMakeLists.txt
@@ -65,6 +65,7 @@ target_link_libraries(slang_shader
     holoscan::core
   PRIVATE
     CUDA::cudart
+    CUDA::cuda_driver
     slang::slang
     nlohmann_json::nlohmann_json
 )


### PR DESCRIPTION
Need to link against CUDA::cuda_drivers to avoid undefined references for some envs