### PR TITLE
fixes multiai_ultrasound test error

### DIFF
--- a/applications/multiai_ultrasound/python/multiai_ultrasound.py
+++ b/applications/multiai_ultrasound/python/multiai_ultrasound.py
@@ -162,7 +162,7 @@ class MultiAIICardio(Application):
 
         # version 2.6 supports the CUDA version of `max_per_channel_scaled`
         try:
-            major, minor = map(int, holoscan_version.split('.')[:2])
+            major, minor = map(int, holoscan_version.split(".")[:2])
             supports_cuda_processing = (major, minor) >= (2, 6)
         except Exception:
             supports_cuda_processing = False


### PR DESCRIPTION
```
$ ./holohub test multiai_ultrasound --cuda 12

3: Test command: /usr/bin/python3 "/workspace/holohub/applications/multiai_ultrasound/python/multiai_ultrasound.py" "--config" "/workspace/holohub/build-multiai_ultrasound/applications/multiai_ultrasound/python/multiai_ultrasound_testing.yaml" "--data" "/workspace/holohub/data-multiai_ultrasound-v3.8.0-cuda13/multiai_ultrasound" "--record_type" "visualizer"
3: Working Directory: /workspace/holohub/build-multiai_ultrasound
3: Environment variables: 
3:  PYTHONPATH=/opt/nvidia/holoscan/lib/../python/lib:/workspace/holohub/build-multiai_ultrasound/python/lib
3: Test timeout computed to be: 600
3: [info] [inference.cpp:296] Call in register types for ActivationSpec
3: Traceback (most recent call last):
3:   File "/workspace/holohub/applications/multiai_ultrasound/python/multiai_ultrasound.py", line 30, in <module>
3:     from packaging.version import Version
3: ModuleNotFoundError: No module named 'packaging'
3/4 Test #3: multiai_ultrasound_python_test ..........***Failed  Required regular expression not found. Regex=[Reach end of file or playback count reaches to the limit. Stop ticking.
]  0.12 sec
test 4
    Start 4: multiai_ultrasound_python_render_test

4: Test command: /usr/bin/python3 "/workspace/holohub/utilities/video_validation.py" "--source_video_dir" "/workspace/holohub/build-multiai_ultrasound/applications/multiai_ultrasound/python/recording_output" "--source_video_basename" "python_multiai_ultrasound_output" "--output_dir" "/workspace/holohub/build-multiai_ultrasound/applications/multiai_ultrasound/python/recording_output" "--validation_frames_dir" "/workspace/holohub/applications/multiai_ultrasound/testing/"
4: Working Directory: /workspace/holohub/build-multiai_ultrasound
4: Test timeout computed to be: 600
4: Traceback (most recent call last):
4:   File "/workspace/holohub/utilities/video_validation.py", line 125, in <module>
4:     main()
4:   File "/workspace/holohub/utilities/video_validation.py", line 110, in main
4:     convert_gxf_entity_to_images(
4:   File "/workspace/holohub/utilities/convert_gxf_entities_to_images.py", line 35, in convert_gxf_entity_to_images
4:     with EntityReader(directory=entity_dir, basename=entity_basename) as reader:
4:   File "/workspace/holohub/utilities/gxf_entity_codec.py", line 908, in __enter__
4:     self.open()
4:   File "/workspace/holohub/utilities/gxf_entity_codec.py", line 916, in open
4:     self._index_file = open(self._index_path, "rb")  # noqa: SIM115
4:                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
4: FileNotFoundError: [Errno 2] No such file or directory: '/workspace/holohub/build-multiai_ultrasound/applications/multiai_ultrasound/python/recording_output/python_multiai_ultrasound_output.gxf_index'
4/4 Test #4: multiai_ultrasound_python_render_test ...***Failed  Required regular expression not found. Regex=[Valid video output!
]  0.05 sec

50% tests passed, 2 tests failed out of 4
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA capability detection to use a deterministic major.minor check (requires holoscan ≥ 2.6). Detection failures now safely disable GPU processing instead of enabling it by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->