### PR TITLE
App: Update xr_holoviz APT dependencies

### DIFF
--- a/applications/xr_holoviz/Dockerfile
+++ b/applications/xr_holoviz/Dockerfile
@@ -27,13 +27,15 @@ RUN wget -qO /etc/apt/sources.list.d/lunarg-vulkan-noble.list \
 RUN apt update \
     && apt install --no-install-recommends -y \
         vulkan-icd \
-        vulkan-sdk 
+        vulkan-sdk \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install OpenXR SDK Dependencies.
 RUN apt update \
     && apt install --no-install-recommends -y \
         build-essential \
-        cmake \
+        cmake=3.31.* \
+        cmake-data=3.31.* \
         libeigen3-dev \
         libgl1-mesa-dev \
         libvulkan-dev \
@@ -49,7 +51,9 @@ RUN apt update \
         mesa-common-dev \
         libopenxr-loader1 \
         libopenxr-dev \
-        libopenxr1-monado
+        libopenxr1-monado \
+        clang-format \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install specific version of markupsafe for OpenXR build
 RUN pip install markupsafe==2.0.1


### PR DESCRIPTION
Changes:
- Pin to CMake 3.x as workaround for OpenXR build. OpenXR sources are currently pinned to release-1.0.26 which does not support CMake 4.x
- Install clang-format to address OpenXR build warning about missing clang-format
- Remove APT cache to reduce layer size

Verified successful app build on x86_64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment dependencies with latest CMake version and expanded OpenXR development libraries.
  * Added development libraries for enhanced platform compatibility.
  * Optimized Docker image configuration for improved build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->