### PR TITLE
App: Fix H.264 data download at build time

### DIFF
--- a/applications/h264/Dockerfile
+++ b/applications/h264/Dockerfile
@@ -65,16 +65,3 @@ WORKDIR /
 #ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/aarch64-linux-gnu/tegra/
 
 RUN /install_dependencies.sh
-
-FROM base as run
-
-# Workaround for reported issue when running Python H264 applications:
-# 2: [warning] [gxf_extension_manager.cpp:174] Unable to load extension from 'libgxf_videodecoder.so' \
-#   (error: /opt/nvidia/holoscan/lib/libgxf_videodecoder.so: undefined symbol: _ZN6nvidia6logger15GlobalGxfLogger8instanceEv)
-# 2: [warning] [gxf_extension_manager.cpp:174] Unable to load extension from 'libgxf_videodecoderio.so' \
-#   (error: /opt/nvidia/holoscan/lib/libgxf_videodecoderio.so: undefined symbol: _ZN6nvidia6logger15GlobalGxfLogger8instanceEv)
-# 2: [info] [fragment.cpp:778] Loading extensions from configs...
-# 2: [warning] [type_registry.cpp:57] Unknown type: nvidia::gxf::VideoReadBitStream
-#
-# This is a workaround to load the libgxf_core.so library before running the application.
-ENV LD_PRELOAD=/opt/nvidia/holoscan/lib/libgxf_core.so

--- a/applications/h264/Dockerfile
+++ b/applications/h264/Dockerfile
@@ -66,6 +66,8 @@ WORKDIR /
 
 RUN /install_dependencies.sh
 
+FROM base as run
+
 # Workaround for reported issue when running Python H264 applications:
 # 2: [warning] [gxf_extension_manager.cpp:174] Unable to load extension from 'libgxf_videodecoder.so' \
 #   (error: /opt/nvidia/holoscan/lib/libgxf_videodecoder.so: undefined symbol: _ZN6nvidia6logger15GlobalGxfLogger8instanceEv)

--- a/applications/h264/h264_endoscopy_tool_tracking/README.md
+++ b/applications/h264/h264_endoscopy_tool_tracking/README.md
@@ -38,7 +38,6 @@ The data is automatically downloaded when building the application.
 Separate build and run commands are required to address the known [symbol loading issue](../README.md#symbol-error-at-load).
 
 ```bash
-# C++ version
 ./holohub build h264_endoscopy_tool_tracking --language python
 
 # Python version

--- a/applications/h264/h264_endoscopy_tool_tracking/README.md
+++ b/applications/h264/h264_endoscopy_tool_tracking/README.md
@@ -39,7 +39,7 @@ Separate build and run commands are required to address the known [symbol loadin
 
 ```bash
 # C++ version
-./holohub build h264_endoscopy_tool_tracking --language cpp
+./holohub build h264_endoscopy_tool_tracking --language python
 
 # Python version
 # Note: LD_PRELOAD required to address symbol issue

--- a/applications/h264/h264_endoscopy_tool_tracking/README.md
+++ b/applications/h264/h264_endoscopy_tool_tracking/README.md
@@ -25,16 +25,26 @@ can be specified in the 'h264_endoscopy_tool_tracking.yaml' file.
 
 The data is automatically downloaded when building the application.
 
-## Building and Running H.264 Endoscopy Tool Tracking Application
+## Build and Run the H.264 Endoscopy Tool Tracking Application
 
-* Building and running the application from the top level Holohub directory:
+### C++
+
+```bash
+./holohub run h264_endoscopy_tool_tracking --language cpp
+```
+
+### Python
+
+Separate build and run commands are required to address the known [symbol loading issue](../README.md#symbol-error-at-load).
 
 ```bash
 # C++ version
-./holohub run h264_endoscopy_tool_tracking --language cpp
+./holohub build h264_endoscopy_tool_tracking --language cpp
 
 # Python version
-./holohub run h264_endoscopy_tool_tracking --language python
+# Note: LD_PRELOAD required to address symbol issue
+./holohub run h264_endoscopy_tool_tracking --language python \
+    --docker-opts="-e LD_PRELOAD=/opt/nvidia/holoscan/lib/libgxf_core.so"
 ```
 
 Important: on aarch64, applications also need tegra folder mounted inside the container and

--- a/applications/h264/h264_endoscopy_tool_tracking/python/metadata.json
+++ b/applications/h264/h264_endoscopy_tool_tracking/python/metadata.json
@@ -48,9 +48,19 @@
         }
       ]
     },
-    "run": {
-      "command": "python3 <holohub_app_source>/h264_endoscopy_tool_tracking.py --data <holohub_data_dir>/endoscopy",
-      "workdir": "holohub_bin"
-    }
-  }
+		"modes": {
+			"replayer": {
+				"description": "Use a pre-recorded Endoscopy video as input",
+				"build": {
+					"docker_build_args": ["--target", "base"]
+				},
+				"run": {
+					"command": "python3 <holohub_app_source>/h264_endoscopy_tool_tracking.py --data <holohub_data_dir>/endoscopy",
+					"workdir": "holohub_bin",
+					"docker_build_args": ["--target", "run"]
+				}
+			}
+		},
+		"default_mode": "replayer"
+	}
 }

--- a/applications/h264/h264_endoscopy_tool_tracking/python/metadata.json
+++ b/applications/h264/h264_endoscopy_tool_tracking/python/metadata.json
@@ -48,19 +48,9 @@
         }
       ]
     },
-		"modes": {
-			"replayer": {
-				"description": "Use a pre-recorded Endoscopy video as input",
-				"build": {
-					"docker_build_args": ["--target", "base"]
-				},
-				"run": {
-					"command": "python3 <holohub_app_source>/h264_endoscopy_tool_tracking.py --data <holohub_data_dir>/endoscopy",
-					"workdir": "holohub_bin",
-					"docker_build_args": ["--target", "run"]
-				}
-			}
-		},
-		"default_mode": "replayer"
-	}
+    "run": {
+      "command": "python3 <holohub_app_source>/h264_endoscopy_tool_tracking.py --data <holohub_data_dir>/endoscopy",
+      "workdir": "holohub_bin"
+    }
+  }
 }

--- a/applications/h264/h264_video_decode/README.md
+++ b/applications/h264/h264_video_decode/README.md
@@ -22,17 +22,26 @@ input file can be specified in the 'h264_video_decode.yaml' file.
 
 The data is automatically downloaded when building the application.
 
-## Building and Running H.264 Endoscopy Tool Tracking Application
+## Build and Run the H.264 Endoscopy Tool Tracking Application
 
-* Building and running the application from the top level Holohub directory:
+### C++
+
+```bash
+./holohub run h264_video_decode --language cpp
+```
+
+### Python
+
+Separate build and run commands are required to address the known [symbol loading issue](../README.md#symbol-error-at-load).
 
 ```bash
 # C++ version
-./holohub run h264_video_decode --language=cpp
+./holohub build h264_video_decode --language python
 
 # Python version
-./holohub run h264_video_decode --language=python
-
+# Note: LD_PRELOAD required to address symbol issue
+./holohub run h264_video_decode --language python \
+    --docker-opts="-e LD_PRELOAD=/opt/nvidia/holoscan/lib/libgxf_core.so"
 ```
 
 Important: on aarch64, applications also need tegra folder mounted inside the container and


### PR DESCRIPTION
Address error where `LD_PRELOAD` fix for runtime H.264 issue blocks NGC CLI from properly downloading Endoscopy Tool Tracking data at build time.

Provide README instructions to distinguish required build and runtime environments for Python apps.