### PR TITLE
Benchmark: Document GPU utilization supported platforms

### DIFF
--- a/benchmarks/holoscan_flow_benchmarking/README.md
+++ b/benchmarks/holoscan_flow_benchmarking/README.md
@@ -113,6 +113,7 @@ python benchmarks/holoscan_flow_benchmarking/benchmark.py -a <app_name> [options
 - `--sched`: Scheduler type
 - `-d, --directory`: Output directory
 - `--run-command`: Custom run command (if needed)
+- `-u, --monitor_gpu`: Monitor GPU utilization (discrete GPU only)
 
 For a complete list of arguments, run:
 


### PR DESCRIPTION
Add a note indicating that GPU utilization monitoring in Holoscan Flow Benchmarking tools is currently supported on discrete GPU platforms only.

GPU monitoring is mentioned later in the Flow Benchmarking README, but internal feedback indicates supported platforms were unclear.

A future request may revisit iGPU support.