### PR TITLE
colonoscopy seg match 12.9 in the base image

### DIFF
--- a/applications/colonoscopy_segmentation/Dockerfile
+++ b/applications/colonoscopy_segmentation/Dockerfile
@@ -32,9 +32,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ffmpeg \
         libnpp-12-9 \
         cuda-nvrtc-12-9 \
-        libnvinfer10 \
-        libnvinfer-plugin10 \
-        libnvonnxparsers10 \
+        libnvinfer10=*+cuda12.9 \
+        libnvinfer-lean10=*+cuda12.9 \
+        libnvinfer-plugin10=*+cuda12.9 \
+        libnvinfer-vc-plugin10=*+cuda12.9 \
+        libnvinfer-dispatch10=*+cuda12.9 \
+        libnvonnxparsers10=*+cuda12.9 \
         && rm -rf /var/lib/apt/lists/*
 
 RUN if [ $(uname -m) = "aarch64" ]; then ARCH=arm64; else ARCH=linux; fi \


### PR DESCRIPTION
see also https://github.com/nvidia-holoscan/holohub/pull/1056

without the fix the apt-get will use cuda13.0 which is not compatible with the base `FROM nvcr.io/nvidia/cuda:12.9.0-base-ubuntu24.04`

```
[2025-08-11T05:45:08.774Z] #9 7.437 Get:49 http://archive.ubuntu.com/ubuntu noble/main amd64 cmake amd64 3.28.3-1build7 [11.2 MB]
[2025-08-11T05:45:09.029Z] #9 7.660 Get:50 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64  libnvinfer10 10.13.2.6-1+cuda13.0 [1494 MB]
```