### PR TITLE
Enable sccache in holohub CLI

### DIFF
--- a/utilities/cli/README.md
+++ b/utilities/cli/README.md
@@ -400,6 +400,7 @@ The CLI supports the following environment variables for customization:
 **Build and Execution Control:**
 - **`HOLOHUB_BUILD_LOCAL`**: Forces local mode (equivalent to `--local`), skips the container build steps and runs on the host directly.
 - **`HOLOHUB_ALWAYS_BUILD`**: Set to `false` to skip builds with `--no-local-build` and `--no-docker-build`.
+- **`HOLOHUB_ENABLE_SCCACHE`**: Defaults to `false`. Set to `true` to enable rapids-sccache for the build. You can configure sccache with `SCCACHE_*` environment variables per the [sccache documentation](https://github.com/rapidsai/sccache/tree/rapids/docs).
 
 **Paths and Directories:**
 - **`HOLOHUB_ROOT`**: HoloHub repository root directory, used to resolve relative paths for components, build artifacts, data, and other resources.

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -331,6 +331,28 @@ def parse_semantic_version(version: str) -> Tuple[int, int, int]:
     return tuple(map(int, match.group(1).split(".")))
 
 
+def parse_rapids_sccache_version(version: str) -> Tuple[int, int, int, int]:
+    """
+    Parse RAPIDS sccache version strings into a 4-tuple (major, minor, patch, rapids_custom).
+    Required format:
+      - "0.12.0-rapids.20"
+      - "v0.12.0-rapids.20"
+    """
+    if not isinstance(version, str):
+        raise ValueError(f"Invalid version type: {type(version)}")
+    v = version.strip()
+    # Remove leading 'v' if present
+    if v.lower().startswith("v"):
+        v = v[1:]
+    # Match format "<major>.<minor>.<patch>-rapids.<custom>"
+    match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)-rapids\.(\d+)", v, re.IGNORECASE)
+    if not match:
+        raise ValueError(
+            f"Failed to parse RAPIDS sccache version string (expected MAJOR.MINOR.PATCH-rapids.CUSTOM): {version}"
+        )
+    return tuple(map(int, match.groups()))
+
+
 def check_nvidia_ctk(min_version: str = "1.12.0", recommended_version: str = "1.14.1") -> None:
     """Check NVIDIA Container Toolkit version"""
 
@@ -1417,6 +1439,87 @@ def setup_ngc_cli(dry_run: bool = False) -> None:
 
     except Exception as e:
         fatal(f"Failed to install NGC CLI: {e}")
