### PR TITLE
CLI create project fixes template property

### DIFF
--- a/applications/template/{{cookiecutter.project_slug}}/CMakeLists.txt
+++ b/applications/template/{{cookiecutter.project_slug}}/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) {{ cookiecutter.year }} {{ cookiecutter.author }}
+# SPDX-FileCopyrightText: Copyright (c) {{ cookiecutter.year }} {{ cookiecutter.full_name }}
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/applications/template/{{cookiecutter.project_slug}}/Dockerfile
+++ b/applications/template/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-# SPDX-FileCopyrightText: Copyright (c) {{ cookiecutter.year }} {{ cookiecutter.author }}
+# SPDX-FileCopyrightText: Copyright (c) {{ cookiecutter.year }} {{ cookiecutter.full_name }}
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
address test errors:
```
Failed to create project: Unable to create file 'CMakeLists.txt'. Error message: 'collections.OrderedDict object' has no attribute 'author'. Context: OrderedDict([('cookiecutter', OrderedDict([('project_name', 'myproj'), ('project_slug', 'myproj'), ('full_name', 'HoloHub User'), ('affiliation', 'Holoscan'), ('language', 'cpp'), ('version', '0.1.0'), ('holoscan_version', '3.5.0'), ('platforms', ''), ('tags', ''), ('description', 'A brief description of the project'), ('license', 'Apache-2.0'), ('year', '2025'), ('_template', '/home/jenkins/agent/workspace/holohub-cli-nightly/holohub/applications/template'), ('_output_dir', '/home/jenkins/agent/workspace/holohub-cli-nightly/holohub/applications'), ('_repo_dir', '/home/jenkins/agent/workspace/holohub-cli-nightly/holohub/applications/template'), ('_checkout', None)])), ('_cookiecutter', {'project_name': 'myproj', 'project_slug': 'myproj', 'full_name': 'HoloHub User', 'affiliation': 'Holoscan', 'language': 'cpp', 'version': '0.1.0', 'holoscan_version': '3.5.0', 'platforms': '', 'tags': '', 'description': 'A brief description of the project', 'license': 'Apache-2.0', 'year': 2025})])
```