### PR TITLE
App: Update object_detection_torch for PyTorch iGPU wheels

### DIFF
--- a/applications/object_detection_torch/Dockerfile
+++ b/applications/object_detection_torch/Dockerfile
@@ -41,7 +41,16 @@ RUN /tmp/scripts/holohub setup && rm -rf /var/lib/apt/lists/*
 FROM base as torch
 
 # Install libraries
-RUN pip install torch torchvision
+ARG GPU_TYPE
+RUN if [ "${GPU_TYPE}" = "igpu" ]; then \
+        python3 -m pip install --force-reinstall torch torchvision torchaudio --index-url "https://pypi.jetson-ai-lab.io/jp6/cu129"; \
+    else \
+        pip install torch torchvision; \
+    fi; \
+    if ! find /usr/local/lib/python3.12/dist-packages/torch -name libtorch_cuda.so | grep -q .; then \
+        echo "libtorch_cuda.so not found, torch installation failed"; \
+        exit 1; \
+    fi
 
 # Set up Holoscan SDK container libtorch to be found with ldconfig for app C++ build and runtime
 RUN echo $(python3 -c "import torch; print(torch.__path__[0])")/lib > /etc/ld.so.conf.d/libtorch.conf \


### PR DESCRIPTION
Upcoming release Holoscan SDK >=3.6.0 aims to drop torchvision as a core Holoscan SDK dependency, however the model used in object_detection_torch requires torchvision symbols.

For iGPU platforms we need to fetch the Jetson PyPI torch and torchvision packages for these symbols.

Addresses link time issue:
```
/usr/bin/ld: /usr/local/lib/python3.12/dist-packages/torch/lib/../../torch.libs/libopenblasp-r0-121ca252.3.30.so: undefined reference to `_gfortran_concat_string@GFORTRAN_8'

/usr/bin/ld: /usr/local/lib/python3.12/dist-packages/torch/lib/../../torch.libs/libopenblasp-r0-121ca252.3.30.so: undefined reference to `_gfortran_etime@GFORTRAN_8'
```

Observed successful build and test on iGPU platform:
```
tbirdsong@hs-jetson-agx-ci:~/build/object_detection_torch$ xvfb-run -a ctest -C Release
Test project /workspace/holohub/build/object_detection_torch
    Start 1: object_detection_torch_test
1/2 Test #1: object_detection_torch_test ..........   Passed    8.73 sec
    Start 2: object_detection_torch_render_test
2/2 Test #2: object_detection_torch_render_test ...   Passed   11.21 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =  19.96 sec
```