+
+
+def setup_sccache(min_version: str = "0.12.0-rapids.20", dry_run: bool = False) -> None:
+    """
+    Install RAPIDS sccache if missing or older than min_version; link into /usr/local/bin.
+
+    Requirements:
+        - Only RAPIDS-formatted versions are supported, e.g. "0.12.0-rapids.20".
+
+    Args:
+        min_version: Minimum required RAPIDS version string ("[v]MAJOR.MINOR.PATCH-rapids.CUSTOM").
+    """
+    # If sccache exists and meets min_version, nothing to do
+    if shutil.which("sccache"):
+        output = run_info_command(["sccache", "--version"]) or ""
+        # Extract RAPIDS-formatted version token from output like "sccache 0.12.0-rapids.20"
+        ver_token = None
+        m = re.search(r"(?:v)?\d+\.\d+\.\d+-rapids\.\d+", output, re.IGNORECASE)
+        if m:
+            ver_token = m.group(0)
+        if ver_token:
+            try:
+                installed_ver = parse_rapids_sccache_version(ver_token)
+                required_ver = parse_rapids_sccache_version(min_version)
+                if installed_ver >= required_ver:
+                    return
+            except ValueError:
+                # Fall through to install if parsing somehow fails
+                pass
+
+    # Build exact release tag from requested RAPIDS-formatted min_version
+    try:
+        major, minor, patch, custom = parse_rapids_sccache_version(min_version)
+    except ValueError:
+        fatal(
+            f"Invalid sccache RAPIDS version format: '{min_version}'. "
+            f"Expected '[v]MAJOR.MINOR.PATCH-rapids.CUSTOM' (e.g., '0.12.0-rapids.20')."
+        )
+    INSTALL_VERSION = f"v{major}.{minor}.{patch}-rapids.{custom}"
+    BASE_URL = "https://github.com/rapidsai/sccache/releases/download"
+    install_dir = "/opt/sccache"
+    symlink_path = "/usr/local/bin/sccache"
+
+    # Normalize arch to match release artifacts
+    machine = platform.machine().lower()
+    if machine in ["x86_64", "amd64"]:
+        arch = "x86_64"
+    elif machine in ["aarch64", "arm64"]:
+        arch = "aarch64"
+    else:
+        arch = machine  # best effort fallback
+
+    tarball_name = f"sccache-{INSTALL_VERSION}-{arch}-unknown-linux-musl.tar.gz"
+    url = f"{BASE_URL}/{INSTALL_VERSION}/{tarball_name}"
+    tar_path = os.path.join(install_dir, "sccache.tar.gz")
+
+    try:
+        # Prepare install directory
+        run_command(["mkdir", "-p", install_dir], dry_run=dry_run)
+        # Download release tarball (wget, like other setup methods)
+        run_command(
+            ["wget", "--quiet", "--content-disposition", url, "-O", tar_path], dry_run=dry_run
+        )
+        # Extract just the 'sccache' binary into install_dir
+        extracted_rel = f"sccache-{INSTALL_VERSION}-{arch}-unknown-linux-musl/sccache"
+        run_command(
+            ["tar", "-xzf", tar_path, "-C", install_dir, "--strip-components=1", extracted_rel],
+            dry_run=dry_run,
+        )
+        run_command(["chmod", "u+x", os.path.join(install_dir, "sccache")], dry_run=dry_run)
+        # Link into /usr/local/bin (sudo added automatically if required)
+        abs_bin = os.path.abspath(os.path.join(install_dir, "sccache"))
+        run_command(["ln", "-sf", abs_bin, symlink_path], dry_run=dry_run)
+    except Exception as e:
+        fatal(f"Failed to install sccache: {e}")
+    finally:
+        # Remove downloaded tarball
+        try:
+            run_command(["rm", "-f", tar_path], dry_run=dry_run)
+        except Exception:
+            pass
 
 
 def get_cuda_runtime_version() -> Optional[str]:


### PR DESCRIPTION
## Context

We want sccache to:
- better reuse cmake build output across clones, nodes
- better reuse cmake build output across holohub projects with common deps

## Changes

Changes are limited to the CLI:
- [x] extend `setup` to install sccache from rapids, used in default dockerfile
- [x] extend `container.py` to mount `SCCACHE_DIR` and forward `SCCACHE_` env vars
- [x] extend `holohub.py` to find sccache, set it as the launcher for C, CXX, CUDA builds, and set some default for env vars

No changes to CMakeLists.txt means projects don't need to add special logic to make it work for them.

## Results

#### `HOLOHUB_ENABLE_SCCACHE=0` (default)

