### PR TITLE
CLI: fixes exiting message

### DIFF
--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -237,7 +237,7 @@ def run_command(
     try:
         return subprocess.run(processed_cmd, check=check, **kwargs)
     except subprocess.CalledProcessError as e:
-        print(f"Error running command: {cmd_str}")
+        print(f"Non-zero exit code running command: {cmd_str}")
         print(f"Exit code: {e.returncode}")
         sys.exit(e.returncode)
 


### PR DESCRIPTION
non-zero exit code is not necessarily an error for this generic `run_command` function