### PR TITLE
CLI: add sccache permission fix

### DIFF
--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -1043,7 +1043,7 @@ class HoloHubCLI:
             # Set default SCCACHE properties if not set
             build_env.setdefault("SCCACHE_DIR", holohub_cli_util.get_sccache_dir(build_env))
             build_env.setdefault("SCCACHE_CACHE_SIZE", "20G")
-            # Print SCCACHE environment variables
+            holohub_cli_util.ensure_docker_dir_permissions(build_env["SCCACHE_DIR"])
             holohub_cli_util.info(f"Using sccache: {sccache_bin}")
             for key, value in build_env.items():
                 if key.startswith("SCCACHE_"):


### PR DESCRIPTION
to address caching issue
```
[19/184] Building CXX object common/foxglove/CMakeFiles/foxglove_sdk.dir/opt/foxglove-sdk/src/server/fetch_asset.cpp.o
FAILED: common/foxglove/CMakeFiles/foxglove_sdk.dir/opt/foxglove-sdk/src/server/fetch_asset.cpp.o 
/usr/local/bin/sccache /usr/bin/c++ -Dfoxglove_sdk_EXPORTS -isystem /opt/foxglove-sdk/include -O3 -DNDEBUG -std=c++17 -fPIC -MD -MT common/foxglove/CMakeFiles/foxglove_sdk.dir/opt/foxglove-sdk/src/server/fetch_asset.cpp.o -MF common/foxglove/CMakeFiles/foxglove_sdk.dir/opt/foxglove-sdk/src/server/fetch_asset.cpp.o.d -o common/foxglove/CMakeFiles/foxglove_sdk.dir/opt/foxglove-sdk/src/server/fetch_asset.cpp.o -c /opt/foxglove-sdk/src/server/fetch_asset.cpp
sccache: encountered fatal error
sccache: error: Operation not permitted (os error 1)
sccache: caused by: Operation not permitted (os error 1)
```