```
./holohub build endoscopy_out_of_body_detection --language cpp
...
2025-11-18 18:07:54 $ docker run --net host --interactive --tty -u 1000:1000 -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro -v /home/agirault/projects/holohub:/workspace/holohub -w /workspace/holohub --runtime nvidia --gpus all --cap-add CAP_SYS_PTRACE --ipc=host -v /dev:/dev --device-cgroup-rule "c 81:* rmw" --device-cgroup-rule "c 189:* rmw" -e NVIDIA_DRIVER_CAPABILITIES=graphics,video,compute,utility,display -e HOME=/workspace/holohub -e CUPY_CACHE_DIR=/workspace/holohub/.cupy/kernel_cache -e HOLOHUB_BUILD_LOCAL=1 --rm --ipc=host --cap-add=CAP_SYS_PTRACE --ulimit=memlock=-1 --ulimit=stack=67108864 --device /dev/snd/controlC0 --device /dev/snd/controlC1 --device /dev/snd/pcmC0D0c --device /dev/snd/pcmC0D0p --device /dev/snd/pcmC1D9p --device /dev/snd/pcmC1D8p --device /dev/snd/pcmC1D7p --device /dev/snd/pcmC1D3p --device /dev/snd/timer --device /dev/snd/seq --device /dev/infiniband/uverbs1 --device /dev/infiniband/uverbs0 --device /dev/nvidia0 --device /dev/nvidia-modeset -v /usr/share/nvidia/nvoptix.bin:/usr/share/nvidia/nvoptix.bin:ro --group-add 44 --group-add 992 --group-add 984 --group-add 29 -e XDG_SESSION_TYPE -e XDG_RUNTIME_DIR -v /run/user/1000:/run/user/1000 -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY -e PYTHONPATH=/opt/nvidia/holoscan/python/lib:/workspace/holohub/benchmarks/holoscan_flow_benchmarking --entrypoint=/bin/bash holohub:ngc-v3.8.0-cuda13 -c "./holohub build endoscopy_out_of_body_detection --local --pkg-generator DEB --language cpp"
INFO: HOLOHUB_ENABLE_SCCACHE=false
WARNING: Detected 'sccache' in PATH but HOLOHUB_ENABLE_SCCACHE is disabled. Skipping sccache.
2025-11-18 18:07:54 $ cmake -B /workspace/holohub/build/endoscopy_out_of_body_detection -S /workspace/holohub --no-warn-unused-cli -DPython3_EXECUTABLE=/usr/bin/python3 -DPython3_ROOT_DIR=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/opt/nvidia/holoscan/lib -DHOLOHUB_DATA_DIR:PATH=/workspace/holohub/data -DAPP_endoscopy_out_of_body_detection=ON -G Ninja -DHOLOHUB_BUILD_PYTHON=OFF -DHOLOHUB_BUILD_CPP=ON
Not searching for unused variables given on the command line.
-- Found UCX: /opt/nvidia/holoscan/lib/cmake/ucx (found version "1.19.0")
-- Finding CCCL components: Thrust;CUB;libcudacxx
-- cccl_cmake_dir: /opt/nvidia/CCCL/lib/cmake/cccl
-- Configuring done (0.2s)
-- Generating done (0.0s)
-- Build files have been written to: /workspace/holohub/build/endoscopy_out_of_body_detection
2025-11-18 18:07:55 $ cmake --build /workspace/holohub/build/endoscopy_out_of_body_detection --config Release -j 36
```

#### `HOLOHUB_ENABLE_SCCACHE=0` + `SCCACHE_*` vars

show warnings

