### PR TITLE
Update H.264 application with MM 1.5 and CUDA 13 support

### DIFF
--- a/applications/h264/Dockerfile
+++ b/applications/h264/Dockerfile
@@ -76,4 +76,3 @@ WORKDIR /
 
 RUN /install_dependencies.sh
 
-ENV LD_PRELOAD=/opt/nvidia/holoscan/lib/libgxf_core.so

--- a/applications/h264/Dockerfile
+++ b/applications/h264/Dockerfile
@@ -25,6 +25,16 @@ FROM ${BASE_IMAGE} as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Starting from Holoscan SDK 3.6.0, only CUDA 13 is supported.
+# To run H.264 application with CUDA 12, please use tags with holoscan-sdk-3.5.0 or earlier.
+RUN CUDA_VERSION_MAJOR=$(echo $CUDA_VERSION | cut -d '.' -f 1) \
+    && if [ "$CUDA_VERSION_MAJOR" != "13" ]; then \
+        echo "CUDA version $CUDA_VERSION is not supported."; \
+        echo "Starting from Holoscan SDK 3.6.0, H.264 applications only support CUDA 13 or higher."; \
+        echo "To run H.264 application with CUDA 12, please use tags with holoscan-sdk-3.5.0 or earlier."; \
+        exit 1; \
+    fi
+
 # --------------------------------------------------------------------------
 #
 # Holohub dev setup 
@@ -65,3 +75,5 @@ WORKDIR /
 #ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/aarch64-linux-gnu/tegra/
 
 RUN /install_dependencies.sh
+
+ENV LD_PRELOAD=/opt/nvidia/holoscan/lib/libgxf_core.so

--- a/applications/h264/README.md
+++ b/applications/h264/README.md
@@ -27,6 +27,10 @@ for rendering decoded data to the native window.
 - x86_64
 - arm64 + discrete GPU platforms (SBSA, IGX dGPU)
 
