### PR TITLE
CLI: configurable HOLOHUB_ROOT

### DIFF
--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -33,6 +33,7 @@ from .util import (
     find_hsdk_build_rel_dir,
     get_compute_capacity,
     get_group_id,
+    get_holohub_root,
     get_host_gpu,
     get_image_pythonpath,
     list_normalized_languages,
@@ -54,7 +55,7 @@ class HoloHubContainer:
     """
 
     CONTAINER_PREFIX = "holohub"
-    HOLOHUB_ROOT = Path(__file__).parent.parent.parent
+    HOLOHUB_ROOT = get_holohub_root()
 
     @classmethod
     def default_base_image(cls) -> str:

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -49,7 +49,7 @@ from utilities.cli.util import Color
 class HoloHubCLI:
     """Command-line interface for HoloHub"""
 
-    HOLOHUB_ROOT = Path(__file__).parent.parent.parent
+    HOLOHUB_ROOT = holohub_cli_util.get_holohub_root()
     DEFAULT_BUILD_PARENT_DIR = HOLOHUB_ROOT / "build"
     DEFAULT_DATA_DIR = HOLOHUB_ROOT / "data"
     DEFAULT_SDK_DIR = "/opt/nvidia/holoscan/lib"

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -152,7 +152,7 @@ def warn(message: str) -> None:
     print(f"{Color.yellow('WARNING:')} {message}")
 
 
-def get_holohub_root() -> Path:
+def _get_holohub_root() -> Path:
     """Get the HoloHub repository root path."""
     env_root = os.environ.get("HOLOHUB_ROOT")
     if env_root:
@@ -166,7 +166,7 @@ def get_holohub_root() -> Path:
     return default_path
 
 
-HOLOHUB_ROOT = get_holohub_root()
+HOLOHUB_ROOT = _get_holohub_root()
 
 
 def get_holohub_root() -> Path:

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -159,11 +159,11 @@ def _get_holohub_root() -> Path:
         env_path = Path(env_root).expanduser()
         if env_path.exists() and env_path.is_dir():
             return env_path
-        warn(f"Environment variable HOLOHUB_ROOT='{env_root}' is invalid.")
-    default_path = Path(__file__).parent.parent.parent
-    if env_root:
-        warn(f"Falling back to default path: {default_path}")
-    return default_path
+        warn(
+            f"Environment variable HOLOHUB_ROOT='{env_root}' is invalid. "
+            f"Falling back to default path: {Path(__file__).parent.parent.parent}"
+        )
+    return Path(__file__).parent.parent.parent
 
 
 HOLOHUB_ROOT = _get_holohub_root()

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -152,6 +152,27 @@ def warn(message: str) -> None:
     print(f"{Color.yellow('WARNING:')} {message}")
 
 
+def get_holohub_root() -> Path:
+    """Get the HoloHub repository root path."""
+    env_root = os.environ.get("HOLOHUB_ROOT")
+    if env_root:
+        env_path = Path(env_root).expanduser()
+        if env_path.exists() and env_path.is_dir():
+            return env_path
+        warn(f"Environment variable HOLOHUB_ROOT='{env_root}' is invalid.")
+    default_path = Path(__file__).parent.parent.parent
+    if env_root:
+        warn(f"Falling back to default path: {default_path}")
+    return default_path
+
+
+HOLOHUB_ROOT = get_holohub_root()
+
+
+def get_holohub_root() -> Path:
+    return HOLOHUB_ROOT
+
+
 def _get_maybe_sudo() -> str:
     """Get sudo command if available, with caching to avoid repeated subprocess calls"""
     global _sudo_available


### PR DESCRIPTION
the root path is currently hard-coded as `HOLOHUB_ROOT = Path(__file__).parent.parent.parent` which is not flexible enough for external use cases.