### PR TITLE
SlangShaderOp: Use CUDA driver API instead of runtime API

### DIFF
--- a/operators/slang_shader/CMakeLists.txt
+++ b/operators/slang_shader/CMakeLists.txt
@@ -19,7 +19,6 @@ project(slang_shader)
 
 find_package(holoscan 3.3.0 REQUIRED CONFIG
              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
-find_package(CUDAToolkit 12.8 REQUIRED)
 
 add_subdirectory(cpp)
 

--- a/operators/slang_shader/cpp/CMakeLists.txt
+++ b/operators/slang_shader/cpp/CMakeLists.txt
@@ -59,7 +59,7 @@ target_link_libraries(slang_shader
   PUBLIC
     holoscan::core
   PRIVATE
-    CUDA::cudart
+    CUDA::cuda_driver
     slang::slang
     nlohmann_json::nlohmann_json
 )

--- a/operators/slang_shader/cpp/command.hpp
+++ b/operators/slang_shader/cpp/command.hpp
@@ -25,6 +25,8 @@
 #include <string>
 #include <vector>
 
+#include <cuda.h>
+
 #include <holoscan/core/execution_context.hpp>
 #include <holoscan/core/io_context.hpp>
 
@@ -75,7 +77,7 @@ class CommandWorkspace {
   /// Resource information
   struct ResourceInfo {
     PortInfo* port_info_ = nullptr;
-    void* pointer_ = nullptr;
+    CUdeviceptr pointer_ = 0;
     size_t size_ = 0;
   };
 
@@ -433,7 +435,8 @@ class CommandLaunch : public Command {
   dim3 thread_group_size_;  ///< CUDA thread group dimensions (threads per thread group).
   const std::string invocations_size_of_name_;  ///< Name of invocation size parameter
   const dim3 invocations_;                      ///< Total number of invocations
-  cudaKernel_t kernel_ = nullptr;               ///< Compiled CUDA kernel handle
+  CUkernel kernel_ = nullptr;                   ///< Compiled CUDA kernel handle
+  CUfunction function_ = nullptr;               ///< CUDA function handle
 };
 
 /**

--- a/operators/slang_shader/cpp/include/slang_shader/slang_shader.hpp
+++ b/operators/slang_shader/cpp/include/slang_shader/slang_shader.hpp
@@ -46,6 +46,7 @@ class SlangShaderOp : public Operator {
   Parameter<std::string> shader_source_;
   Parameter<std::string> shader_source_file_;
   Parameter<PreprocessorMacros> preprocessor_macros_;
+  Parameter<int> cuda_device_ordinal_;
   Parameter<std::shared_ptr<Allocator>> allocator_;
 
   // Forward declaration of implementation

--- a/operators/slang_shader/cpp/slang_shader_compiler.hpp
+++ b/operators/slang_shader/cpp/slang_shader_compiler.hpp
@@ -87,7 +87,7 @@ class SlangShaderCompiler {
    * a CUDA kernel handle. The kernel can then be launched using CUDA runtime
    * functions with appropriate grid and block dimensions.
    */
-  cudaKernel_t get_kernel(const std::string& name);
+  CUkernel get_kernel(const std::string& name);
 
   /**
    * @brief Updates global parameters for the shader
@@ -112,15 +112,15 @@ class SlangShaderCompiler {
   Slang::ComPtr<slang::IComponentType> linked_program_;
 
   /// CUDA libraries containing the compiled kernels
-  std::vector<UniqueCudaLibrary> cuda_libraries_;
+  std::vector<UniqueCuLibrary> cuda_libraries_;
 
   /// Size of the global parameters buffer in bytes
   size_t global_params_size_ = 0;
 
   /// Kernel information
   struct KernelInfo {
-    void* dev_global_params_ = nullptr;   ///< Pointer to the device global parameters
-    cudaKernel_t cuda_kernel_ = nullptr;  ///< CUDA kernel handle
+    CUdeviceptr dev_global_params_ = 0;  ///< Pointer to the device global parameters
+    CUkernel cuda_kernel_ = nullptr;     ///< CUDA kernel handle
   };
 
   /// Map of kernel names to kernel information

--- a/operators/slang_shader/cpp/test/test_slang_shader_op.cpp
+++ b/operators/slang_shader/cpp/test/test_slang_shader_op.cpp
@@ -220,7 +220,7 @@ class SinkOp : public Operator {
 
     if (print_output_.get()) {
       std::vector<int> values(tensor->size());
-      CUDA_CALL(cudaMemcpy(
+      CUDA_RT_CALL(cudaMemcpy(
           values.data(), tensor->data(), tensor->size() * sizeof(int), cudaMemcpyDefault));
 
       std::cout << fmt::format("{}", fmt::join(values, ", ")) << std::endl;
@@ -319,7 +319,7 @@ class SlangShaderApp : public holoscan::Application {
     EXPECT_NO_THROW(run());
 
     // Synchronize to ensure that the output is captured
-    CUDA_CALL(cudaDeviceSynchronize());
+    CUDA_RT_CALL(cudaDeviceSynchronize());
 
     std::string stdout_output = testing::internal::GetCapturedStdout();
     EXPECT_THAT(stdout_output, testing::Eq(expected_output));


### PR DESCRIPTION
Runtime API for CUDA library management needs at least CTK 12.8 but we want to support earlier versions also.