### PR TITLE
Change DOCA install in Holoscan Networking Tutorial from 2.10.0 to 2.8.0

### DIFF
--- a/tutorials/high_performance_networking/README.md
+++ b/tutorials/high_performance_networking/README.md
@@ -71,7 +71,7 @@ First, add the [DOCA apt repository](https://developer.nvidia.com/doca-downloads
 === "IGX OS 1.1"
 
     ```bash
-    export DOCA_URL="https://linux.mellanox.com/public/repo/doca/2.10.0/ubuntu22.04/arm64-sbsa/"
+    export DOCA_URL="https://linux.mellanox.com/public/repo/doca/2.8.0/ubuntu22.04/arm64-sbsa/"
     wget -qO- https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/GPG-KEY-Mellanox.pub > /dev/null
     echo "deb [signed-by=/etc/apt/trusted.gpg.d/GPG-KEY-Mellanox.pub] $DOCA_URL ./"  | sudo tee /etc/apt/sources.list.d/doca.list > /dev/null
 
@@ -81,7 +81,7 @@ First, add the [DOCA apt repository](https://developer.nvidia.com/doca-downloads
 === "SBSA (Ubuntu 22.04)"
 
     ```bash
-    export DOCA_URL="https://linux.mellanox.com/public/repo/doca/2.10.0/ubuntu22.04/arm64-sbsa/"
+    export DOCA_URL="https://linux.mellanox.com/public/repo/doca/2.8.0/ubuntu22.04/arm64-sbsa/"
     wget -qO- https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/GPG-KEY-Mellanox.pub > /dev/null
     echo "deb [signed-by=/etc/apt/trusted.gpg.d/GPG-KEY-Mellanox.pub] $DOCA_URL ./"  | sudo tee /etc/apt/sources.list.d/doca.list > /dev/null
 
@@ -95,7 +95,7 @@ First, add the [DOCA apt repository](https://developer.nvidia.com/doca-downloads
 === "x86_64 (Ubuntu 22.04)"
 
     ```bash
-    export DOCA_URL="https://linux.mellanox.com/public/repo/doca/2.10.0/ubuntu22.04/x86_64/"
+    export DOCA_URL="https://linux.mellanox.com/public/repo/doca/2.8.0/ubuntu22.04/x86_64/"
     wget -qO- https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/GPG-KEY-Mellanox.pub > /dev/null
     echo "deb [signed-by=/etc/apt/trusted.gpg.d/GPG-KEY-Mellanox.pub] $DOCA_URL ./"  | sudo tee /etc/apt/sources.list.d/doca.list > /dev/null
 


### PR DESCRIPTION
The Dockerfile used to build and install Holoscan networking from source uses DOCA version 2.8.0, but the docs specify 2.10.0.

When using 2.10.0 to build and install manually, a number of DOCA API errors result. 

Example: `holohub/operators/advanced_network/advanced_network/managers/gpunetio/adv_network_doca_mgr.cpp:907:7: error: 'struct doca_flow_fwd' has no member named 'rss_queues'`