### PR TITLE
App: Add iGPU support in "yolo_model_deployment"

### DIFF
--- a/applications/yolo_model_deployment/Dockerfile
+++ b/applications/yolo_model_deployment/Dockerfile
@@ -22,10 +22,25 @@ FROM ${BASE_IMAGE} as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+FROM base as holohub-setup
+
+# --------------------------------------------------------------------------
+#
+# Holohub dev setup
+#
+RUN mkdir -p /tmp/scripts
+COPY holohub /tmp/scripts/
+RUN mkdir -p /tmp/scripts/utilities
+COPY utilities /tmp/scripts/utilities/
+RUN chmod +x /tmp/scripts/holohub
+RUN /tmp/scripts/holohub setup && rm -rf /var/lib/apt/lists/*
+
 # --------------------------------------------------------------------------
 #
 # Install required apt packages and python modules
 #
+FROM holohub-setup as holohub-yolo
+
 RUN apt-get update \
     && apt-get install -y libgl1
 
@@ -34,17 +49,12 @@ RUN pip3 install \
     onnx \
     onnx-graphsurgeon
 
-# --------------------------------------------------------------------------
-#
-# Holohub dev setup
-#
-
-RUN mkdir -p /tmp/scripts
-COPY holohub /tmp/scripts/
-RUN mkdir -p /tmp/scripts/utilities
-COPY utilities /tmp/scripts/utilities/
-RUN chmod +x /tmp/scripts/holohub
-RUN /tmp/scripts/holohub setup && rm -rf /var/lib/apt/lists/*
+ARG GPU_TYPE
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+RUN if [ "${GPU_TYPE}" == "igpu" ]; then \
+        python3 -m pip list | grep -i torch | awk '{print $1}' | xargs -r python3 -m pip uninstall -y; \
+        python3 -m pip install torch torchvision torchaudio --force-reinstall --index-url "https://pypi.jetson-ai-lab.io/jp6/cu129"; \
+    fi
 
 # Enable autocomplete
 RUN echo ". /etc/bash_completion.d/holohub_autocomplete" >> /etc/bash.bashrc


### PR DESCRIPTION
Jetson Orin integrated GPU support requires dedicated wheels from NVIDIA Jetson team.

Tested in a headless environment with Xvfb.