### PR TITLE
Bump Default Holoscan SDK Base Container to v3.8.0 Release

### DIFF
--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -29,7 +29,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
-DEFAULT_BASE_SDK_VERSION = "3.7.0"
+DEFAULT_BASE_SDK_VERSION = "3.8.0"
 
 PROJECT_PREFIXES = {
     "application": "APP",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated default SDK version baseline to 3.8.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->