### PR TITLE
CLI enable cache-from by default

### DIFF
--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -93,7 +93,9 @@ class HoloHubContainer:
     DEFAULT_DOCKER_BUILD_ARGS = os.environ.get("HOLOHUB_DEFAULT_DOCKER_BUILD_ARGS", "")
     # Additional Default run arguments for docker run command
     DEFAULT_DOCKER_RUN_ARGS = os.environ.get("HOLOHUB_DEFAULT_DOCKER_RUN_ARGS", "")
-    REPO_NAME_FORMAT = os.environ.get("HOLOHUB_REPO_NAME_FORMAT", "{container_prefix}-{project_name}")
+    REPO_NAME_FORMAT = os.environ.get(
+        "HOLOHUB_REPO_NAME_FORMAT", "{container_prefix}-{project_name}"
+    )
 
     @classmethod
     def default_base_image(cls, cuda_version: Optional[Union[str, int]] = None) -> str:
@@ -337,7 +339,9 @@ class HoloHubContainer:
     def image_names(self) -> List[str]:
         """Return list of image tags to apply: sha-tag, branch-tag, and legacy tag."""
         project = self.project_metadata.get("project_name", "") if self.project_metadata else ""
-        repo = self.REPO_NAME_FORMAT.format(container_prefix=self.CONTAINER_PREFIX, project_name=project)
+        repo = self.REPO_NAME_FORMAT.format(
+            container_prefix=self.CONTAINER_PREFIX, project_name=project
+        )
         sha_tag = f"{repo}:{get_git_short_sha()}"
         branch_tag = f"{repo}:{get_current_branch_slug()}"
         legacy_tag = self.image_name


### PR DESCRIPTION
this enhance the docker build with `--cache-from` aligning with the `-t ` options
e.g. the new `--cache-from` in:
```
    --cache-from holohub:0739c6558ef0 \
    --cache-from holohub:add-cache-from \
    --cache-from holohub:ngc-v3.8.0-cuda13 \
    -f /home/Documents/holohub/Dockerfile \
    -t holohub:0739c6558ef0 \
    -t holohub:add-cache-from \
    -t holohub:ngc-v3.8.0-cuda13 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for customizable image repository naming via an environment setting, allowing per-project repository name formats.

* **Bug Fixes**
  * Build process now uses cached layers from all image tags when caching is enabled, improving build speed and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->