### PR TITLE
Fix URL Check Error For PR Only Changes

### DIFF
--- a/.github/workflows/check_urls.yml
+++ b/.github/workflows/check_urls.yml
@@ -47,6 +47,7 @@ jobs:
           --no-progress
           ${{ steps.changed-files.outputs.changed_files_list }}
         fail: true
+        failIfEmpty: false
         jobSummary: true
 
     - name: Link checker (all files)


### PR DESCRIPTION
This pull request introduces a minor configuration update to the link checker workflow. The change ensures that the workflow does not fail if no files are found to check, which can help prevent unnecessary failures in certain scenarios.

* Workflow configuration: Set `failIfEmpty: false` in the `jobs:` section of `.github/workflows/check_urls.yml` to avoid failing the job when there are no files to check.