### PR TITLE
App: Fix Endoscopy Tool Tracking compatibility on IGX OS host environment

### DIFF
--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -49,8 +49,11 @@ add_holohub_application(endoscopy_out_of_body_detection DEPENDS OPERATORS aja_so
 add_holohub_application(endoscopy_tool_tracking DEPENDS
                         OPERATORS lstm_tensor_rt_inference
                                   tool_tracking_postprocessor
+                        OPTIONAL  aja_source
+                                  deltacast_videomaster
                                   slang_shader
-                                  OPTIONAL deltacast_videomaster yuan_qcap vtk_renderer aja_source)
+                                  yuan_qcap
+                                  vtk_renderer)
 
 add_subdirectory(h264)
 

--- a/applications/endoscopy_tool_tracking/cpp/CMakeLists.txt
+++ b/applications/endoscopy_tool_tracking/cpp/CMakeLists.txt
@@ -32,12 +32,12 @@ target_link_libraries(endoscopy_tool_tracking
   holoscan::ops::holoviz
   lstm_tensor_rt_inference
   tool_tracking_postprocessor
-  holoscan::ops::slang_shader
 )
 
 target_link_libraries(endoscopy_tool_tracking PRIVATE $<TARGET_NAME_IF_EXISTS:holoscan::aja>)
-target_link_libraries(endoscopy_tool_tracking PRIVATE $<TARGET_NAME_IF_EXISTS:holoscan::videomaster>)
 target_link_libraries(endoscopy_tool_tracking PRIVATE $<TARGET_NAME_IF_EXISTS:holoscan::qcap_source>)
+target_link_libraries(endoscopy_tool_tracking PRIVATE $<TARGET_NAME_IF_EXISTS:holoscan::ops::slang_shader>)
+target_link_libraries(endoscopy_tool_tracking PRIVATE $<TARGET_NAME_IF_EXISTS:holoscan::videomaster>)
 target_link_libraries(endoscopy_tool_tracking PRIVATE $<TARGET_NAME_IF_EXISTS:holoscan::vtk_renderer>)
 
 # Download the associated dataset if needed

--- a/applications/endoscopy_tool_tracking/cpp/main.cpp
+++ b/applications/endoscopy_tool_tracking/cpp/main.cpp
@@ -23,9 +23,13 @@
 #include <holoscan/operators/video_stream_recorder/video_stream_recorder.hpp>
 #include <holoscan/operators/video_stream_replayer/video_stream_replayer.hpp>
 #include <lstm_tensor_rt_inference.hpp>
-#include <slang_shader/slang_shader.hpp>
 #include <string>
 #include <tool_tracking_postprocessor.hpp>
+
+#ifdef HOLOSCAN_OP_SLANG_SHADER
+#include <slang_shader/slang_shader.hpp>
+#endif
+
 #ifdef VTK_RENDERER
 #include <vtk_renderer.hpp>
 #endif