```
./holohub build endoscopy_out_of_body_detection --language cpp
...
WARNING: SCCACHE_* environment variables detected but HOLOHUB_ENABLE_SCCACHE is disabled; not mounting sccache cache into the container.
WARNING: SCCACHE_* environment variables detected but HOLOHUB_ENABLE_SCCACHE is disabled; not forwarding sccache environment variables into the container: SCCACHE_MEMCACHED_ENDPOINT
2025-11-18 18:06:51 $ docker inspect --format "{{range .Config.Env}}{{println .}}{{end}}" holohub:ngc-v3.8.0-cuda13
2025-11-18 18:06:51 $ docker run --net host --interactive --tty -u 1000:1000 -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro -v /home/agirault/projects/holohub:/workspace/holohub -w /workspace/holohub --runtime nvidia --gpus all --cap-add CAP_SYS_PTRACE --ipc=host -v /dev:/dev --device-cgroup-rule "c 81:* rmw" --device-cgroup-rule "c 189:* rmw" -e NVIDIA_DRIVER_CAPABILITIES=graphics,video,compute,utility,display -e HOME=/workspace/holohub -e CUPY_CACHE_DIR=/workspace/holohub/.cupy/kernel_cache -e HOLOHUB_BUILD_LOCAL=1 --rm --ipc=host --cap-add=CAP_SYS_PTRACE --ulimit=memlock=-1 --ulimit=stack=67108864 --device /dev/snd/controlC0 --device /dev/snd/controlC1 --device /dev/snd/pcmC0D0c --device /dev/snd/pcmC0D0p --device /dev/snd/pcmC1D9p --device /dev/snd/pcmC1D8p --device /dev/snd/pcmC1D7p --device /dev/snd/pcmC1D3p --device /dev/snd/timer --device /dev/snd/seq --device /dev/infiniband/uverbs1 --device /dev/infiniband/uverbs0 --device /dev/nvidia0 --device /dev/nvidia-modeset -v /usr/share/nvidia/nvoptix.bin:/usr/share/nvidia/nvoptix.bin:ro --group-add 44 --group-add 992 --group-add 984 --group-add 29 -e XDG_SESSION_TYPE -e XDG_RUNTIME_DIR -v /run/user/1000:/run/user/1000 -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY -e PYTHONPATH=/opt/nvidia/holoscan/python/lib:/workspace/holohub/benchmarks/holoscan_flow_benchmarking --entrypoint=/bin/bash holohub:ngc-v3.8.0-cuda13 -c "./holohub build endoscopy_out_of_body_detection --local --pkg-generator DEB --language cpp"
INFO: HOLOHUB_ENABLE_SCCACHE=false
WARNING: Detected 'sccache' in PATH but HOLOHUB_ENABLE_SCCACHE is disabled. Skipping sccache.
2025-11-18 18:06:52 $ cmake -B /workspace/holohub/build/endoscopy_out_of_body_detection -S /workspace/holohub --no-warn-unused-cli -DPython3_EXECUTABLE=/usr/bin/python3 -DPython3_ROOT_DIR=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/opt/nvidia/holoscan/lib -DHOLOHUB_DATA_DIR:PATH=/workspace/holohub/data -DAPP_endoscopy_out_of_body_detection=ON -G Ninja -DHOLOHUB_BUILD_PYTHON=OFF -DHOLOHUB_BUILD_CPP=ON
Not searching for unused variables given on the command line.
-- Found UCX: /opt/nvidia/holoscan/lib/cmake/ucx (found version "1.19.0")
-- Finding CCCL components: Thrust;CUB;libcudacxx
-- cccl_cmake_dir: /opt/nvidia/CCCL/lib/cmake/cccl
-- Configuring done (0.2s)
-- Generating done (0.0s)
-- Build files have been written to: /workspace/holohub/build/endoscopy_out_of_body_detection
2025-11-18 18:06:52 $ cmake --build /workspace/holohub/build/endoscopy_out_of_body_detection --config Release -j 36
[1/1] cd /workspace/holohub/build/endoscopy_out_of_body_detection/applications/endoscopy_out_of_body_detection/cpp && ...tection.yaml /workspace/holohub/build/endoscopy_out_of_body_detection/applications/endoscopy_out_of_body_detection/cpp
```

#### `HOLOHUB_ENABLE_SCCACHE=1`

