### PR TITLE
Update Orsi `FormatConverterOp` for CUDA 13 with Backward Compatibility

### DIFF
--- a/operators/orsi/orsi_format_converter/format_converter.cpp
+++ b/operators/orsi/orsi_format_converter/format_converter.cpp
@@ -155,7 +155,8 @@ void FormatConverterOp::initialize() {
   HOLOSCAN_CUDA_CALL_THROW_ERROR(cudaGetDevice(&device), "Failed to get CUDA device");
 
   cudaDeviceProp prop{};
-  HOLOSCAN_CUDA_CALL_THROW_ERROR(cudaGetDeviceProperties(&prop, device), "Failed to get CUDA device properties");
+  HOLOSCAN_CUDA_CALL_THROW_ERROR(cudaGetDeviceProperties(&prop, device),
+                                 "Failed to get CUDA device properties");
 
   npp_stream_ctx_.nCudaDeviceId = device;
   npp_stream_ctx_.nMultiProcessorCount = prop.multiProcessorCount;

--- a/operators/orsi/orsi_format_converter/format_converter.cpp
+++ b/operators/orsi/orsi_format_converter/format_converter.cpp
@@ -152,10 +152,10 @@ void FormatConverterOp::initialize() {
 #if CUDART_VERSION >= 13000
   // Workaround pending proper NPP support to get stream context in CUDA 13.0+
   int device = 0;
-  HOLOSCAN_CUDA_CALL_THROW_ERROR(cudaGetDevice(&device));
+  HOLOSCAN_CUDA_CALL_THROW_ERROR(cudaGetDevice(&device), "Failed to get CUDA device");
 
   cudaDeviceProp prop{};
-  HOLOSCAN_CUDA_CALL_THROW_ERROR(cudaGetDeviceProperties(&prop, device));
+  HOLOSCAN_CUDA_CALL_THROW_ERROR(cudaGetDeviceProperties(&prop, device), "Failed to get CUDA device properties");
 
   npp_stream_ctx_.nCudaDeviceId = device;
   npp_stream_ctx_.nMultiProcessorCount = prop.multiProcessorCount;

--- a/operators/orsi/orsi_format_converter/format_converter.cpp
+++ b/operators/orsi/orsi_format_converter/format_converter.cpp
@@ -38,20 +38,7 @@
 #include "holoscan/core/operator_spec.hpp"
 #include "holoscan/core/resources/gxf/allocator.hpp"
 #include "holoscan/core/resources/gxf/cuda_stream_pool.hpp"
-
-#define CUDA_TRY(stmt)                                                                          \
-  ({                                                                                            \
-    cudaError_t _holoscan_cuda_err = stmt;                                                      \
-    if (cudaSuccess != _holoscan_cuda_err) {                                                    \
-      HOLOSCAN_LOG_ERROR("CUDA Runtime call %s in line %d of file %s failed with '%s' (%d).\n", \
-                         #stmt,                                                                 \
-                         __LINE__,                                                              \
-                         __FILE__,                                                              \
-                         cudaGetErrorString(_holoscan_cuda_err),                                \
-                         static_cast<int>(_holoscan_cuda_err));                                 \
-    }                                                                                           \
-    _holoscan_cuda_err;                                                                         \
-  })
+#include "holoscan/utils/cuda_macros.hpp"
 
 namespace holoscan::ops::orsi {
 
@@ -162,10 +149,28 @@ static gxf_result_t verifyFormatDTypeChannels(FormatDType dtype, int channel_cou
 }
 
 void FormatConverterOp::initialize() {
+#if CUDART_VERSION >= 13000
+  // Workaround pending proper NPP support to get stream context in CUDA 13.0+
+  int device = 0;
+  HOLOSCAN_CUDA_CALL_THROW_ERROR(cudaGetDevice(&device));
+
+  cudaDeviceProp prop{};
+  HOLOSCAN_CUDA_CALL_THROW_ERROR(cudaGetDeviceProperties(&prop, device));
+
+  npp_stream_ctx_.nCudaDeviceId = device;
+  npp_stream_ctx_.nMultiProcessorCount = prop.multiProcessorCount;
+  npp_stream_ctx_.nMaxThreadsPerMultiProcessor = prop.maxThreadsPerMultiProcessor;
+  npp_stream_ctx_.nMaxThreadsPerBlock = prop.maxThreadsPerBlock;
+  npp_stream_ctx_.nSharedMemPerBlock = prop.sharedMemPerBlock;
+  npp_stream_ctx_.nCudaDevAttrComputeCapabilityMajor = prop.major;
+  npp_stream_ctx_.nCudaDevAttrComputeCapabilityMinor = prop.minor;
+#else
   auto nppStatus = nppGetStreamContext(&npp_stream_ctx_);
   if (NPP_SUCCESS != nppStatus) {
     throw std::runtime_error("Failed to get NPP CUDA stream context");
   }
+#endif
+
   Operator::initialize();
 }
 
@@ -335,10 +340,11 @@ void FormatConverterOp::compute(InputContext& op_input, OutputContext& op_output
               fmt::format("Failed to allocate device scratch buffer ({} bytes)", buffer_size));
         }
       }
-      CUDA_TRY(cudaMemcpy(device_scratch_buffer_->pointer(),
-                          frame->pointer(),
-                          buffer_size,
-                          cudaMemcpyHostToDevice));
+      HOLOSCAN_CUDA_CALL_THROW_ERROR(cudaMemcpy(device_scratch_buffer_->pointer(),
+                                                frame->pointer(),
+                                                buffer_size,
+                                                cudaMemcpyHostToDevice),
+                                     "Failed to copy input data to device scratch buffer");
       in_tensor_data = device_scratch_buffer_->pointer();
       in_memory_storage_type = nvidia::gxf::MemoryStorageType::kDevice;
     }
