### PR TITLE
infra: fixes copyright header autofix

### DIFF
--- a/.github/workflows/scripts/check_copyright.py
+++ b/.github/workflows/scripts/check_copyright.py
@@ -82,7 +82,7 @@ def replace_current_year(line, start, end):
     def replace_spdx_with_copyright(match):
         comment_prefix = match.group(1) or ""
         affiliation = match.group(4)
-        return f"{comment_prefix}SPDX-FileCopyrightText: Copyright (c) {start}-{end} {affiliation}."
+        return f"{comment_prefix}SPDX-FileCopyrightText: Copyright (c) {start}-{end} {affiliation}"
 
     def replace_spdx_reuse(match):
         comment_prefix = match.group(1) or ""
@@ -92,7 +92,7 @@ def replace_current_year(line, start, end):
     def replace_non_spdx(match):
         comment_prefix = match.group(1) or ""
         affiliation = match.group(4)
-        return f"{comment_prefix}Copyright (c) {start}-{end}, {affiliation}."
+        return f"{comment_prefix}Copyright (c) {start}-{end}, {affiliation}"
 
     # Apply each pattern's replacement
     res = CheckSPDXWithCopyright.sub(replace_spdx_with_copyright, line)


### PR DESCRIPTION
autofix of the header has additional dots due to multiline regex matching
```diff
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+..# SPDX-License-Identifier: Apache-2.0
```

this fix removes the additional dots