### PR TITLE
CLI: ./holohub test update ctest options

### DIFF
--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -376,13 +376,15 @@ class HoloHubCLI:
         test.add_argument("--platform-name", help="Platform name")
         test.add_argument(
             "--cmake-options",
-            help="CMake options (semicolon-separated for multiple). "
-            "Example: --cmake-options='-DCUSTOM_OPTION=ON;-DDEBUG_MODE=1'",
+            action="append",
+            help="CMake options"
+            "example: --cmake-options='-DCUSTOM_OPTION=ON' --cmake-options='-DDEBUG_MODE=1'",
         )
         test.add_argument(
             "--ctest-options",
-            help="CTest options (semicolon-separated for multiple). "
-            "Example: --ctest-options='-DGPU_TYPE=rtx4090;-DDEBUG_MODE=ON'",
+            action="append",
+            help="CTest options"
+            "example: --ctest-options='-DGPU_TYPE=rtx4090' --ctest-options='-DDEBUG_MODE=ON'",
         )
         test.add_argument("--no-xvfb", action="store_true", help="Do not use xvfb")
         test.add_argument("--ctest-script", help="CTest script")
@@ -852,17 +854,11 @@ class HoloHubCLI:
         ctest_cmd = f"{xvfb} ctest -DAPP={args.project} -DTAG={tag} "
 
         if args.cmake_options:
-            ctest_cmd += f'-DCONFIGURE_OPTIONS="{args.cmake_options}" '
+            cmake_opts = ";".join(args.cmake_options)
+            ctest_cmd += f'-DCONFIGURE_OPTIONS="{cmake_opts}" '
 
         if getattr(args, "ctest_options", None):
-            # Parse semicolon-separated ctest options and add each as a -D flag to ctest
-            ctest_opts = args.ctest_options.split(";")
-            for opt in ctest_opts:
-                opt = opt.strip()
-                if opt:  # Skip empty options
-                    if opt.startswith("-D"):
-                        opt = opt[2:]
-                    ctest_cmd += f"-D{opt} "
+            ctest_cmd += " ".join(args.ctest_options) + " "
 
         if args.cdash_url:
             ctest_cmd += f"-DCTEST_SUBMIT_URL={args.cdash_url} "

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -374,7 +374,11 @@ class HoloHubCLI:
         test.add_argument("--site-name", help="Site name")
         test.add_argument("--cdash-url", help="CDash URL")
         test.add_argument("--platform-name", help="Platform name")
-        test.add_argument("--cmake-options", help="CMake options")
+        test.add_argument(
+            "--cmake-options",
+            help="CMake options (semicolon-separated for multiple). "
+            "Example: --cmake-options='-DCUSTOM_OPTION=ON;-DDEBUG_MODE=1'",
+        )
         test.add_argument("--no-xvfb", action="store_true", help="Do not use xvfb")
         test.add_argument("--ctest-script", help="CTest script")
         test.add_argument(

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -382,7 +382,7 @@ class HoloHubCLI:
         test.add_argument(
             "--ctest-options",
             help="CTest options (semicolon-separated for multiple). "
-            "Example: --ctest-options='GPU_TYPE=rtx4090;DEBUG_MODE=ON'",
+            "Example: --ctest-options='-DGPU_TYPE=rtx4090;-DDEBUG_MODE=ON'",
         )
         test.add_argument("--no-xvfb", action="store_true", help="Do not use xvfb")
         test.add_argument("--ctest-script", help="CTest script")

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -379,6 +379,11 @@ class HoloHubCLI:
             help="CMake options (semicolon-separated for multiple). "
             "Example: --cmake-options='-DCUSTOM_OPTION=ON;-DDEBUG_MODE=1'",
         )
