### PR TITLE
App: fix `colonoscopy_segmentation` test

### DIFF
--- a/applications/colonoscopy_segmentation/CMakeLists.txt
+++ b/applications/colonoscopy_segmentation/CMakeLists.txt
@@ -61,6 +61,9 @@ if(BUILD_TESTING)
     DEPENDS "colonoscopy_segmentation_test.py"
   )
 
+  # Get GXF_LIB_DIR for Python tests
+  find_package(holoscan)
+
   # Add test
   add_test(NAME colonoscopy_segmentation_python_test
            COMMAND python3 ${CMAKE_CURRENT_BINARY_DIR}/colonoscopy_segmentation_test.py


### PR DESCRIPTION
`colonoscopy_segmentation` testing depends on Holoscan CMake import for PYTHONPATH library path setup. Observed an issue when testing locally where PYTHONPATH was improperly set up due to Holoscan SDK CMake not being imported. It's not clear where this variable has been defined in existing, passing coverage.

Update to formalize `find_package(holoscan)` requirement for the app test.