### PR TITLE
CLI: fixes setup apt install error

### DIFF
--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -1457,6 +1457,7 @@ def setup_cuda_packages(cuda_major_version: str, dry_run: bool = False) -> None:
                 f"libnvinfer-dispatch10={installed_libnvinferversion}",
                 f"libnvonnxparsers10={installed_libnvinferversion}",
             ],
+            apt_options=["--no-install-recommends", "-y", "--allow-downgrades"],
             dry_run=dry_run,
         )
 


### PR DESCRIPTION
append apt install option `--allow-downgrades` to avoid the following error during `./holohub setup` in certain environment:

```
2025-10-23 10:31:01 $ apt install --no-install-recommends -y libnvinfer-bin=10.13.3.9-1+cuda12.9 libnvinfer-lean10=10.13.3.9-1+cuda12.9 libnvinfer-plugin10=10.13.3.9-1+cuda12.9 libnvinfer-vc-plugin10=10.13.3.9-1+cuda12.9 libnvinfer-dispatch10=10.13.3.9-1+cuda12.9 libnvonnxparsers10=10.13.3.9-1+cuda12.9
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  libnvinfer-bin libnvinfer-plugin10 libnvonnxparsers10
The following packages will be DOWNGRADED:
  libnvinfer-dispatch10 libnvinfer-lean10 libnvinfer-vc-plugin10
0 upgraded, 3 newly installed, 3 downgraded, 0 to remove and 11 not upgraded.
E: Packages were downgraded and -y was used without --allow-downgrades.
Non-zero exit code running command: apt install --no-install-recommends -y libnvinfer-bin=10.13.3.9-1+cuda12.9 libnvinfer-lean10=10.13.3.9-1+cuda12.9 libnvinfer-plugin10=10.13.3.9-1+cuda12.9 libnvinfer-vc-plugin10=10.13.3.9-1+cuda12.9 libnvinfer-dispatch10=10.13.3.9-1+cuda12.9 libnvonnxparsers10=10.13.3.9-1+cuda12.9
Exit code: 100
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized CUDA package installation process to reduce unnecessary dependencies and enable flexible version management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->