+> [!IMPORTANT]  
+> Starting from Holoscan 3.6.0, H.264 applications only support CUDA 13 or higher.
+> To run H.264 application with CUDA 12, please use tags with [holoscan-sdk-3.5.0](https://github.com/nvidia-holoscan/holohub/tree/holoscan-sdk-3.5.0) or earlier.
+
 ## Known Issues
 
 ### Unsupported Platforms

--- a/applications/h264/h264_endoscopy_tool_tracking/cpp/CMakeLists.txt
+++ b/applications/h264/h264_endoscopy_tool_tracking/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/applications/h264/h264_endoscopy_tool_tracking/cpp/CMakeLists.txt
+++ b/applications/h264/h264_endoscopy_tool_tracking/cpp/CMakeLists.txt
@@ -15,7 +15,7 @@
 cmake_minimum_required(VERSION 3.20)
 project(h264_endoscopy_tool_tracking CXX)
 
-find_package(holoscan 2.1.0 REQUIRED CONFIG
+find_package(holoscan 3.6.1 REQUIRED CONFIG
              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
 add_executable(h264_endoscopy_tool_tracking

--- a/applications/h264/h264_endoscopy_tool_tracking/cpp/metadata.json
+++ b/applications/h264/h264_endoscopy_tool_tracking/cpp/metadata.json
@@ -16,8 +16,8 @@
     },
     "dockerfile": "applications/h264/Dockerfile",
     "holoscan_sdk": {
-      "minimum_required_version": "3.3.0",
-      "tested_versions": ["3.4.0"]
+      "minimum_required_version": "3.6.1",
+      "tested_versions": ["3.6.1"]
     },
     "platforms": ["x86_64", "aarch64"],
     "tags": ["Healthcare AI", "Video", "Surgical AI", "Endoscopy", "Visualization"],
@@ -26,19 +26,19 @@
       "operators": [
         {
           "name": "videodecoder",
-          "version": "1.4.1"
+          "version": "1.5.0"
         },
         {
           "name": "videodecoderio",
-          "version": "1.4.1"
+          "version": "1.5.0"
         },
         {
           "name": "videoencoder",
-          "version": "1.4.1"
+          "version": "1.5.0"
         },
         {
           "name": "videoencoderio",
-          "version": "1.4.1"
+          "version": "1.5.0"
         }
       ]
     },

--- a/applications/h264/h264_endoscopy_tool_tracking/python/CMakeLists.txt
+++ b/applications/h264/h264_endoscopy_tool_tracking/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/applications/h264/h264_endoscopy_tool_tracking/python/CMakeLists.txt
+++ b/applications/h264/h264_endoscopy_tool_tracking/python/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 cmake_minimum_required(VERSION 3.20)
 
-find_package(holoscan 2.1.0 REQUIRED CONFIG
+find_package(holoscan 3.6.1 REQUIRED CONFIG
   PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
 # Enable the operators

--- a/applications/h264/h264_endoscopy_tool_tracking/python/metadata.json
+++ b/applications/h264/h264_endoscopy_tool_tracking/python/metadata.json
@@ -14,8 +14,8 @@
     },
     "dockerfile": "applications/h264/Dockerfile",
     "holoscan_sdk": {
-      "minimum_required_version": "2.6.0",
-      "tested_versions": ["2.6.0"]
+      "minimum_required_version": "3.6.1",
+      "tested_versions": ["3.6.1"]
     },
     "platforms": ["x86_64", "aarch64"],
     "tags": ["Healthcare AI", "Video", "Surgical AI", "Endoscopy", "Visualization"],
@@ -24,19 +24,19 @@
       "operators": [
         {
           "name": "videodecoder",
-          "version": "1.2.0"
+          "version": "1.5.0"
         },
         {
           "name": "videodecoderio",
-          "version": "1.2.0"
+          "version": "1.5.0"
         },
         {
           "name": "videoencoder",
-          "version": "1.2.0"
+          "version": "1.5.0"
         },
         {
           "name": "videoencoderio",
-          "version": "1.2.0"
+          "version": "1.5.0"
         }
       ],
       "data": [
@@ -50,7 +50,10 @@
     },
     "run": {
       "command": "python3 <holohub_app_source>/h264_endoscopy_tool_tracking.py --data <holohub_data_dir>/endoscopy",
-      "workdir": "holohub_bin"
+      "workdir": "holohub_bin",
+      "env": {
+        "LD_PRELOAD": "/opt/nvidia/holoscan/lib/libgxf_core.so"
+      }
     }
   }
 }

--- a/applications/h264/h264_video_decode/cpp/CMakeLists.txt
+++ b/applications/h264/h264_video_decode/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/applications/h264/h264_video_decode/cpp/CMakeLists.txt
+++ b/applications/h264/h264_video_decode/cpp/CMakeLists.txt
@@ -15,7 +15,7 @@
 cmake_minimum_required(VERSION 3.20)
 project(h264_video_decode CXX)
 
-find_package(holoscan 2.1.0 REQUIRED CONFIG
+find_package(holoscan 3.6.1 REQUIRED CONFIG
              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
 add_executable(h264_video_decode

--- a/applications/h264/h264_video_decode/cpp/metadata.json
+++ b/applications/h264/h264_video_decode/cpp/metadata.json
@@ -16,8 +16,8 @@
     },
     "dockerfile": "applications/h264/Dockerfile",
     "holoscan_sdk": {
-      "minimum_required_version": "3.3.0",
-      "tested_versions": ["3.4.0"]
+      "minimum_required_version": "3.6.1",
+      "tested_versions": ["3.6.1"]
     },
     "platforms": ["x86_64", "aarch64"],
     "tags": ["Healthcare AI", "Video", "Hardware Accelerated Decode", "Endoscopy"],
@@ -26,11 +26,11 @@
       "operators": [
         {
           "name": "videodecoder",
-          "version": "1.4.1"
+          "version": "1.5.0"
         },
         {
           "name": "videodecoderio",
-          "version": "1.4.1"
+          "version": "1.5.0"
         }
       ]
     },

--- a/applications/h264/h264_video_decode/python/CMakeLists.txt
+++ b/applications/h264/h264_video_decode/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/applications/h264/h264_video_decode/python/CMakeLists.txt
+++ b/applications/h264/h264_video_decode/python/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 cmake_minimum_required(VERSION 3.20)
 
-find_package(holoscan 2.1.0 REQUIRED CONFIG
+find_package(holoscan 3.6.1 REQUIRED CONFIG
              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
 # Add testing

--- a/applications/h264/h264_video_decode/python/metadata.json
+++ b/applications/h264/h264_video_decode/python/metadata.json
@@ -14,8 +14,8 @@
     },
     "dockerfile": "applications/h264/Dockerfile",
     "holoscan_sdk": {
-      "minimum_required_version": "3.3.0",
-      "tested_versions": ["3.4.0"]
+      "minimum_required_version": "3.6.1",
+      "tested_versions": ["3.6.1"]
     },
     "platforms": ["x86_64", "aarch64"],
     "tags": ["Healthcare AI", "Video", "Hardware Accelerated Decode", "Endoscopy"],
@@ -24,17 +24,20 @@
       "operators": [
         {
           "name": "videodecoder",
-          "version": "1.4.1"
+          "version": "1.5.0"
         },
         {
           "name": "videodecoderio",
-          "version": "1.4.1"
+          "version": "1.5.0"
         }
       ]
     },
     "run": {
       "command": "python3 <holohub_app_source>/h264_video_decode.py --data <holohub_data_dir>/endoscopy",
-      "workdir": "holohub_bin"
+      "workdir": "holohub_bin",
+      "env": {
+        "LD_PRELOAD": "/opt/nvidia/holoscan/lib/libgxf_core.so"
+      }
     }
   }
 }

