### PR TITLE
Op: Update "slang_shader" minimum CUDAToolkit version

### DIFF
--- a/operators/slang_shader/CMakeLists.txt
+++ b/operators/slang_shader/CMakeLists.txt
@@ -19,6 +19,7 @@ project(slang_shader)
 
 find_package(holoscan 3.3.0 REQUIRED CONFIG
              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+find_package(CUDAToolkit 12.8 REQUIRED)
 
 # Fetch Slang
 include(FetchContent)


### PR DESCRIPTION
In reflection of app build failures observed with NVCC 12.6 on bare metal IGX dGPU (IGX OS 1.1.2)

```
[ 80%] Building CXX object operators/slang_shader/CMakeFiles/slang_shader.dir/slang_shader_op.cpp.o
In file included from /home/tbirdsong/repos/holohub/operators/slang_shader/slang_shader.hpp:28,
                 from /home/tbirdsong/repos/holohub/operators/slang_shader/slang_shader.cpp:18:
/home/tbirdsong/repos/holohub/operators/slang_shader/cuda_utils.hpp:83:21: error: ‘cudaLibrary_t’ was not declared in this scope; did you mean ‘cudaArray_t’?
   83 |     std::unique_ptr<cudaLibrary_t, Deleter<cudaLibrary_t, &cudaLibraryUnload>>;
      |                     ^~~~~~~~~~~~~
      |                     cudaArray_t
```

It appears that CUDA Runtime library management APIs required for building SlangShaderOp were introduced in CUDA Toolkit 12.8

Ref: https://docs.nvidia.com/cuda/archive/12.8.0/cuda-driver-api/group__CUDA__LIBRARY.html#group__CUDA__LIBRARY

## Additional Details

Failure observed with toolchain versions:
```
$ nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2024 NVIDIA Corporation
Built on Wed_Oct_30_00:08:18_PDT_2024
Cuda compilation tools, release 12.6, V12.6.85
Build cuda_12.6.r12.6/compiler.35059454_0

$ gcc --version
gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```