```
INFO: Host SCCACHE_DIR: /home/agirault/.cache/sccache
INFO: Container mount point: /.cache/sccache
2025-11-18 18:09:12 $ docker inspect --format "{{range .Config.Env}}{{println .}}{{end}}" holohub:ngc-v3.8.0-cuda13
2025-11-18 18:09:12 $ docker run --net host --interactive --tty -u 1000:1000 -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro -v /home/agirault/projects/holohub:/workspace/holohub -w /workspace/holohub -v /home/agirault/.cache/sccache:/.cache/sccache --runtime nvidia --gpus all --cap-add CAP_SYS_PTRACE --ipc=host -v /dev:/dev --device-cgroup-rule "c 81:* rmw" --device-cgroup-rule "c 189:* rmw" -e NVIDIA_DRIVER_CAPABILITIES=graphics,video,compute,utility,display -e HOME=/workspace/holohub -e CUPY_CACHE_DIR=/workspace/holohub/.cupy/kernel_cache -e HOLOHUB_BUILD_LOCAL=1 -e HOLOHUB_ENABLE_SCCACHE -e SCCACHE_DIR=/.cache/sccache --rm --ipc=host --cap-add=CAP_SYS_PTRACE --ulimit=memlock=-1 --ulimit=stack=67108864 --device /dev/snd/controlC0 --device /dev/snd/controlC1 --device /dev/snd/pcmC0D0c --device /dev/snd/pcmC0D0p --device /dev/snd/pcmC1D9p --device /dev/snd/pcmC1D8p --device /dev/snd/pcmC1D7p --device /dev/snd/pcmC1D3p --device /dev/snd/timer --device /dev/snd/seq --device /dev/infiniband/uverbs1 --device /dev/infiniband/uverbs0 --device /dev/nvidia0 --device /dev/nvidia-modeset -v /usr/share/nvidia/nvoptix.bin:/usr/share/nvidia/nvoptix.bin:ro --group-add 44 --group-add 992 --group-add 984 --group-add 29 -e XDG_SESSION_TYPE -e XDG_RUNTIME_DIR -v /run/user/1000:/run/user/1000 -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY -e PYTHONPATH=/opt/nvidia/holoscan/python/lib:/workspace/holohub/benchmarks/holoscan_flow_benchmarking --entrypoint=/bin/bash holohub:ngc-v3.8.0-cuda13 -c "./holohub build endoscopy_out_of_body_detection --local --pkg-generator DEB --language cpp"
INFO: HOLOHUB_ENABLE_SCCACHE=1
INFO: Using sccache: /usr/local/bin/sccache
INFO: SCCACHE_DIR=/.cache/sccache
INFO: SCCACHE_CACHE_SIZE=20G
2025-11-18 18:09:12 $ cmake -B /workspace/holohub/build/endoscopy_out_of_body_detection -S /workspace/holohub --no-warn-unused-cli -DPython3_EXECUTABLE=/usr/bin/python3 -DPython3_ROOT_DIR=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/opt/nvidia/holoscan/lib -DHOLOHUB_DATA_DIR:PATH=/workspace/holohub/data -DAPP_endoscopy_out_of_body_detection=ON -G Ninja -DHOLOHUB_BUILD_PYTHON=OFF -DHOLOHUB_BUILD_CPP=ON -DCMAKE_C_COMPILER_LAUNCHER=/usr/local/bin/sccache -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/local/bin/sccache -DCMAKE_CUDA_COMPILER_LAUNCHER=/usr/local/bin/sccache
Not searching for unused variables given on the command line.
-- Found UCX: /opt/nvidia/holoscan/lib/cmake/ucx (found version "1.19.0")
-- Finding CCCL components: Thrust;CUB;libcudacxx
-- cccl_cmake_dir: /opt/nvidia/CCCL/lib/cmake/cccl
-- Configuring done (0.2s)
-- Generating done (0.0s)
-- Build files have been written to: /workspace/holohub/build/endoscopy_out_of_body_detection
2025-11-18 18:09:12 $ cmake --build /workspace/holohub/build/endoscopy_out_of_body_detection --config Release -j 36
[3/3] Linking CXX executable applications/endoscopy_out_of_body_detection/cpp/endoscopy_out_of_body_detection
2025-11-18 18:09:13 $ sccache --show-stats
Queued compilations                    0
Pending compilations                   0
Pending cache lookups                  0
Active compilations                    0
Compile requests                       1
Compile requests executed              1
Compile request errors                 0
Cache hits                             1
Cache hits (C/C++)                     1
Preprocessor cache hits                1
Preprocessor cache hits (C/C++)        1
Cache misses                           0
Preprocessor cache misses              0
Cache hits rate                   100.00 %
Cache hits rate (C/C++)           100.00 %
Cache timeouts                         0
Cache read errors                      0
Forced recaches                        0
Cache write errors                     0
Compilations                           0
Compilation failures                   0
Non-cacheable compilations             0
Non-cacheable calls                    0
Non-compilation calls                  0
Unsupported compiler calls             0
Average cache write                0.000 s
Average compiler                   0.000 s
Average cache read hit             0.000 s
Fatal errors                           0
Successful distributed compiles        0
Failed distributed compilations        0
Cache location                  Local disk: "/.cache/sccache/"
Use direct/preprocessor mode?   yes
Version (client)                0.12.0-rapids.9
Cache size                           428 KiB
Max cache size                        20 GiB
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional sccache compiler caching via HOLOHUB_ENABLE_SCCACHE for local and container builds; forwards SCCACHE_* into containers, surfaces usage during builds, and emits post-build stats.
  * Automatic sccache install/setup when enabled, with version checks, architecture-aware install, and a dry-run mode.

* **Bug Fixes / Warnings**
  * Warns if SCCACHE_* vars exist but caching is disabled; fatal error if enabled but sccache is missing.

* **Documentation**
  * README updated to document HOLOHUB_ENABLE_SCCACHE and SCCACHE_* usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->