@@ -412,7 +418,9 @@ void FormatConverterOp::compute(InputContext& op_input, OutputContext& op_output
   if (out_img_size[0] > 0 && out_img_size[1] > 0) {
     auto resize_result = resizeImage(
         in_tensor_data, rows, columns, in_channels, in_primitive_type, out_img_size, src_img_roi);
-    if (!resize_result) { throw std::runtime_error("Failed to resize image.\n"); }
+    if (!resize_result) {
+      throw std::runtime_error("Failed to resize image.\n");
+    }
 
     // Update the tensor pointer and shape
     out_shape = nvidia::gxf::Shape{out_img_size[1], out_img_size[0], in_channels};
@@ -464,9 +472,13 @@ void FormatConverterOp::compute(InputContext& op_input, OutputContext& op_output
                         nvidia::gxf::ComputeTrivialStrides(out_shape, dst_typesize)}},
                       false);
 
-  if (!out_message) { std::runtime_error("failed to create out_message"); }
+  if (!out_message) {
+    std::runtime_error("failed to create out_message");
+  }
   const auto out_tensor = out_message.value().get<nvidia::gxf::Tensor>();
-  if (!out_tensor) { std::runtime_error("failed to create out_tensor"); }
+  if (!out_tensor) {
+    std::runtime_error("failed to create out_tensor");
+  }
 
   // Set tensor to constant using NPP
   if (in_channels == 2 || in_channels == 3 || in_channels == 4) {
@@ -564,7 +576,9 @@ nvidia::gxf::Expected<void*> FormatConverterOp::resizeImage(
       break;
   }
 
-  if (status != NPP_SUCCESS) { return nvidia::gxf::ExpectedOrCode(GXF_FAILURE, nullptr); }
+  if (status != NPP_SUCCESS) {
+    return nvidia::gxf::ExpectedOrCode(GXF_FAILURE, nullptr);
+  }
 
   return nvidia::gxf::ExpectedOrCode(GXF_SUCCESS, converted_tensor_ptr);
 }
