### PR TITLE
Fix Build Issue with NV Video Codec Operators

### DIFF
--- a/operators/nvidia_video_codec/nv_video_decoder/CMakeLists.txt
+++ b/operators/nvidia_video_codec/nv_video_decoder/CMakeLists.txt
@@ -44,4 +44,6 @@ target_include_directories(nv_video_decoder PUBLIC
   ${NVC_SDK_PATH}/NvDecoder
 )
 
-add_subdirectory(python)
+if(HOLOHUB_BUILD_PYTHON)
+  add_subdirectory(python)
+endif()

--- a/operators/nvidia_video_codec/nv_video_encoder/CMakeLists.txt
+++ b/operators/nvidia_video_codec/nv_video_encoder/CMakeLists.txt
@@ -45,4 +45,6 @@ target_include_directories(nv_video_encoder PUBLIC
   ${NVC_SDK_PATH}/NvEncoder
 )
 
-add_subdirectory(python)
+if(HOLOHUB_BUILD_PYTHON)
+  add_subdirectory(python)
+endif()

--- a/operators/nvidia_video_codec/nv_video_reader/CMakeLists.txt
+++ b/operators/nvidia_video_codec/nv_video_reader/CMakeLists.txt
@@ -48,4 +48,6 @@ target_include_directories(nv_video_reader PUBLIC
   $<BUILD_INTERFACE:${NVC_SDK_PATH}/Utils>
 )
 
-add_subdirectory(python)
+if(HOLOHUB_BUILD_PYTHON)
+  add_subdirectory(python)
+endif()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Made Python components for NVIDIA video codec operators optional during build configuration, allowing builds to skip Python component compilation when not needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->