### PR TITLE
Add holohubCLI_wrapper script and update README.md for CLI integration

### DIFF
--- a/tutorials/holohub_operators_external_applications/README.md
+++ b/tutorials/holohub_operators_external_applications/README.md
@@ -439,12 +439,87 @@ cmake -DCMAKE_VERBOSE_MAKEFILE=ON ..
 
 See the `main.cpp`, `main.py`, and `CMakeLists.txt` files in this directory for complete working examples that demonstrate how to use the AJA source operator from Holohub in both C++ and Python applications.
 
+## Using Holohub CLI in External Projects
+
+The Holohub CLI provides convenient command-line tools for managing Holohub applications, including building, running, and testing operators and applications. You can easily integrate the CLI into your external projects to leverage these functionalities.
+
+### Adding holohubCLI_wrapper to Your Project
+
+To use the Holohub CLI in your external project, simply copy the `holohubCLI_wrapper` script from this tutorial to the root of your project.:
+
+```bash
+# Copy the CLI script to your project root
+cp tutorials/holohub_operators_external_applications/holohubCLI_wrapper /path/to/your/project/myprojectCLI
+
+# Make it executable
+chmod +x /path/to/your/project/myprojectCLI
+```
+
+Edit the line in `myprojectCLI` to match the name of the script:
+
+```bash
+export HOLOHUB_CMD_NAME='./holohubCLI_wrapper'
+```
+
+### Project Structure with CLI
+
+Your project structure will look like this:
+
+```
+your_external_app/
+├── myprojectCLI           # Holohub CLI script
+├── CMakeLists.txt
+├── main.cpp
+├── main.py (optional)
+└── build/
+```
+
+### Using the CLI
+
+Once you have the `myprojectCLI` script in your project, you can use it to access various Holohub CLI commands:
+
+```bash
+# Run your application
+./myprojectCLI run <application>
+
+# List available commands
+./myprojectCLI --help
+```
+
+> **Note:** The first time you run the script, it will automatically download the Holohub CLI scripts locally from the Holohub repository. Therefore, an internet connection is required for the initial run.
+
+
+Please refer to the inline Holohub CLI help for more information.
+
+### CLI Features
+
+The Holohub CLI provides several useful features for external projects:
+
+- **Build Management**: Automated building of C++ and Python applications
+- **Docker Integration**: Run applications in Docker containers with proper environment setup
+- **Testing**: Run tests and validation for your operators
+- **Development Tools**: Various utilities for Holohub development
+
+### Environment Setup
+
+The CLI script automatically handles:
+- Setting up the correct Python path
+- Managing Docker options (if using Docker)
+- Configuring environment variables
+- Fetching necessary utilities from the Holohub repository
+
+### Benefits for External Projects
+
+Using the Holohub CLI in your external project provides:
+
+1. **Consistency**: Same build and run processes as Holohub applications
+2. **Automation**: Automated setup and configuration
+3. **Docker Support**: Easy containerization of your applications
+4. **Testing**: Built-in testing capabilities
+5. **Documentation**: Access to Holohub's documentation and examples
+
 ## Additional Resources
 
 - [Holohub Repository](https://github.com/nvidia-holoscan/holohub)
 - [Holoscan Documentation](https://docs.nvidia.com/holoscan/)
 - [Holohub Operators Documentation](https://github.com/nvidia-holoscan/holohub/tree/main/operators)
-
-## License
-
-This tutorial is part of Holohub and is licensed under the Apache 2.0 License. 

--- a/tutorials/holohub_operators_external_applications/README.md
+++ b/tutorials/holohub_operators_external_applications/README.md
@@ -448,17 +448,20 @@ The Holohub CLI provides convenient command-line tools for managing Holohub appl
 To use the Holohub CLI in your external project, simply copy the `holohubCLI_wrapper` script from this tutorial to the root of your project.:
 
 ```bash
-# Copy the CLI script to your project root
-cp tutorials/holohub_operators_external_applications/holohubCLI_wrapper /path/to/your/project/myprojectCLI
+# Download the CLI script to your project root
+wget -O /path/to/your/project/proj_cli https://raw.githubusercontent.com/nvidia-holoscan/holohub/main/tutorials/holohub_operators_external_applications/holohubCLI_wrapper
 
 # Make it executable
-chmod +x /path/to/your/project/myprojectCLI
+chmod +x /path/to/your/project/proj_cli
 ```
 
-Edit the line in `myprojectCLI` to match the name of the script:
+Add the following to your `.gitignore` file to exclude the downloaded Holohub CLI utilities:
 
 ```bash
-export HOLOHUB_CMD_NAME='./holohubCLI_wrapper'
+# Holohub CLI
+utilities
+cmake
+.local
 ```
 
 ### Project Structure with CLI
@@ -476,20 +479,19 @@ your_external_app/
 
 ### Using the CLI
 
-Once you have the `myprojectCLI` script in your project, you can use it to access various Holohub CLI commands:
+Once you have the `proj_cli` script in your project, you can use it to access various Holohub CLI commands:
 
 ```bash
 # Run your application
-./myprojectCLI run <application>
+./proj_cli run <application>
 
 # List available commands
-./myprojectCLI --help
+./proj_cli --help
 ```
 
 > **Note:** The first time you run the script, it will automatically download the Holohub CLI scripts locally from the Holohub repository. Therefore, an internet connection is required for the initial run.
 
-
-Please refer to the inline Holohub CLI help for more information.
+Please refer to the Holohub CLI help command for more information.
 
 ### CLI Features
 

--- a/tutorials/holohub_operators_external_applications/holohubCLI_wrapper
+++ b/tutorials/holohub_operators_external_applications/holohubCLI_wrapper
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Pulls the holohub CLI from the holohub repo
+if [ ! -d "${SCRIPT_PATH}/utilities/cli" ]; then
+    git clone --depth 1 --no-checkout https://github.com/nvidia-holoscan/holohub.git ${SCRIPT_PATH}/.tmp-holohub/holohub \
+        && cd ${SCRIPT_PATH}/.tmp-holohub/holohub \
+        && git sparse-checkout init --cone \
+        && git sparse-checkout set utilities/cli utilities/metadata utilities/testing cmake\
+        && git checkout main \
+        && mv ${SCRIPT_PATH}/.tmp-holohub/holohub/utilities ${SCRIPT_PATH} \
+        && mv ${SCRIPT_PATH}/.tmp-holohub/holohub/cmake ${SCRIPT_PATH} \
+        && rm -rf ${SCRIPT_PATH}/.tmp-holohub \
+        && cd ${SCRIPT_PATH}
+fi
+
+# Check if RTI_LICENSE_FILE is set
+if [ -n "$RTI_LICENSE_FILE" ]; then
+    if [ "$1" == "run" ] && [[ ! " $@ " =~ " --local " ]]; then
+      DOCKER_OPTS="--docker-opts=-v ${RTI_LICENSE_FILE}:/workspace/rti_license.dat"
+    fi
+fi
+
+# TODO: Set the command name to the script name
+export HOLOHUB_CMD_NAME='./holohubCLI_wrapper'
+
+# Only pass DOCKER_OPTS if it's set and not empty
+if [ -n "$DOCKER_OPTS" ]; then
+    PYTHONPATH=${PYTHONPATH}:${SCRIPT_PATH} python3 ${SCRIPT_PATH}/utilities/cli/holohub.py "$@" "$DOCKER_OPTS"
+else
+    PYTHONPATH=${PYTHONPATH}:${SCRIPT_PATH} python3 ${SCRIPT_PATH}/utilities/cli/holohub.py "$@"
+fi

--- a/tutorials/holohub_operators_external_applications/holohubCLI_wrapper
+++ b/tutorials/holohub_operators_external_applications/holohubCLI_wrapper
@@ -18,6 +18,9 @@
 SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Pulls the holohub CLI from the holohub repo
+# The script checks if utilities/cli exists in the current directory, 
+# if not it pulls the holohub CLI from the holohub repo
+# To update the holohub CLI, remove the utilities/cli directory and run the script again
 if [ ! -d "${SCRIPT_PATH}/utilities/cli" ]; then
     git clone --depth 1 --no-checkout https://github.com/nvidia-holoscan/holohub.git ${SCRIPT_PATH}/.tmp-holohub/holohub \
         && cd ${SCRIPT_PATH}/.tmp-holohub/holohub \
@@ -30,19 +33,6 @@ if [ ! -d "${SCRIPT_PATH}/utilities/cli" ]; then
         && cd ${SCRIPT_PATH}
 fi
 
-# Check if RTI_LICENSE_FILE is set
-if [ -n "$RTI_LICENSE_FILE" ]; then
-    if [ "$1" == "run" ] && [[ ! " $@ " =~ " --local " ]]; then
-      DOCKER_OPTS="--docker-opts=-v ${RTI_LICENSE_FILE}:/workspace/rti_license.dat"
-    fi
-fi
+export HOLOHUB_CMD_NAME=${BASH_SOURCE[0]}
 
-# TODO: Set the command name to the script name
-export HOLOHUB_CMD_NAME='./holohubCLI_wrapper'
-
-# Only pass DOCKER_OPTS if it's set and not empty
-if [ -n "$DOCKER_OPTS" ]; then
-    PYTHONPATH=${PYTHONPATH}:${SCRIPT_PATH} python3 ${SCRIPT_PATH}/utilities/cli/holohub.py "$@" "$DOCKER_OPTS"
-else
-    PYTHONPATH=${PYTHONPATH}:${SCRIPT_PATH} python3 ${SCRIPT_PATH}/utilities/cli/holohub.py "$@"
-fi
+PYTHONPATH=${PYTHONPATH}:${SCRIPT_PATH} python3 ${SCRIPT_PATH}/utilities/cli/holohub.py "$@"


### PR DESCRIPTION
- Introduced a new script, `holohubCLI_wrapper`, to facilitate the use of the Holohub CLI in external projects. This script automates the process of downloading necessary CLI components from the Holohub repository and sets up the environment for running Holohub applications.
- Updated the README.md to include instructions on how to integrate the `holohubCLI_wrapper` into external projects, detailing usage examples and project structure.