### PR TITLE
Update nvinfer package installation in Docker file

### DIFF
--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -1255,7 +1255,7 @@ def setup_cuda_packages(cuda_major_version: str, dry_run: bool = False) -> None:
     # Install TensorRT dependencies
     NVINFER_PATTERN = rf"\d+\.[0-9]+\.[0-9]+\.[0-9]+-[0-9]\+cuda{cuda_major_version}\.[0-9]+"
     try:
-        
+
         installed_libnvinferversion = install_cuda_dependencies_package(
             package_name="libnvinfer10",
             version_pattern=NVINFER_PATTERN,
@@ -1264,15 +1264,17 @@ def setup_cuda_packages(cuda_major_version: str, dry_run: bool = False) -> None:
         libnvinfer_pattern = re.escape(installed_libnvinferversion)
 
         install_packages_if_missing(
-            [f"libnvinfer-bin={installed_libnvinferversion}", 
-             f"libnvinfer-lean10={installed_libnvinferversion}",
-             f"libnvinfer-plugin10={installed_libnvinferversion}",
-             f"libnvinfer-vc-plugin10={installed_libnvinferversion}",
-             f"libnvinfer-dispatch10={installed_libnvinferversion}",
-             f"libnvonnxparsers10={installed_libnvinferversion}"],     
+            [
+                f"libnvinfer-bin={installed_libnvinferversion}",
+                f"libnvinfer-lean10={installed_libnvinferversion}",
+                f"libnvinfer-plugin10={installed_libnvinferversion}",
+                f"libnvinfer-vc-plugin10={installed_libnvinferversion}",
+                f"libnvinfer-dispatch10={installed_libnvinferversion}",
+                f"libnvonnxparsers10={installed_libnvinferversion}",
+            ],
             dry_run=dry_run,
         )
-       
+
         for trt_package_name in [
             "libnvinfer-headers-dev",
             "libnvinfer-dev",


### PR DESCRIPTION
- Added installation for additional TensorRT packages: `libnvinfer-lean10`, `libnvinfer-plugin10`, `libnvinfer-vc-plugin10`, `libnvinfer-dispatch10`, and `libnvonnxparsers10` to support CUDA 12 and CUDA 13

This enhances the setup process for CUDA dependencies.