### PR TITLE
App: Update "holoscan" wheel installation in colonoscopy_segmentation

### DIFF
--- a/applications/colonoscopy_segmentation/Dockerfile
+++ b/applications/colonoscopy_segmentation/Dockerfile
@@ -75,8 +75,9 @@ RUN if ! python3 -m pip --version >/dev/null 2>&1; then \
         curl -sS https://bootstrap.pypa.io/get-pip.py | ${PYTHON_VERSION} \
     ; fi
 
-RUN pip3 install holoscan cupy-cuda12x \
-    && python3 -m site
+RUN set -e \
+    && pip3 install holoscan cupy-cuda12x \
+    && python3 -c "pass"  # dummy command to run wheel-axle-runtime post-installation setup
 
 ########################################################
 # Build with AJA C++ requirements


### PR DESCRIPTION
Replaces previous permissions approach to instead run holoscan wheel post-install setup in advance.

The `holoscan-cuX` bdist wheels rely on wheel-axle-runtime to run post-installation setup in the Python3 system environment. Setup requires certain user permissions.

Previous behavior:
- `pip install holoscan` with root permissions, no post-install setup, run as non-root user encounters blocking runtime error:
```
  PermissionError: [Errno 13] Permission denied: '/usr/local/lib/python3.12/dist-packages/holoscan_cu12-3.8.0.dist-info/axle.lck'
```
- `pip install holoscan` and relaxed folder permissions: post-install runs automatically at container runtime, no error

Updated behavior with `python3 -m site`: runs wheel-axle-runtime post-install setup during the docker build, no permission updates required, running as non-root user succeeds

Post-install setup does the following:
- Runs "python3.12/dist-packages/holoscan_cu12-3.8.0.pth" to initiate setup
- Holds "axle.lck"
- Sets up Holoscan SDK shared library binary locations
- Creates "axle.done" and removes "holoscan_cu12-3.8.0.pth" when complete

Reference: https://github.com/karellen/wheel-axle-runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified the colonoscopy segmentation app build by removing explicit filesystem permission tweaks and using a safer wrapper to run post-install steps.
  * Enforced fail-fast behavior and replaced the previous permission workaround with a lightweight Python invocation to trigger downstream post-install actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->