### PR TITLE
Update README to clarify cache reset instructions and dry run behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ You can run the command below to reset cache directories:
   ./holohub clear-cache
   ```
 
-This removes all the `build` and `data` directories. You can use `--dryrun` to preview what would be removed.
+This removes the `build`, `data`, and `install` directories. You can use `--dryrun` to preview what would be removed.
 
 In some cases you may want to clear out only the datasets downloaded by applications to the `data` folder:
 


### PR DESCRIPTION
The readme said that `./holohub clear-cache` only removed the build directory, but it also removed the data. Now it specifies which directories it removes, along with the `--dryrun` flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated cleanup instructions to target cache directories for resets
  * Broadened removal guidance to include build, data, and install directories
  * Added a --dryrun option to preview removals before execution
  * Clarified guidance about clearing only datasets in the data folder

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->