@@ -590,12 +604,12 @@ void FormatConverterOp::convertTensorFormat(const void* in_tensor_data, void* ou
       const auto in_tensor_ptr = static_cast<const uint8_t*>(in_tensor_data);
       auto out_tensor_ptr = static_cast<uint8_t*>(out_tensor_data);
 
-      cudaError_t cuda_status = CUDA_TRY(cudaMemcpyAsync(out_tensor_ptr,
-                                                         in_tensor_ptr,
-                                                         src_step * rows,
-                                                         cudaMemcpyDeviceToDevice,
-                                                         npp_stream_ctx_.hStream));
-      if (cuda_status) { throw std::runtime_error("Failed to copy GPU data to GPU memory."); }
+      HOLOSCAN_CUDA_CALL_THROW_ERROR(cudaMemcpyAsync(out_tensor_ptr,
+                                                     in_tensor_ptr,
+                                                     src_step * rows,
+                                                     cudaMemcpyDeviceToDevice,
+                                                     npp_stream_ctx_.hStream),
+                                     "Failed to copy GPU data to GPU memory.");
       status = NPP_SUCCESS;
       break;
     }
@@ -734,11 +748,11 @@ void FormatConverterOp::convertTensorFormat(const void* in_tensor_data, void* ou
       const int32_t out_v_step = color_planes[2].stride;
       int32_t out_yuv_steps[3] = {out_y_step, out_u_step, out_v_step};
 
-      status = nppiRGBToYUV420_8u_C3P3R(in_tensor_ptr, src_step, out_yuv_ptrs, out_yuv_steps, roi);
+      status = nppiRGBToYUV420_8u_C3P3R_Ctx(
+          in_tensor_ptr, src_step, out_yuv_ptrs, out_yuv_steps, roi, npp_stream_ctx_);
       if (status != NPP_SUCCESS) {
-        throw std::runtime_error(
-            fmt::format("rgb888 to yuv420 conversion failed (NPP error code: {})",
-              static_cast<int>(status)));
+        throw std::runtime_error(fmt::format(
+            "rgb888 to yuv420 conversion failed (NPP error code: {})", static_cast<int>(status)));
       }
       break;
     }
@@ -757,11 +771,11 @@ void FormatConverterOp::convertTensorFormat(const void* in_tensor_data, void* ou
 
       const auto out_tensor_ptr = static_cast<uint8_t*>(out_tensor_data);
 
-      status = nppiYUV420ToRGB_8u_P3AC4R(in_yuv_ptrs, in_yuv_steps, out_tensor_ptr, dst_step, roi);
+      status = nppiYUV420ToRGB_8u_P3AC4R_Ctx(
+          in_yuv_ptrs, in_yuv_steps, out_tensor_ptr, dst_step, roi, npp_stream_ctx_);
       if (status != NPP_SUCCESS) {
-        throw std::runtime_error(
-            fmt::format("yuv420 to rgba8888 conversion failed (NPP error code: {})",
-                        static_cast<int>(status)));
+        throw std::runtime_error(fmt::format(
+            "yuv420 to rgba8888 conversion failed (NPP error code: {})", static_cast<int>(status)));
       }
       break;
     }
@@ -780,11 +794,11 @@ void FormatConverterOp::convertTensorFormat(const void* in_tensor_data, void* ou
 
       const auto out_tensor_ptr = static_cast<uint8_t*>(out_tensor_data);
 
-      status = nppiYUV420ToRGB_8u_P3C3R(in_yuv_ptrs, in_yuv_steps, out_tensor_ptr, dst_step, roi);
+      status = nppiYUV420ToRGB_8u_P3C3R_Ctx(
+          in_yuv_ptrs, in_yuv_steps, out_tensor_ptr, dst_step, roi, npp_stream_ctx_);
       if (status != NPP_SUCCESS) {
-        throw std::runtime_error(
-            fmt::format("yuv420 to rgb888 conversion failed (NPP error code: {})",
-                        static_cast<int>(status)));
+        throw std::runtime_error(fmt::format(
+            "yuv420 to rgb888 conversion failed (NPP error code: {})", static_cast<int>(status)));
       }
       break;
     }
@@ -799,12 +813,11 @@ void FormatConverterOp::convertTensorFormat(const void* in_tensor_data, void* ou
 
       const auto out_tensor_ptr = static_cast<uint8_t*>(out_tensor_data);
 
-      status =
-          nppiNV12ToRGB_709HDTV_8u_P2C3R(in_y_uv_ptrs, in_y_uv_step, out_tensor_ptr, dst_step, roi);
+      status = nppiNV12ToRGB_709HDTV_8u_P2C3R_Ctx(
+          in_y_uv_ptrs, in_y_uv_step, out_tensor_ptr, dst_step, roi, npp_stream_ctx_);
       if (status != NPP_SUCCESS) {
-        throw std::runtime_error(
-            fmt::format("NV12 to rgb888 conversion failed (NPP error code: {})",
-                        static_cast<int>(status)));
+        throw std::runtime_error(fmt::format(
+            "NV12 to rgb888 conversion failed (NPP error code: {})", static_cast<int>(status)));
       }
       break;
     }