--- a/applications/h264/install_dependencies.sh
+++ b/applications/h264/install_dependencies.sh
@@ -20,8 +20,7 @@
 set -e
 
 # URL of the DeepStream dependencies required for gxf-mm extensions above
-DS_DEPS_URL="https://api.ngc.nvidia.com/v2/resources/org/nvidia/gxf_and_gc/4.0.0/files?redirect=true&path=nvv4l2_x86_ds-7.0.deb"
-
+DS_DEPS_URL="https://api.ngc.nvidia.com/v2/resources/org/nvidia/gxf_and_gc/5.1.0/files?redirect=true&path=nvv4l2_x86_ds-8.0.deb"
 ARCH=$(arch)
 HOLOSCAN_LIBS_DIR=/opt/nvidia/holoscan/lib/
 
@@ -39,8 +38,8 @@ gxf_mm_extensions=(["decoderio"]="45081ccb-982e-4946-96f9-0d684f2cfbd0" \
                    ["encoder"]="ea5c44e4-15db-4448-a3a6-f32004303338")
 mkdir -p gxf-mm
 mkdir -p ${HOLOSCAN_LIBS_DIR}
-MM_VERSION=1.4.1
-CUDA_VERSION=12.8
+MM_VERSION=1.5.0
+CUDA_VERSION=13.0
 UBUNTU_VERSION=24.04
 for extension in "${!gxf_mm_extensions[@]}"; do
   if [[ $extension == "decoderio" ]] || [[ $extension == "encoderio" ]]; then

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -1201,6 +1201,9 @@ class HoloHubCLI:
                 "HOLOSCAN_INPUT_PATH", str(HoloHubCLI.DEFAULT_DATA_DIR)
             )
 
+            if run_config.get("env", None) is not None:
+                env.update(run_config["env"])
+
             # Print environment setup
             if args.verbose or args.dryrun:
                 print(


### PR DESCRIPTION

- Added a check in the Dockerfile to enforce CUDA version 13 or higher for H.264 applications starting from Holoscan SDK 3.6.0.
- Updated DeepStream dependencies URL in install_dependencies.sh to version 5.1.0.
- Bumped the version of the GXF MM extensions and CUDA in install_dependencies.sh to 1.5.0 and 13.0, respectively.
- Updated CMakeLists.txt files for C++ and Python projects to require Holoscan version 3.6.1.

These changes ensure compatibility with the latest SDK and improve dependency management.