### PR TITLE
CLI: Fix executable reference for cpplint

### DIFF
--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -1700,7 +1700,7 @@ class HoloHubCLI:
             if (
                 holohub_cli_util.run_command(
                     [
-                        "python",
+                        sys.executable,
                         "-m",
                         "cpplint",
                         "--quiet",


### PR DESCRIPTION
To address failure in container:
```
FileNotFoundError: [Errno 2] No such file or directory: 'python'
```

Verified successful `./holohub lint` run in container with this fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed C++ linting to use the correct Python interpreter from the current environment, ensuring proper compatibility across different Python installations and virtual environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->