### PR TITLE
App: Fix missing object_detection_torch header

### DIFF
--- a/applications/object_detection_torch/CMakeLists.txt
+++ b/applications/object_detection_torch/CMakeLists.txt
@@ -66,6 +66,8 @@ target_link_libraries(object_detection_torch
     holoscan::ops::inference
     holoscan::ops::inference_processor
     holoscan::ops::holoviz
+    holoscan::infer
+    $<TARGET_NAME_IF_EXISTS:holoscan::holoinfer_utils>
     $<TARGET_NAME_IF_EXISTS:holoscan::aja>
 )
 

--- a/applications/object_detection_torch/CMakeLists.txt
+++ b/applications/object_detection_torch/CMakeLists.txt
@@ -66,8 +66,6 @@ target_link_libraries(object_detection_torch
     holoscan::ops::inference
     holoscan::ops::inference_processor
     holoscan::ops::holoviz
-    holoscan::infer
-    $<TARGET_NAME_IF_EXISTS:holoscan::holoinfer_utils>
     $<TARGET_NAME_IF_EXISTS:holoscan::aja>
 )
 
@@ -78,6 +76,14 @@ if(holoscan_VERSION GREATER 3.5)
     torchvision::torchvision
     "-Wl,--no-as-needed $<TARGET_PROPERTY:Python3::Python,IMPORTED_LOCATION> $<TARGET_PROPERTY:torchvision::torchvision,IMPORTED_LOCATION> -Wl,--as-needed"
   )
+endif()
+
+if("${holoscan_VERSION}" VERSION_GREATER_EQUAL "3.7")
+  # holoscan::holoinfer_utils is directly available in Holoscan SDK 3.7 and later
+  target_link_libraries(object_detection_torch PRIVATE holoscan::holoinfer_utils)
+else()
+  # "holoscan_utils.hpp" is exposed through holoscan::infer in Holoscan SDK 3.6 and earlier
+  target_link_libraries(object_detection_torch PRIVATE holoscan::infer)
 endif()
 
 # Download the cars sample data

--- a/applications/object_detection_torch/main.cpp
+++ b/applications/object_detection_torch/main.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include <holoscan/holoscan.hpp>
+#include <holoinfer_utils.hpp>
 #include <holoscan/operators/format_converter/format_converter.hpp>
 #include <holoscan/operators/holoviz/holoviz.hpp>
 #include <holoscan/operators/inference/inference.hpp>


### PR DESCRIPTION
Apply fix for upcoming Holoscan SDK v3.7, which moves the "holoscan::inference::node_type" definition from the "holoscan::infer" target into the "holoscan::holoinfer_util" target

Backwards compatible with <=v3.6

Addresses error:
```
[object_detection_torch/main.cpp:130](https://gitlab-master.nvidia.com/clara-holoscan/clara-holoscan-sdk/blob/09a0250c71581fd51a3f8e4c872a441e40ab1b78/object_detection_torch/main.cpp#L130):75: error: 'node_type' is not a member of 'holoscan::inference'
  130 |     auto configuration = config["generate_boxes"].as<holoscan::inference::node_type>();
      |                                                                           ^~~~~~~~~
```

cc @shekhardw 