### PR TITLE
Apps: Disable optional AJA source operator build by default

### DIFF
--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -44,7 +44,8 @@ add_subdirectory(distributed)
 
 add_holohub_application(endoscopy_depth_estimation)
 
-add_holohub_application(endoscopy_out_of_body_detection DEPENDS OPERATORS aja_source)
+add_holohub_application(endoscopy_out_of_body_detection DEPENDS
+                        OPERATORS OPTIONAL aja_source)
 
 add_holohub_application(endoscopy_tool_tracking DEPENDS
                         OPERATORS lstm_tensor_rt_inference
@@ -75,8 +76,10 @@ add_holohub_application(iio DEPENDS OPERATORS iio_controller fft)
 add_subdirectory(laser_detection_latency)
 
 add_holohub_application(monai_endoscopic_tool_seg DEPENDS OPERATORS aja_source)
-add_holohub_application(multiai_endoscopy DEPENDS OPERATORS aja_source)
-add_holohub_application(multiai_ultrasound DEPENDS OPERATORS aja_source)
+add_holohub_application(multiai_endoscopy DEPENDS
+                        OPERATORS OPTIONAL aja_source)
+add_holohub_application(multiai_ultrasound DEPENDS
+                        OPERATORS OPTIONAL aja_source)
 
 add_subdirectory(nvidia_video_codec)
 
@@ -84,7 +87,8 @@ add_holohub_application(simple_radar_pipeline)
 add_holohub_application(simple_pdw_pipeline DEPENDS
                         OPERATORS basic_network)
 
-add_holohub_application(object_detection_torch DEPENDS OPERATORS OPTIONAL aja_source)
+add_holohub_application(object_detection_torch DEPENDS
+                        OPERATORS OPTIONAL aja_source)
 
 add_holohub_application(openigtlink_3dslicer DEPENDS OPERATORS openigtlink)
 
@@ -114,7 +118,8 @@ add_holohub_application(psd_pipeline DEPENDS
                                   vita49_psd_packetizer
                                   data_writer)
 
-add_holohub_application(ultrasound_segmentation DEPENDS OPERATORS aja_source)
+add_holohub_application(ultrasound_segmentation DEPENDS
+                        OPERATORS OPTIONAL aja_source)
 
 add_holohub_application(velodyne_lidar_app DEPENDS
                         OPERATORS velodyne_lidar


### PR DESCRIPTION
Followup to 5290f24a608d1a68700e25a5558d1fd06fe23c0d to mark aja_source operator as an optional, off-by-default component in updated applications