### PR TITLE
Do not check links of deleted files.

### DIFF
--- a/.github/workflows/check_urls.yml
+++ b/.github/workflows/check_urls.yml
@@ -19,7 +19,7 @@ jobs:
       id: changed-files
       run: |
         # Get changed files using git diff
-        if git diff --name-only origin/${{ github.base_ref }}..HEAD | grep -E '\.(md|html|rst)$' > changed_files.txt; then
+        if git diff --name-only --diff-filter=d origin/${{ github.base_ref }}..HEAD | grep -E '\.(md|html|rst)$' > changed_files.txt; then
           if [ -s changed_files.txt ]; then
             echo "any_changed=true" >> $GITHUB_OUTPUT
             echo "changed_files_list=$(cat changed_files.txt | sed 's|^|'"'"'${{ github.workspace }}/|; s|$|'"'"'|' | tr '\n' ' ')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The link-check workflow will currently check links for the result of `git diff --name-only`, which will return added, modified, and deleted files. Applying `--diff-filter=d` will exclude deleted files so that those links are not checked.