### PR TITLE
Remove `ctest_update()`

### DIFF
--- a/utilities/testing/holohub.container.ctest
+++ b/utilities/testing/holohub.container.ctest
@@ -56,7 +56,6 @@ set(configure_options
 set(CTEST_NIGHTLY_START_TIME "06:00:00 UTC")
 
 ctest_start(Nightly)
-ctest_update()
 ctest_configure(OPTIONS "${configure_options}")
 ctest_build()
 ctest_test(RETURN_VALUE test_result)


### PR DESCRIPTION
Currently, the `ctest_update() is causing the deletion of changes that are not on the remote branch, even if they are committed. This PR removes that CTest function.