### PR TITLE
CLI: flexible default build-args (e.g. --build-context) and test commands

### DIFF
--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -369,19 +369,22 @@ class HoloHubContainer:
         if not build_args:
             return
         args_list = shlex.split(build_args)
-        for i, arg in enumerate(args_list):
-            # --build-context name=path
-            if arg == "--build-context" and i + 1 < len(args_list):
+        i = 0
+        while i < len(args_list):
+            arg = args_list[i]
+            context_spec = None
+            if arg == "--build-context" and i + 1 < len(args_list):  # --build-context name=path
                 context_spec = args_list[i + 1]
-            # --build-context=name=path
-            elif arg.startswith("--build-context="):
+                i += 2  # Skip both arguments
+            elif arg.startswith("--build-context="):  # --build-context=name=path
                 context_spec = arg.split("=", 1)[1]
+                i += 1
             else:
+                i += 1
                 continue
-            if "=" in context_spec:
-                _, path = context_spec.split("=", 1)
+            if context_spec and "=" in context_spec:
                 ensure_local_directory(
-                    path=path,
+                    path=context_spec.split("=", 1)[1],
                     base_dir=HoloHubContainer.HOLOHUB_ROOT,
                     dry_run=self.dryrun,
                     verbose=self.verbose,

--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -436,7 +436,7 @@ class HoloHubContainer:
         if no_cache:
             cmd.append("--no-cache")
 
-        full_build_args = " ".join(filter(str.strip, [HoloHubContainer.DEFAULT_BUILD_ARGS, build_args]))
+        full_build_args = " ".join(filter(None, [HoloHubContainer.DEFAULT_BUILD_ARGS, build_args]))
         if full_build_args:
             self.ensure_build_context_dirs(full_build_args)
             cmd.extend(shlex.split(full_build_args))

--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -667,6 +667,8 @@ class HoloHubContainer:
         docker_args.extend(self.ucx_args())
         docker_args.extend(self.get_device_cgroup_args())
         docker_args.extend(self.get_nvidia_runtime_args())
+        if HoloHubContainer.DEFAULT_DOCKER_RUN_ARGS:
+            docker_args.extend(shlex.split(HoloHubContainer.DEFAULT_DOCKER_RUN_ARGS))
         if docker_opts:
             docker_args.extend(shlex.split(docker_opts))
         project_name = self.project_metadata.get("project_name") if self.project_metadata else None

--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -436,7 +436,7 @@ class HoloHubContainer:
         if no_cache:
             cmd.append("--no-cache")
 
-        full_build_args = " ".join(filter(None, [HoloHubContainer.DEFAULT_BUILD_ARGS, build_args]))
+        full_build_args = " ".join(filter(str.strip, [HoloHubContainer.DEFAULT_BUILD_ARGS, build_args]))
         if full_build_args:
             self.ensure_build_context_dirs(full_build_args)
             cmd.extend(shlex.split(full_build_args))

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -848,7 +848,7 @@ class HoloHubCLI:
 
         xvfb = "" if args.no_xvfb else "xvfb-run -a"
 
-        # TAG is used in utilities/testing/holohub.container.ctest by default
+        # TAG is used in CTest scripts by default
         if getattr(args, "build_name_suffix", None):
             tag = args.build_name_suffix
         else:
@@ -857,7 +857,11 @@ class HoloHubCLI:
             else:
                 image_name = args.base_img or container.default_base_image()
             tag = image_name.split(":")[-1]
-        ctest_cmd = f"{xvfb} ctest -DAPP={args.project} -DTAG={tag} "
+
+        ctest_cmd = f"{xvfb} ctest "
+        if args.project:
+            ctest_cmd += f"-DAPP={args.project} "
+        ctest_cmd += f"-DTAG={tag} "
 
         if args.cmake_options:
             cmake_opts = ";".join(args.cmake_options)

--- a/utilities/cli/tests/CMakeLists.txt
+++ b/utilities/cli/tests/CMakeLists.txt
@@ -100,6 +100,20 @@ set_property(TEST test_holohub_build_container_build_args PROPERTY
     PASS_REGULAR_EXPRESSION "--build-arg TEST=value"
 )
 
+# default docker build args via environment variable
+add_test(
+    NAME test_holohub_default_docker_build_args_env
+    COMMAND ${CMAKE_SOURCE_DIR}/holohub build-container --dryrun
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_property(TEST test_holohub_default_docker_build_args_env PROPERTY
+    ENVIRONMENT "HOLOHUB_DEFAULT_DOCKER_BUILD_ARGS=--build-arg DEFAULT_FLAG=abc"
+)
+set_property(TEST test_holohub_default_docker_build_args_env PROPERTY
+    PASS_REGULAR_EXPRESSION "docker build"
+    PASS_REGULAR_EXPRESSION "DEFAULT_FLAG=abc"
+)
+
 add_test(
     NAME test_holohub_run_container_docker_opts
     COMMAND ${CMAKE_SOURCE_DIR}/holohub run-container --dryrun --docker-opts "--memory 4g --entrypoint=bash"
@@ -118,6 +132,20 @@ add_test(
 set_property(TEST test_holohub_run_container_add_volume PROPERTY
     PASS_REGULAR_EXPRESSION "docker run"
     PASS_REGULAR_EXPRESSION "-v /tmp:/tmp"
+)
+
+# default docker run args via environment variable
+add_test(
+    NAME test_holohub_default_docker_run_args_env
+    COMMAND ${CMAKE_SOURCE_DIR}/holohub run-container --dryrun
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_property(TEST test_holohub_default_docker_run_args_env PROPERTY
+    ENVIRONMENT "HOLOHUB_DEFAULT_DOCKER_RUN_ARGS=-e TEST_ENV=123"
+)
+set_property(TEST test_holohub_default_docker_run_args_env PROPERTY
+    PASS_REGULAR_EXPRESSION "docker run"
+    PASS_REGULAR_EXPRESSION "TEST_ENV=123"
 )
 
 add_test(

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -823,32 +823,6 @@ def docker_args_to_devcontainer_format(docker_args: List[str]) -> List[str]:
     return result
 
 
-def ensure_local_directory(
-    path: Union[str, Path],
-    base_dir: Optional[Path] = None,
-    dry_run: bool = False,
-    verbose: bool = False,
-) -> Path:
-    """Ensure a local directory exists after expanding env vars and user home.
-
-    - Expands environment variables and '~'
-    - Resolves relative paths against `base_dir` (defaults to `HOLOHUB_ROOT`)
-    - Creates the directory (parents=True) if it doesn't exist
-
-    Returns the absolute resolved path.
-    """
-    expanded = Path(os.path.expandvars(os.path.expanduser(str(path))))
-    # Resolve relative paths against provided base or HOLOHUB_ROOT
-    if not expanded.is_absolute():
-        expanded = Path(base_dir or get_holohub_root()) / expanded
-    if not expanded.exists():
-        if verbose:
-            print(f"Creating directory: {expanded}")
-        if not dry_run:
-            expanded.mkdir(parents=True, exist_ok=True)
-    return expanded
-
-
 def get_entrypoint_command_args(
     img: str, command: str, docker_opts: str, dry_run: bool = False
 ) -> tuple[str, List[str]]:
@@ -1154,7 +1128,8 @@ def collect_environment_variables() -> None:
         "HOLOHUB_DEFAULT_DOCKERFILE",
         "HOLOHUB_BASE_IMAGE_FORMAT",
         "HOLOHUB_DEFAULT_IMAGE_FORMAT",
-        "HOLOHUB_DEFAULT_BUILD_ARGS",
+        "HOLOHUB_DEFAULT_DOCKER_BUILD_ARGS",
+        "HOLOHUB_DEFAULT_DOCKER_RUN_ARGS",
         "HOLOHUB_DOCS_URL",
         "HOLOHUB_CLI_DOCS_URL",
         "HOLOHUB_DATA_PATH",


### PR DESCRIPTION
this PR provides CLI usability enhancements:

- allow for additional default docker `build-args` for external usage, e.g.
```bash
export HOLOHUB_DEFAULT_BUILD_ARGS="--build-context sipl_src_context=/tmp/sipl_empty"
./holohub run-container
```

~- ensure that `/local/path` exists when CLI args include docker `--build-context` configurations such as `--build-context=sipl_src_context=/local/path`~ (removed after offline discussions with @agirault)

- revise `./holohub test` to remove the hard-coded `-DAPP={args.project}`, `args.project` should be optional for the command