### PR TITLE
CLI: flexible build type options

### DIFF
--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -181,8 +181,8 @@ class HoloHubCLI:
         build.add_argument("--verbose", action="store_true", help="Print extra output")
         build.add_argument(
             "--build-type",
-            choices=["debug", "release", "rel-debug"],
-            help="Build type (debug, release, rel-debug)",
+            help="Build type (debug, release, rel-debug). "
+            "If not specified, uses CMAKE_BUILD_TYPE environment variable or defaults to 'release'",
         )
         build.add_argument(
             "--build-with",
@@ -236,8 +236,8 @@ class HoloHubCLI:
         )
         run.add_argument(
             "--build-type",
-            choices=["debug", "release", "rel-debug"],
-            help="Build type (debug, release, rel-debug)",
+            help="Build type (debug, release, rel-debug). "
+            "If not specified, uses CMAKE_BUILD_TYPE environment variable or defaults to 'release'",
         )
         run.add_argument(
             "--run-args",
@@ -337,8 +337,8 @@ class HoloHubCLI:
         )
         install.add_argument(
             "--build-type",
-            choices=["debug", "release", "rel-debug"],
-            help="Build type (debug, release, rel-debug)",
+            help="Build type (debug, release, rel-debug). "
+            "If not specified, uses CMAKE_BUILD_TYPE environment variable or defaults to 'release'",
         )
         install.add_argument(
             "--language", choices=["cpp", "python"], help="Specify language implementation"
@@ -1135,7 +1135,7 @@ class HoloHubCLI:
                 build_dir, project_data = self.build_project_locally(
                     project_name=args.project,
                     language=args.language if hasattr(args, "language") else None,
-                    build_type=args.build_type or "Release",  # Default to Release for run
+                    build_type=args.build_type,
                     with_operators=build_args.get("with_operators"),
                     dryrun=args.dryrun,
                     pkg_generator=getattr(args, "pkg_generator", "DEB"),


### PR DESCRIPTION
the logic will fully rely on the existing util:
https://github.com/nvidia-holoscan/holohub/blob/b9f59a3a75f4eb0360fc8ab05185131a84ceb8dc/utilities/cli/util.py#L486-L491