@@ -877,7 +890,9 @@ void FormatConverterOp::convertTensorFormat(const void* in_tensor_data, void* ou
             break;
           }
         }
-        if (status != NPP_SUCCESS) { throw std::runtime_error("Failed to convert channel order"); }
+        if (status != NPP_SUCCESS) {
+          throw std::runtime_error("Failed to convert channel order");
+        }
       }
     }
     default:

--- a/operators/orsi/orsi_segmentation_postprocessor/CMakeLists.txt
+++ b/operators/orsi/orsi_segmentation_postprocessor/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/operators/orsi/orsi_segmentation_postprocessor/CMakeLists.txt
+++ b/operators/orsi/orsi_segmentation_postprocessor/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(${PROJECT_NAME}
   segmentation_postprocessor.cu
 )
 
-set_target_properties(${PROJECT_NAME}  PROPERTIES CUDA_ARCHITECTURES "70;80")
+set_target_properties(${PROJECT_NAME}  PROPERTIES CUDA_ARCHITECTURES "80")
 
 add_library(holoscan::orsi::segmentation_postprocessor ALIAS ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/operators/orsi/orsi_segmentation_postprocessor/CMakeLists.txt
+++ b/operators/orsi/orsi_segmentation_postprocessor/CMakeLists.txt
@@ -28,7 +28,6 @@ add_library(${PROJECT_NAME}
   segmentation_postprocessor.cu
 )
 
-set_target_properties(${PROJECT_NAME}  PROPERTIES CUDA_ARCHITECTURES "80")
 
 add_library(holoscan::orsi::segmentation_postprocessor ALIAS ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/operators/orsi/orsi_segmentation_preprocessor/CMakeLists.txt
+++ b/operators/orsi/orsi_segmentation_preprocessor/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/operators/orsi/orsi_segmentation_preprocessor/CMakeLists.txt
+++ b/operators/orsi/orsi_segmentation_preprocessor/CMakeLists.txt
@@ -28,8 +28,6 @@ add_library(${PROJECT_NAME}
   segmentation_preprocessor.cu
 )
 
-set_target_properties(${PROJECT_NAME}  PROPERTIES CUDA_ARCHITECTURES "80")
-
 add_library(holoscan::orsi::segmentation_preprocessor ALIAS ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/operators/orsi/orsi_segmentation_preprocessor/CMakeLists.txt
+++ b/operators/orsi/orsi_segmentation_preprocessor/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(${PROJECT_NAME}
   segmentation_preprocessor.cu
 )
 
-set_target_properties(${PROJECT_NAME}  PROPERTIES CUDA_ARCHITECTURES "70;80")
+set_target_properties(${PROJECT_NAME}  PROPERTIES CUDA_ARCHITECTURES "80")
 
 add_library(holoscan::orsi::segmentation_preprocessor ALIAS ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
This pull request updates the `FormatConverterOp` implementation in `format_converter.cpp` to support CUDA 13.0 with backward compatibility for earlier versions.

**CUDA error handling and NPP integration:**

* Replaces the custom `CUDA_TRY` macro with standardized error handling using `HOLOSCAN_CUDA_CALL_THROW_ERROR` from `holoscan/utils/cuda_macros.hpp`, ensuring consistent and informative error reporting for CUDA API calls. 

**CUDA 13+ compatibility:**

* Adds a conditional initialization for the NPP stream context in `initialize()` to manually populate context fields when running on CUDA 13.0 or newer, addressing changes in CUDA's stream context handling.

**Build configuration updates:**

* Updates the CUDA architecture targets for both segmentation preprocessor and postprocessor operators to only build for architecture 80 (Ampere), removing support for architecture 70 (Volta). (`orsi_segmentation_preprocessor/CMakeLists.txt`, `orsi_segmentation_postprocessor/CMakeLists.txt`).