### PR TITLE
Update Slang version to fix error with CUDA 13.0

### DIFF
--- a/operators/slang_shader/CMakeLists.txt
+++ b/operators/slang_shader/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(holoscan 3.3.0 REQUIRED CONFIG
 include(FetchContent)
 FetchContent_Declare(
   Slang
-  URL https://github.com/shader-slang/slang/releases/download/v2025.10.2/slang-2025.10.2-linux-${CMAKE_SYSTEM_PROCESSOR}.tar.gz
+  URL https://github.com/shader-slang/slang/releases/download/v2025.14.3/slang-2025.14.3-linux-${CMAKE_SYSTEM_PROCESSOR}.tar.gz
   DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(Slang)


### PR DESCRIPTION
Slang shader examples failed with
`nvrtc 13.0: nvrtc: error : invalid value for --gpu-architecture (-arch)`
Updating to the latest Slang version fixed that.