@@ -190,10 +194,16 @@ class App : public holoscan::Application {
                                        tool_tracking_postprocessor_block_size,
                                        tool_tracking_postprocessor_num_blocks);
     if (postprocessor_ == "slang_shader") {
+#ifdef HOLOSCAN_OP_SLANG_SHADER
       tool_tracking_postprocessor = make_operator<ops::SlangShaderOp>(
           "slang_postprocessor",
           Arg("shader_source_file", app_path_ + "/postprocessor.slang"),
           Arg("allocator") = postprocessor_allocator);
+#else
+      throw std::runtime_error(
+          "Slang shader postprocessor is requested but not available."
+          " Please enable slang_shader at build time.");
+#endif
     } else if (postprocessor_ == "tool_tracking_postprocessor") {
       tool_tracking_postprocessor = make_operator<ops::ToolTrackingPostprocessorOp>(
           "tool_tracking_postprocessor",

--- a/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py
+++ b/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py
@@ -33,7 +33,6 @@ from holoscan.resources import (
 )
 
 from holohub.lstm_tensor_rt_inference import LSTMTensorRTInferenceOp
-from holohub.slang_shader import SlangShaderOp
 from holohub.tool_tracking_postprocessor import ToolTrackingPostprocessorOp
 
 
@@ -252,7 +251,8 @@ class EndoscopyApp(Application):
             num_blocks=tool_tracking_postprocessor_num_blocks,
         )
         if self.postprocessor == "slang_shader":
-            tool_tracking_postprocessor = SlangShaderOp(
+            slang_shader = lazy_import("holohub.slang_shader")
+            tool_tracking_postprocessor = slang_shader.SlangShaderOp(
                 self,
                 name="slang_postprocessor",
                 shader_source_file=os.path.join(os.path.dirname(__file__), "postprocessor.slang"),

--- a/operators/slang_shader/cpp/CMakeLists.txt
+++ b/operators/slang_shader/cpp/CMakeLists.txt
@@ -73,6 +73,7 @@ target_link_libraries(slang_shader
 target_include_directories(slang_shader INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_compile_definitions(slang_shader PRIVATE HOLOSCAN_MAJOR_VERSION=${holoscan_VERSION_MAJOR})
 target_compile_definitions(slang_shader PRIVATE HOLOSCAN_MINOR_VERSION=${holoscan_VERSION_MINOR})
+target_compile_definitions(slang_shader PUBLIC HOLOSCAN_OP_SLANG_SHADER)
 
 install(TARGETS slang_shader
   COMPONENT holoscan-ops

--- a/operators/slang_shader/cpp/CMakeLists.txt
+++ b/operators/slang_shader/cpp/CMakeLists.txt
@@ -15,6 +15,12 @@
 
 cmake_minimum_required(VERSION 3.20)
 
+
+# Check minimum required GCC version for Slang release package
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND (CMAKE_C_COMPILER_VERSION VERSION_LESS "13.0.0" OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS "13.0.0"))
+    message(FATAL_ERROR "GCC version ${CMAKE_CXX_COMPILER_VERSION} is too old. Need GCC 13.0.0 or newer to compile with libslang.so.")
+endif()
+
 # Fetch Slang
 include(FetchContent)
 FetchContent_Declare(

--- a/operators/slang_shader/cpp/slang_shader_compiler.hpp
+++ b/operators/slang_shader/cpp/slang_shader_compiler.hpp
@@ -102,7 +102,7 @@ class SlangShaderCompiler {
    * parameter structure as defined in the shader source.
    */
   void update_global_params(const std::string& name, const std::vector<uint8_t>& shader_parameters,
-                            CUstream stream);
+                            cudaStream_t stream);
 
  private:
   /// Slang module containing the compiled shader code

--- a/operators/slang_shader/cpp/slang_shader_compiler.hpp
+++ b/operators/slang_shader/cpp/slang_shader_compiler.hpp
@@ -102,7 +102,7 @@ class SlangShaderCompiler {
    * parameter structure as defined in the shader source.
    */
   void update_global_params(const std::string& name, const std::vector<uint8_t>& shader_parameters,
-                            cudaStream_t stream);
+                            CUstream stream);
 
  private:
   /// Slang module containing the compiled shader code


### PR DESCRIPTION
## Overview

Followup to 4ae73c0ef67e648f10db8fd9e063c36313c1070d to restore IGX Orin dGPU bare metal build and runtime compatibility to the Endoscopy Tool Tracking demo app.

## Background

deebc27f1244032797d422016d81e14874f6cbb1 added SlangShaderOp support to the Endoscopy Tool Tracking application. Tests and inspection reveal that the SlangShaderOp is not currently compatible with the IGX OS 1.x build and runtime environment.

- IGX OS 1.x: CUDA Driver R535, CUDA Toolkit 12.6, GCC 11.4, GLIBC 2.35
- SlangShaderOp: CUDA Toolkit >= 12.8 (previous) or >= 12.0 (updated)
  - libslang.so: GCC >= 13

## Changes

Updates Endoscopy Tool Tracking and SlangShaderOp as follows:
- Makes SlangShaderOp an optional build and runtime dependency of Endoscopy Tool Tracking. A similar approach is used for other optional operators such as the VTK renderer.
- Fixes leftover CUDA Runtime symbol `cudaLibrary_t` in SlangShaderOp to update compatibility from CTK >= 12.8 to CTK >= 12.0. Fixes compilation error with CTK 12.6 (tested)

Fixes observed error when building on IGX OS 1.1.2:
```
$ ./holohub build --local endoscopy_tool_tracking
...
[7/37] Building CXX object operators/slang_shader/cpp/CMakeFiles/slang_shader.dir/slang_shader_compiler.cpp.o
FAILED: operators/slang_shader/cpp/CMakeFiles/slang_shader.dir/slang_shader_compiler.cpp.o 
/usr/bin/c++ -DEIGEN_MPL2_ONLY -DFMT_HEADER_ONLY=1 -DHOLOSCAN_MAJOR_VERSION=3 -DHOLOSCAN_MINOR_VERSION=5 -DRMM_LOG_ACTIVE_LEVEL=RAPIDS_LOGGER_LEVEL_INFO -DSLANG_DYNAMIC -DUCXX_ENABLE_RMM -DYAML_CPP_STATIC_DEFINE -Dslang_shader_EXPORTS -I/home/tbirdsong/repos/holohub/build/endoscopy_tool_tracking/operators/slang_shader/cpp -I/home/tbirdsong/repos/holohub/build/endoscopy_tool_tracking/_deps/nlohmann_json-src/include -isystem /home/tbirdsong/repos/holohub/build/endoscopy_tool_tracking/_deps/slang-src/include -isystem /opt/nvidia/holoscan/include -isystem /opt/nvidia/holoscan/include/3rdparty -isystem /opt/nvidia/holoscan/include/gxf -isystem /usr/local/cuda/targets/sbsa-linux/include -isystem /opt/nvidia/holoscan/include/3rdparty/ucx -isystem /opt/nvidia/holoscan/include/3rdparty/ucxx -O3 -DNDEBUG -fPIC -MD -MT operators/slang_shader/cpp/CMakeFiles/slang_shader.dir/slang_shader_compiler.cpp.o -MF operators/slang_shader/cpp/CMakeFiles/slang_shader.dir/slang_shader_compiler.cpp.o.d -o operators/slang_shader/cpp/CMakeFiles/slang_shader.dir/slang_shader_compiler.cpp.o -c /home/tbirdsong/repos/holohub/operators/slang_shader/cpp/slang_shader_compiler.cpp
/home/tbirdsong/repos/holohub/operators/slang_shader/cpp/slang_shader_compiler.cpp: In lambda function:
/home/tbirdsong/repos/holohub/operators/slang_shader/cpp/slang_shader_compiler.cpp:76:7: error: ‘cudaLibrary_t’ was not declared in this scope; did you mean ‘cudaArray_t’?
   76 |       cudaLibrary_t library;
      |       ^~~~~~~~~~~~~
      |       cudaArray_t
In file included from /home/tbirdsong/repos/holohub/operators/slang_shader/cpp/slang_shader_compiler.hpp:28,
                 from /home/tbirdsong/repos/holohub/operators/slang_shader/cpp/slang_shader_compiler.cpp:18:
/home/tbirdsong/repos/holohub/operators/slang_shader/cpp/slang_shader_compiler.cpp:78:12: error: ‘library’ was not declared in this scope; did you mean ‘CUlibrary’?
   78 |           &library, ptx_code->getBufferPointer(), nullptr, nullptr, 0, nullptr, nullptr, 0));
      |            ^~~~~~~
/home/tbirdsong/repos/holohub/operators/slang_shader/cpp/cuda_utils.hpp:73:35: note: in definition of macro ‘CUDA_CALL’
   73 |     CUresult _holoscan_cuda_err = stmt;                                                   \
      |                                   ^~~~
/home/tbirdsong/repos/holohub/operators/slang_shader/cpp/slang_shader_compiler.cpp:79:14: error: ‘library’ was not declared in this scope; did you mean ‘CUlibrary’?
   79 |       return library;
      |              ^~~~~~~
      |              CUlibrary
```

- Adds compiler check to enforce GCC >= 13 when linking against libslang.so. Fixes observed linking error:
```
    /usr/bin/ld: .../holohub-internal/build/endoscopy_tool_tracking/_deps/slang-src/lib/libslang.so: undefined reference t
o `fmodf@GLIBC_2.38'
```

## Testing

Verified Endoscopy Tool Tracking tests pass in the IGX dGPU OS 1.1.2 host environment with Holoscan SDK 3.5.0 Debian package and Python wheel installed. SlangShaderOp test coverage is disabled by default.
```
$ xvfb-run -a ctest -C Release
Test project /home/tbirdsong/repos/holohub/build/endoscopy_tool_tracking
    Start 1: endoscopy_tool_tracking_cpp_test
1/4 Test #1: endoscopy_tool_tracking_cpp_test .............   Passed    1.36 sec
    Start 2: endoscopy_tool_tracking_cpp_render_test
2/4 Test #2: endoscopy_tool_tracking_cpp_render_test ......   Passed    2.08 sec
    Start 3: endoscopy_tool_tracking_python_test
3/4 Test #3: endoscopy_tool_tracking_python_test ..........   Passed    1.67 sec
    Start 4: endoscopy_tool_tracking_python_render_test
4/4 Test #4: endoscopy_tool_tracking_python_render_test ...   Passed    2.09 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =   7.21 sec
```