### PR TITLE
App: Remove extraneous "colonoscopy_segmentation" test PYTHONPATH

### DIFF
--- a/applications/colonoscopy_segmentation/CMakeLists.txt
+++ b/applications/colonoscopy_segmentation/CMakeLists.txt
@@ -67,8 +67,8 @@ if(BUILD_TESTING)
                    --config ${CMAKE_CURRENT_BINARY_DIR}/colonoscopy_segmentation_testing.yaml
                    --data "${HOLOHUB_DATA_DIR}/colonoscopy_segmentation"
            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  set_property(TEST colonoscopy_segmentation_python_test PROPERTY ENVIRONMENT
-               "PYTHONPATH=${GXF_LIB_DIR}/../python/lib:${CMAKE_BINARY_DIR}/python/lib")
+  set_property(TEST colonoscopy_segmentation_python_test
+                PROPERTY ENVIRONMENT PYTHONPATH="")
 
   set_tests_properties(colonoscopy_segmentation_python_test
                 PROPERTIES PASS_REGULAR_EXPRESSION "Reach end of file or playback count reaches to the limit. Stop ticking.;"


### PR DESCRIPTION
Followup to e86a13e removing GXF_LIB_DIR from test PYTHONPATH. As of f9d44deb the Holoscan Python package is installed in the Python dist-packages path at container build time, so we do not need to set PYTHONPATH to find it.

The app with replayer preset builds no Python operators, so the HoloHub Python module is not required.