### PR TITLE
vila live generates test config in cmake binary dir

### DIFF
--- a/applications/vila_live/CMakeLists.txt
+++ b/applications/vila_live/CMakeLists.txt
@@ -51,7 +51,7 @@ if(BUILD_TESTING)
   # add model path and quant path to the yaml file, see also Dockerfile
   string(APPEND CONFIG_FILE "\nmodel_path: /workspace/volumes/models/Llama-3-VILA1.5-8b-Fix-AWQ/")
   string(APPEND CONFIG_FILE "\nquant_path: /workspace/volumes/models/Llama-3-VILA1.5-8b-Fix-AWQ/llm/llama-3-vila1.5-8b-fix-w4-g128-awq-v2.pt")
-  file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/tests/vila_live_testing.yaml ${CONFIG_FILE})
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/vila_live_testing.yaml ${CONFIG_FILE})
 
   add_custom_target(vila_live_test ALL
     DEPENDS "vila_live"

--- a/applications/vila_live/tests/CMakeLists.txt
+++ b/applications/vila_live/tests/CMakeLists.txt
@@ -24,12 +24,13 @@ add_test(NAME vila_live_tinychat_test
 # Set test properties
 set_tests_properties(vila_live_vlm_test
   PROPERTIES
-  ENVIRONMENT "HOLOHUB_DATA_DIR=${HOLOHUB_DATA_DIR}"
+  ENVIRONMENT "HOLOHUB_DATA_DIR=${HOLOHUB_DATA_DIR};VILA_LIVE_TEST_CONFIG=${CMAKE_CURRENT_BINARY_DIR}/../vila_live_testing.yaml"
   PASS_REGULAR_EXPRESSION "Scheduler finished"
   FAIL_REGULAR_EXPRESSION "FAILED")
 
 # Set test properties for TinyChat test
 set_tests_properties(vila_live_tinychat_test
   PROPERTIES
+  ENVIRONMENT "VILA_LIVE_TEST_CONFIG=${CMAKE_CURRENT_BINARY_DIR}/../vila_live_testing.yaml"
   PASS_REGULAR_EXPRESSION "Llama"
   FAIL_REGULAR_EXPRESSION "Traceback")

--- a/applications/vila_live/tests/test_tinychat.py
+++ b/applications/vila_live/tests/test_tinychat.py
@@ -22,7 +22,11 @@ import unittest
 import requests
 import yaml
 
-test_yaml = os.path.join(os.path.dirname(os.path.abspath(__file__)), "vila_live_testing.yaml")
+# Use environment variable if set, otherwise fallback to source directory location
+test_yaml = os.environ.get(
+    "VILA_LIVE_TEST_CONFIG",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "vila_live_testing.yaml"),
+)
 
 
 class TestTinyChat(unittest.TestCase):

--- a/applications/vila_live/tests/test_vlm.py
+++ b/applications/vila_live/tests/test_vlm.py
@@ -82,8 +82,10 @@ class TestVLM(unittest.TestCase):
     def test_generate_response(self):
         """Test the generate_response method"""
         app = V4L2toVLM("none", "replayer", "none")
-        testing_yaml = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "vila_live_testing.yaml"
+        # Use environment variable if set, otherwise fallback to source directory location
+        testing_yaml = os.environ.get(
+            "VILA_LIVE_TEST_CONFIG",
+            os.path.join(os.path.dirname(os.path.abspath(__file__)), "vila_live_testing.yaml"),
         )
         if not os.path.exists(testing_yaml):
             raise FileNotFoundError(f"Testing YAML file not found: {testing_yaml}")


### PR DESCRIPTION
change to generate testing config in the cmake binary dir

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration to support environment variable-based path resolution for test configuration files
  * Modified test configuration file generation to output to the build directory instead of source directory
  * Enhanced test setup to allow external configuration specification while maintaining backward compatibility with original file paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->