### PR TITLE
Fix Build Issue with "NVIDIA Video Codec: Video Writer" Application

### DIFF
--- a/operators/tensor_to_file/CMakeLists.txt
+++ b/operators/tensor_to_file/CMakeLists.txt
@@ -34,4 +34,7 @@ target_include_directories(tensor_to_file PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 
-add_subdirectory(python)
+# Python module
+if(HOLOHUB_BUILD_PYTHON)
+  add_subdirectory(python)
+endif()


### PR DESCRIPTION
"NVIDIA Video Codec: Video Writer" Application (`nvc_encode_writer`) fails to build with C++ language. This PR fixes this issue by gating the python build in its tensor to file dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made Python module building configurable through a build flag, allowing users to optionally exclude the Python component during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->