### PR TITLE
CLI: support subfolder name app_name/py

### DIFF
--- a/utilities/metadata/gather_metadata.py
+++ b/utilities/metadata/gather_metadata.py
@@ -69,7 +69,7 @@ def extract_project_name(metadata_filepath: str) -> str:
 
     """
     parts = metadata_filepath.split(os.sep)
-    if parts[-2] in ["cpp", "python"]:
+    if parts[-2] in ["cpp", "python", "py"]:
         return parts[-3]
     return parts[-2]
 


### PR DESCRIPTION
in addition to `app_name/python/metadata.json`, this PR makes `app_name/py/metadata.json` a valid app folder