### PR TITLE
Refactor CMake configuration for colonoscopy segmentation tests

### DIFF
--- a/applications/colonoscopy_segmentation/CMakeLists.txt
+++ b/applications/colonoscopy_segmentation/CMakeLists.txt
@@ -61,9 +61,6 @@ if(BUILD_TESTING)
     DEPENDS "colonoscopy_segmentation_test.py"
   )
 
-  # Get GXF_LIB_DIR for Python tests
-  find_package(holoscan)
-
   # Add test
   add_test(NAME colonoscopy_segmentation_python_test
            COMMAND python3 ${CMAKE_CURRENT_BINARY_DIR}/colonoscopy_segmentation_test.py

--- a/utilities/testing/holohub.container.ctest
+++ b/utilities/testing/holohub.container.ctest
@@ -48,7 +48,6 @@ ctest_read_custom_files("${CTEST_BINARY_DIRECTORY}")
 set(configure_options
   ${CONFIGURE_OPTIONS}
   -D HOLOHUB_DATA_DIR=/workspace/holohub/data-${APP}-${TAG}
-  -D CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc
   -D CMAKE_BUILD_TYPE=RelWithDebInfo
   -D APP_${APP}=ON
 )


### PR DESCRIPTION
- Removed the unused `find_package(holoscan)` line from the CMakeLists.txt file for the colonoscopy segmentation application.
- Updated the `holohub.container.ctest` file by removing the CUDA compiler option. Applications should set the NVCC compiler in the CMake files.