### PR TITLE
update metadata.json endoscopy-tool-tracking to include cmake flags

### DIFF
--- a/applications/endoscopy_tool_tracking/python/metadata.json
+++ b/applications/endoscopy_tool_tracking/python/metadata.json
@@ -39,7 +39,7 @@
 			]
 		},
 		"default_mode": "replayer",
-        "modes": {
+		"modes": {
 			"replayer": {
 				"description": "Run the application in replayer mode",
 				"build": {


### PR DESCRIPTION
fixing an issue when building both cpp and python without clearing cache (which was working before the cpp flag change https://github.com/nvidia-holoscan/holohub/blob/769f99446915d4c72cd7fb57d0b61c54a400197d/applications/endoscopy_tool_tracking/cpp/metadata.json#L42-L44):
```
./holohub clear-cache;
./holohub run endoscopy_tool_tracking --language cpp --local;
./holohub run endoscopy_tool_tracking --language python --local
```
final error:
```
...
[1/1] cd /workspace/holohub/build/endoscopy_tool_tracking/applications/endoscopy_tool_tracking/cpp && /usr/bin/cmake -E copy_if_different /workspace/holohub/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking.yaml /workspace/holohub/build/endoscopy_tool_tracking/applications/endoscopy_tool_tracking/cpp && /usr/bin/cmake -E copy_if_different /workspace/holohub/applications/endoscopy_tool_tracking/cpp/endoscopy_tool_tracking_aja_overlay.yaml /workspace/holohub/build/endoscopy_tool_tracking/applications/endoscopy_tool_tracking/cpp && /usr/bin/cmake -E copy_if_different /workspace/holohub/applications/endoscopy_tool_tracking/cpp/postprocessor.slang /workspace/holohub/build/endoscopy_tool_tracking/applications/endoscopy_tool_tracking/cpp
Traceback (most recent call last):
  File "/workspace/holohub/applications/endoscopy_tool_tracking/python/endoscopy_tool_tracking.py", line 35, in <module>
    from holohub.lstm_tensor_rt_inference import LSTMTensorRTInferenceOp
ModuleNotFoundError: No module named 'holohub'
```