### PR TITLE
Fix multiai_ultrasound application for Holoscan 3.7 (update VisualizerICardioOp linking)

### DIFF
--- a/applications/multiai_ultrasound/operators/visualizer_icardio/python/CMakeLists.txt
+++ b/applications/multiai_ultrasound/operators/visualizer_icardio/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,5 +19,9 @@ pybind11_add_holohub_module(
     CLASS_NAME "VisualizerICardioOp"
     SOURCES visualizer_icardio_pybind.cpp
 )
+
+if("${holoscan_VERSION}" VERSION_GREATER_EQUAL "3.7")
+  target_link_libraries(visualizer_icardio_python PRIVATE holoscan::holoinfer_utils)
+endif()
 
 target_include_directories(visualizer_icardio_python PRIVATE ${Holohub_SOURCE_DIR}/operators)


### PR DESCRIPTION
Without the change here, running 
```
./holohub run multiai_ultrasound --language python
```
with the upcoming Holoscan v3.7 release will fail with:

```
Traceback (most recent call last):
  File "/workspace/holohub/applications/multiai_ultrasound/python/multiai_ultrasound.py", line 33, in <module>
    from holohub.visualizer_icardio import VisualizerICardioOp
  File "/workspace/holohub/build/multiai_ultrasound/python/lib/holohub/visualizer_icardio/__init__.py", line 29, in <module>
    raise e
  File "/workspace/holohub/build/multiai_ultrasound/python/lib/holohub/visualizer_icardio/__init__.py", line 23, in <module>
    from ._visualizer_icardio import VisualizerICardioOp
ImportError: /workspace/holohub/build/multiai_ultrasound/applications/multiai_ultrasound/operators/visualizer_icardio/libvisualizer_icardio.so: undefined symbol: _ZN8holoscan9inference11raise_errorERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES8_
Non-zero exit code running command: python3 /workspace/holohub/applications/multiai_ultrasound/python/multiai_ultrasound.py --data /workspace/holohub/data/multiai_ultrasound
Exit code: 1
```

Due to upstream changes, it is now necessary to link target `holoscan::holoinfer_utils` as done here. This target does not exist on older versions so the linking should be conditional on version number.