### PR TITLE
App: fix aja_source in multiai_endoscopy

### DIFF
--- a/applications/multiai_endoscopy/python/multi_ai.py
+++ b/applications/multiai_endoscopy/python/multi_ai.py
@@ -29,8 +29,6 @@ from holoscan.operators import (
 )
 from holoscan.resources import UnboundedAllocator
 
-from holohub.aja_source import AJASourceOp
-
 
 class DetectionPostprocessorOp(Operator):
     """Example of an operator post processing the tensor from inference component.
@@ -156,7 +154,12 @@ class MultiAIDetectionSegmentation(Application):
 
         # start constructing app
         is_aja = self.source.lower() == "aja"
-        SourceClass = AJASourceOp if is_aja else VideoStreamReplayerOp
+        if is_aja:
+            from holohub.aja_source import AJASourceOp
+
+            SourceClass = AJASourceOp
+        else:
+            SourceClass = VideoStreamReplayerOp
         source_kwargs = self.kwargs(self.source)
         if self.source == "replayer":
             video_dir = os.path.join(self.sample_data_path, "endoscopy")


### PR DESCRIPTION
`./holohub test multiai_endoscopy --verbose`

```
[2025-11-13T09:55:42.588Z] test 3
[2025-11-13T09:55:42.588Z]     Start 3: multiai_endoscopy_python_test
[2025-11-13T09:55:42.588Z] 
[2025-11-13T09:55:42.588Z] 3: Test command: /usr/bin/python3 "/workspace/holohub/build-multiai_endoscopy/applications/multiai_endoscopy/python/multi_ai_test.py" "--config" "/workspace/holohub/build-multiai_endoscopy/applications/multiai_endoscopy/python/multi_ai_test.yaml" "--data" "/workspace/holohub/data-multiai_endoscopy-main/"
[2025-11-13T09:55:42.588Z] 3: Working Directory: /workspace/holohub/build-multiai_endoscopy
[2025-11-13T09:55:42.588Z] 3: Environment variables: 
[2025-11-13T09:55:42.588Z] 3:  PYTHONPATH=/opt/nvidia/holoscan/lib/../python/lib:/workspace/holohub/build-multiai_endoscopy/python/lib
[2025-11-13T09:55:42.588Z] 3: Test timeout computed to be: 1200
[2025-11-13T09:55:42.588Z] 3: [info] [inference.cpp:296] Call in register types for ActivationSpec
[2025-11-13T09:55:42.588Z] 3: Traceback (most recent call last):
[2025-11-13T09:55:42.588Z] 3:   File "/workspace/holohub/build-multiai_endoscopy/applications/multiai_endoscopy/python/multi_ai_test.py", line 33, in <module>
[2025-11-13T09:55:42.588Z] 3:     from holohub.aja_source import AJASourceOp
[2025-11-13T09:55:42.588Z] 3: ModuleNotFoundError: No module named 'holohub.aja_source'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized import handling for improved performance. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->