### PR TITLE
CLI: add container flag `CMAKE_BUILD_PARALLEL_LEVEL` if it's defined on the host

### DIFF
--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -599,9 +599,7 @@ class HoloHubContainer:
         # Pass CMAKE_BUILD_PARALLEL_LEVEL to container if set on host
         cmake_parallel_level = os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL")
         if cmake_parallel_level:
-            args.extend(
-                ["-e", f"CMAKE_BUILD_PARALLEL_LEVEL={cmake_parallel_level}"]
-            )
+            args.extend(["-e", f"CMAKE_BUILD_PARALLEL_LEVEL={cmake_parallel_level}"])
         return args
 
     def enable_x11_access(self) -> None:


### PR DESCRIPTION
if `CMAKE_BUILD_PARALLEL_LEVEL` is defined on the host, also make it available in a container