### PR TITLE
CLI: add build-name-suffix to ./holohub test

### DIFF
--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -840,7 +840,7 @@ class HoloHubCLI:
             else:
                 image_name = args.base_img or container.default_base_image()
             tag = image_name.split(":")[-1]
-        ctest_cmd = f"{xvfb} ctest " f"-DAPP={args.project} " f"-DTAG={tag} "
+        ctest_cmd = f"{xvfb} ctest -DAPP={args.project} -DTAG={tag} "
 
         if args.cmake_options:
             ctest_cmd += f'-DCONFIGURE_OPTIONS="{args.cmake_options}" '

--- a/utilities/cli/tests/CMakeLists.txt
+++ b/utilities/cli/tests/CMakeLists.txt
@@ -344,3 +344,12 @@ add_test(
 set_property(TEST test_holohub_run_multi_language_project PROPERTY
     PASS_REGULAR_EXPRESSION "has multiple languages.*language"
 )
+
+add_test(
+    NAME test_holohub_test_build_name_suffix
+    COMMAND ${CMAKE_SOURCE_DIR}/holohub test --dryrun --build-name-suffix=test-branch
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_property(TEST test_holohub_test_build_name_suffix PROPERTY
+    PASS_REGULAR_EXPRESSION "DTAG=test-branch"
+)


### PR DESCRIPTION
Added `--build-name-suffix` parameter to the `./holohub test` command

the existing `-DTAG` option is hard-coded to `base_img.split(":")[-1]` which is not flexible enough for cases such as `no-docker-build`