### PR TITLE
App: Fix nvidia_video_codec sample data download

### DIFF
--- a/applications/nvidia_video_codec/CMakeLists.txt
+++ b/applications/nvidia_video_codec/CMakeLists.txt
@@ -13,24 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Download the endoscopy sample data
-if(OP_nv_video_encoder OR OP_nv_video_decoder)
-  if(HOLOHUB_DOWNLOAD_DATASETS)
-  include(holoscan_download_data)
-  holoscan_download_data(endoscopy
-    URL nvidia/clara-holoscan/holoscan_endoscopy_sample_data:20230222
-    DOWNLOAD_NAME holoscan_endoscopy_sample_data_20230222.zip
-    DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
-    GENERATE_GXF_ENTITIES
-    GXF_ENTITIES_HEIGHT 480
-    GXF_ENTITIES_WIDTH 854
-    GXF_ENTITIES_CHANNELS 3
-    GXF_ENTITIES_FRAMERATE 30
-    ALL
-  )
-  endif()
-endif()
-
 add_holohub_application(nvc_decode DEPENDS OPERATORS
                           nv_video_encoder
                           nv_video_decoder
@@ -41,3 +23,21 @@ add_holohub_application(nvc_encode_decode DEPENDS OPERATORS
 add_holohub_application(nvc_encode_writer DEPENDS OPERATORS
                           nv_video_encoder
                           tensor_to_file)
+
+# Download the endoscopy sample data
+if(OP_nv_video_encoder OR OP_nv_video_decoder)
+  if(HOLOHUB_DOWNLOAD_DATASETS)
+    include(holoscan_download_data)
+    holoscan_download_data(endoscopy
+      URL nvidia/clara-holoscan/holoscan_endoscopy_sample_data:20230222
+      DOWNLOAD_NAME holoscan_endoscopy_sample_data_20230222.zip
+      DOWNLOAD_DIR ${HOLOHUB_DATA_DIR}
+      GENERATE_GXF_ENTITIES
+      GXF_ENTITIES_HEIGHT 480
+      GXF_ENTITIES_WIDTH 854
+      GXF_ENTITIES_CHANNELS 3
+      GXF_ENTITIES_FRAMERATE 30
+      ALL
+    )
+  endif()
+endif()


### PR DESCRIPTION
Move conditional statement such that data download is conditionally enabled following "OP_nv_video_encoder", "OP_nv_video_decoder" variable definitions in "add_holohub_application" function above

Minor fix to resolve observed issue where NVC application sample data not available unless previously downloaded by Endoscopy Tool Tracking or another HoloHub sample app