### PR TITLE
App: Update Endoscopy Depth Estimation for latest Holoscan SDK

### DIFF
--- a/applications/endoscopy_depth_estimation/Dockerfile
+++ b/applications/endoscopy_depth_estimation/Dockerfile
@@ -18,12 +18,23 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE} as base
 
-ARG OPEN_CV_VERSION=4.10.0
+#############################################################
+# Install common dependencies via HoloHub CLI
+#############################################################
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Set default shell to /bin/bash
-SHELL ["/bin/bash", "-cu"]
+FROM base as holohub-setup
+RUN mkdir -p /tmp/scripts
+COPY holohub /tmp/scripts/
+RUN mkdir -p /tmp/scripts/utilities
+COPY utilities /tmp/scripts/utilities/
+RUN chmod +x /tmp/scripts/holohub
+RUN /tmp/scripts/holohub setup && rm -rf /var/lib/apt/lists/*
 
+#############################################################
+# Install Runtime Dependencies
+#############################################################
+FROM holohub-setup as run
 
 RUN apt-get update && apt-get install -y build-essential cmake git \
     libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev \
@@ -33,41 +44,6 @@ RUN apt-get update && apt-get install -y build-essential cmake git \
     libgstreamer-plugins-base1.0-dev libavutil-dev libavfilter-dev libjsoncpp-dev ffmpeg \
      && apt-get clean
 
-RUN chmod +rwx /usr/bin/python3.10
-
 # Install OpenCV
-RUN git clone --depth 1 --branch $OPEN_CV_VERSION https://github.com/opencv/opencv.git && \
-    git clone --depth 1 --branch $OPEN_CV_VERSION https://github.com/opencv/opencv_contrib.git && \
-    cd opencv && mkdir -p build && cd build && \
-    cmake -D CMAKE_BUILD_TYPE=RELEASE \
-    -D CMAKE_INSTALL_PREFIX=/usr/local \
-    -D BUILD_TESTS=OFF \
-    -D BUILD_PERF_TESTS=OFF \
-    -D BUILD_opencv_apps=OFF \
-    -D BUILD_EXAMPLES=OFF \
-    -D BUILD_DOCS=OFF \
-    -D INSTALL_PYTHON_EXAMPLES=OFF \
-    -D INSTALL_C_EXAMPLES=OFF \
-    -D WITH_TBB=ON \
-    -D ENABLE_FAST_MATH=1 \
-    -D CUDA_FAST_MATH=1 \
-    -D WITH_CUBLAS=1 \
-    -D WITH_CUDA=ON \
-    -D BUILD_opencv_cudacodec=OFF \
-    -D WITH_CUDNN=ON \
-    -D OPENCV_DNN_CUDA=ON \
-    -D CUDA_ARCH_BIN=8.6,8.7,8.9 \
-    -D WITH_V4L=ON \
-    -D WITH_QT=OFF \
-    -D WITH_OPENGL=ON \
-    -D WITH_GSTREAMER=ON \
-    -D OPENCV_GENERATE_PKGCONFIG=ON \
-    -D OPENCV_PC_FILE_NAME=opencv.pc \
-    -D OPENCV_ENABLE_NONFREE=ON \
-    -D PYTHON3_PACKAGES_PATH=/usr/lib/python3.10/dist-packages \
-    -D PYTHON_EXECUTABLE=/usr/bin/python \
-    -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib/modules \
-    .. && \
-    make -j8 && \
-    make install && \
-    ldconfig
+ARG OPEN_CV_VERSION=4.10
+RUN python3 -m pip install opencv-python~=${OPEN_CV_VERSION}

--- a/applications/endoscopy_depth_estimation/metadata.json
+++ b/applications/endoscopy_depth_estimation/metadata.json
@@ -13,9 +13,9 @@
 			"1.0": "Initial Release"
 		},
 		"holoscan_sdk": {
-			"minimum_required_version": "0.6.0",
+			"minimum_required_version": "3.3.0",
 			"tested_versions": [
-				"0.6.0"
+				"3.5.0"
 			]
 		},
 		"platforms": [


### PR DESCRIPTION
Update to build and run Endoscopy Depth Estimation with Holoscan SDK v3.5.

Holoscan SDK v3.3 updated the default Python version to Python 3.12.

Also addresses observed issues:
- NGC CLI missing, data could not be downloaded
- OpenCV build error in latest Holoscan SDK container, but OpenCV is only a Python runtime dependency and can be installed from PyPI

Tested with Xvfb on x86_64 with Holoscan SDK v3.5.