+        test.add_argument(
+            "--ctest-options",
+            help="CTest options (semicolon-separated for multiple). "
+            "Example: --ctest-options='GPU_TYPE=rtx4090;DEBUG_MODE=ON'",
+        )
         test.add_argument("--no-xvfb", action="store_true", help="Do not use xvfb")
         test.add_argument("--ctest-script", help="CTest script")
         test.add_argument(
@@ -848,6 +853,16 @@ class HoloHubCLI:
 
         if args.cmake_options:
             ctest_cmd += f'-DCONFIGURE_OPTIONS="{args.cmake_options}" '
+
+        if getattr(args, "ctest_options", None):
+            # Parse semicolon-separated ctest options and add each as a -D flag to ctest
+            ctest_opts = args.ctest_options.split(";")
+            for opt in ctest_opts:
+                opt = opt.strip()
+                if opt:  # Skip empty options
+                    if opt.startswith("-D"):
+                        opt = opt[2:]
+                    ctest_cmd += f"-D{opt} "
 
         if args.cdash_url:
             ctest_cmd += f"-DCTEST_SUBMIT_URL={args.cdash_url} "

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -377,13 +377,13 @@ class HoloHubCLI:
         test.add_argument(
             "--cmake-options",
             action="append",
-            help="CMake options"
+            help="CMake options, "
             "example: --cmake-options='-DCUSTOM_OPTION=ON' --cmake-options='-DDEBUG_MODE=1'",
         )
         test.add_argument(
             "--ctest-options",
             action="append",
-            help="CTest options"
+            help="CTest options, "
             "example: --ctest-options='-DGPU_TYPE=rtx4090' --ctest-options='-DDEBUG_MODE=ON'",
         )
         test.add_argument("--no-xvfb", action="store_true", help="Do not use xvfb")

--- a/utilities/cli/tests/CMakeLists.txt
+++ b/utilities/cli/tests/CMakeLists.txt
@@ -355,10 +355,19 @@ set_property(TEST test_holohub_test_build_name_suffix PROPERTY
 )
 
 add_test(
+    NAME test_holohub_test_cmake_options
+    COMMAND ${CMAKE_SOURCE_DIR}/holohub test --dryrun --cmake-options="-DMAKE=1" --cmake-options="-DMAKE2=2" --ctest-options="-DTEST=2"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_property(TEST test_holohub_test_cmake_options PROPERTY
+    PASS_REGULAR_EXPRESSION "DCONFIGURE_OPTIONS.*DMAKE=1.*DMAKE2=2.*DTEST=2"
+)
+
+add_test(
     NAME test_holohub_test_ctest_options
-    COMMAND ${CMAKE_SOURCE_DIR}/holohub test --dryrun --cmake-options=-DMAKE=1 --ctest-options=-DTEST=2
+    COMMAND ${CMAKE_SOURCE_DIR}/holohub test --dryrun --ctest-options="-DMAKE2=2" --ctest-options="-DTEST=2"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 set_property(TEST test_holohub_test_ctest_options PROPERTY
-    PASS_REGULAR_EXPRESSION "-DCONFIGURE_OPTIONS=\"-DMAKE=1\" -DTEST=2"
+    PASS_REGULAR_EXPRESSION "DMAKE2=2.*DTEST=2"
 )

--- a/utilities/cli/tests/CMakeLists.txt
+++ b/utilities/cli/tests/CMakeLists.txt
@@ -353,3 +353,12 @@ add_test(
 set_property(TEST test_holohub_test_build_name_suffix PROPERTY
     PASS_REGULAR_EXPRESSION "DTAG=test-branch"
 )
+
+add_test(
+    NAME test_holohub_test_ctest_options
+    COMMAND ${CMAKE_SOURCE_DIR}/holohub test --dryrun --cmake-options=-DMAKE=1 --ctest-options=-DTEST=2
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_property(TEST test_holohub_test_ctest_options PROPERTY
+    PASS_REGULAR_EXPRESSION "-DCONFIGURE_OPTIONS=\"-DMAKE=1\" -DTEST=2"
+)

--- a/utilities/testing/holohub.container.ctest
+++ b/utilities/testing/holohub.container.ctest
@@ -50,9 +50,8 @@ set(configure_options
   -D HOLOHUB_DATA_DIR=/workspace/holohub/data-${APP}-${TAG}
   -D CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc
   -D CMAKE_BUILD_TYPE=RelWithDebInfo
+  -D APP_${APP}=ON
 )
-
-list(APPEND configure_options -DAPP_${APP}=ON)
 
 # Default nightly start time
 set(CTEST_NIGHTLY_START_TIME "06:00:00 UTC")


### PR DESCRIPTION
~change the ctest config to unquoted `${configure_options}` to allow for multiple `-Doptions`~

existing `./holohub test --cmake-options` will pass the -D options to the app level.
there's still a need for `--ctest-options` with additional config directly set for `ctest ...`

