### PR TITLE
Holoscan 3.7: resolve `holoinfer_utils` link issue in `object_detection_torch` application

### DIFF
--- a/applications/object_detection_torch/main.cpp
+++ b/applications/object_detection_torch/main.cpp
@@ -17,6 +17,13 @@
 
 #include <getopt.h>
 
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
 #include <holoscan/holoscan.hpp>
 #include <holoscan/operators/format_converter/format_converter.hpp>
 #include <holoscan/operators/holoviz/holoviz.hpp>
@@ -131,12 +138,19 @@ class App : public holoscan::Application {
     }
 
     if (configuration.find("color") != configuration.end()) {
+      auto string_split = [](const std::string& line, std::vector<std::string>& tokens, char c) {
+        std::string token;
+        std::istringstream tokenStream(line);
+        while (std::getline(tokenStream, token, c)) {
+          tokens.push_back(token);
+        }
+      };
       for (const auto &[current_object, current_color] : configuration["color"]) {
         std::vector<std::string> tokens;
         std::vector<float> col;
 
         if (current_color.length() != 0) {
-          holoscan::inference::string_split(current_color, tokens, ' ');
+          string_split(current_color, tokens, ' ');
           if (tokens.size() == 4) {
             for (const auto &t : tokens) {
               col.push_back(std::stof(t));


### PR DESCRIPTION
This PR is intended to resolve the following error seen in nightly builds (I could not reproduce the exact error on my x86_64 system):
```
[2025-09-22T21:08:02.372Z] /usr/bin/ld: applications/object_detection_torch/CMakeFiles/object_detection_torch.dir/main.cpp.o: undefined reference to symbol '_ZN8holoscan9inference12string_splitERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorIS6_SaIS6_EEc'

[2025-09-22T21:08:02.372Z] /usr/bin/ld: /opt/nvidia/holoscan/lib/libholoinfer_utils.so: error adding symbols: DSO missing from command line
```

The goal here is similar to #1140 for **multiai_ultrasound**, but in this case `holoscan::inference::string_strip` was not marked with `_HOLOSCAN_EXTERNAL_API_` in the `holoscan_utils.hpp` header, so I don't think it should be used from Holohub.

I just duplicated that trivial function locally in the app here to remove the `libholoscan_utils.so` dependency.

The only other thing from that header used in this app is `holoscan::inference::node_type`, but that one is [just a using declaration](https://github.com/nvidia-holoscan/holoscan-sdk/blob/94763219acf432fdfe0f2a72925e759fe8d57cae/modules/holoinfer/src/include/holoinfer_utils.hpp#L112) so I think it should be okay to leave it as-is.

A grep of `holoscan::inference` and `HoloInfer` in the applications folder did not find any additional applications outside of this one and `multiai_ultrasound` that are using APIs defined in `holoinfer_utils.hpp`.


