### PR TITLE
CLI: default parallel param

### DIFF
--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -968,7 +968,7 @@ class HoloHubCLI:
         build_cmd = ["cmake", "--build", str(build_dir), "--config", build_type]
         # Determine the number of parallel jobs (user input > env var > CPU count):
         if parallel is not None:
-            build_njobs = parallel
+            build_njobs = str(parallel)
         else:
             build_njobs = os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", str(os.cpu_count()))
         build_cmd.extend(["-j", build_njobs])

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -967,7 +967,10 @@ class HoloHubCLI:
         # Build the project with optional parallel jobs
         build_cmd = ["cmake", "--build", str(build_dir), "--config", build_type]
         # Determine the number of parallel jobs (user input > env var > CPU count):
-        build_njobs = parallel if parallel is not None else os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", str(os.cpu_count()))
+        if parallel is not None:
+            build_njobs = parallel
+        else:
+            build_njobs = os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", str(os.cpu_count()))
         build_cmd.extend(["-j", build_njobs])
 
         holohub_cli_util.run_command(build_cmd, dry_run=dryrun)

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -966,10 +966,9 @@ class HoloHubCLI:
 
         # Build the project with optional parallel jobs
         build_cmd = ["cmake", "--build", str(build_dir), "--config", build_type]
-        if parallel:
-            build_cmd.extend(["-j", parallel])
-        else:
-            build_cmd.append("-j")  # Use default number of jobs
+        # Determine the number of parallel jobs (user input > env var > CPU count):
+        build_njobs = parallel or os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", str(os.cpu_count()))
+        build_cmd.extend(["-j", build_njobs])
 
         holohub_cli_util.run_command(build_cmd, dry_run=dryrun)
 

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -967,7 +967,7 @@ class HoloHubCLI:
         # Build the project with optional parallel jobs
         build_cmd = ["cmake", "--build", str(build_dir), "--config", build_type]
         # Determine the number of parallel jobs (user input > env var > CPU count):
-        build_njobs = parallel or os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", str(os.cpu_count()))
+        build_njobs = parallel if parallel is not None else os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", str(os.cpu_count()))
         build_cmd.extend(["-j", build_njobs])
 
         holohub_cli_util.run_command(build_cmd, dry_run=dryrun)


### PR DESCRIPTION
add support of `CMAKE_BUILD_PARALLEL_LEVEL` to override the default nproc value