### PR TITLE
fixes cvcuda dockerfile

### DIFF
--- a/applications/cvcuda_basic/Dockerfile
+++ b/applications/cvcuda_basic/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
https://github.com/CVCUDA/CV-CUDA/releases location changed to v0.15.0
```
[2025-12-08T11:30:42.410Z] #12 12.13 dpkg-deb: error: unexpected end of file in archive magic version number in cvcuda-lib-0.15.0-cuda12-aarch64-linux.deb
[2025-12-08T11:30:42.410Z] #12 12.13 dpkg: error processing archive cvcuda-lib-0.15.0-cuda12-aarch64-linux.deb (--install):
[2025-12-08T11:30:42.410Z] #12 12.13  dpkg-deb --control subprocess returned error exit status 2
[2025-12-08T11:30:42.410Z] #12 12.14 Errors were encountered while processing:
[2025-12-08T11:30:42.410Z] #12 12.14  cvcuda-lib-0.15.0-cuda12-aarch64-linux.deb
[2025-12-08T11:30:42.410Z] ------
[2025-12-08T11:30:42.410Z] Dockerfile:36
[2025-12-08T11:30:42.410Z] --------------------
[2025-12-08T11:30:42.410Z]   35 |     # Detect architecture and install appropriate CV-CUDA wheel
[2025-12-08T11:30:42.410Z]   36 | >>> RUN ARCH=$(uname -m) && \
[2025-12-08T11:30:42.410Z]   37 | >>>     if [ "$ARCH" = "x86_64" ]; then \
[2025-12-08T11:30:42.410Z]   38 | >>>         # install Python package for x86_64
[2025-12-08T11:30:42.410Z]   39 | >>>         pip install cvcuda-cu12==0.15.0 && \
[2025-12-08T11:30:42.410Z]   40 | >>>         # Download and install C++ library for x86_64
[2025-12-08T11:30:42.410Z]   41 | >>>         curl -LO https://github.com/CVCUDA/CV-CUDA/releases/download/v0.15.0-beta/cvcuda-lib-0.15.0-cuda12-x86_64-linux.deb && curl -LO https://github.com/CVCUDA/CV-CUDA/releases/download/v0.15.0-beta/cvcuda-dev-0.15.0-cuda12-x86_64-linux.deb && \
[2025-12-08T11:30:42.410Z]   42 | >>>         dpkg -i cvcuda-lib-0.15.0-cuda12-x86_64-linux.deb && \
[2025-12-08T11:30:42.410Z]   43 | >>>         dpkg -i cvcuda-dev-0.15.0-cuda12-x86_64-linux.deb && \
[2025-12-08T11:30:42.410Z]   44 | >>>         rm cvcuda-lib-0.15.0-cuda12-x86_64-linux.deb && \
[2025-12-08T11:30:42.410Z]   45 | >>>         rm cvcuda-dev-0.15.0-cuda12-x86_64-linux.deb; \
[2025-12-08T11:30:42.410Z]   46 | >>>     else \
[2025-12-08T11:30:42.410Z]   47 | >>>         # install Python package for aarch64
[2025-12-08T11:30:42.410Z]   48 | >>>         pip install cvcuda-cu12==0.15.0 && \
[2025-12-08T11:30:42.410Z]   49 | >>>         # Download and install C++ library for aarch64
[2025-12-08T11:30:42.410Z]   50 | >>>         curl -LO https://github.com/CVCUDA/CV-CUDA/releases/download/v0.15.0-beta/cvcuda-lib-0.15.0-cuda12-aarch64-linux.deb && \
[2025-12-08T11:30:42.410Z]   51 | >>>         curl -LO https://github.com/CVCUDA/CV-CUDA/releases/download/v0.15.0-beta/cvcuda-dev-0.15.0-cuda12-aarch64-linux.deb && \
[2025-12-08T11:30:42.411Z]   52 | >>>         dpkg -i cvcuda-lib-0.15.0-cuda12-aarch64-linux.deb && \
[2025-12-08T11:30:42.411Z]   53 | >>>         dpkg -i cvcuda-dev-0.15.0-cuda12-aarch64-linux.deb && \
[2025-12-08T11:30:42.411Z]   54 | >>>         rm cvcuda-lib-0.15.0-cuda12-aarch64-linux.deb && \
[2025-12-08T11:30:42.411Z]   55 | >>>         rm cvcuda-dev-0.15.0-cuda12-aarch64-linux.deb; \
[2025-12-08T11:30:42.411Z]   56 | >>>     fi
[2025-12-08T11:30:42.411Z]   57 |     
[2025-12-08T11:30:42.411Z] --------------------
[2025-12-08T11:30:42.411Z] error: failed to solve: process "/bin/sh -c ARCH=$(uname -m) &&     if [ \"$ARCH\" = \"x86_64\" ]; then         pip install cvcuda-cu12==0.15.0 &&         curl -LO https://github.com/CVCUDA/CV-CUDA/releases/download/v0.15.0-beta/cvcuda-lib-0.15.0-cuda12-x86_64-linux.deb && curl -LO https://github.com/CVCUDA/CV-CUDA/releases/download/v0.15.0-beta/cvcuda-dev-0.15.0-cuda12-x86_64-linux.deb &&         dpkg -i cvcuda-lib-0.15.0-cuda12-x86_64-linux.deb &&         dpkg -i cvcuda-dev-0.15.0-cuda12-x86_64-linux.deb &&         rm cvcuda-lib-0.15.0-cuda12-x86_64-linux.deb &&         rm cvcuda-dev-0.15.0-cuda12-x86_64-linux.deb;     else         pip install cvcuda-cu12==0.15.0 &&         curl -LO https://github.com/CVCUDA/CV-CUDA/releases/download/v0.15.0-beta/cvcuda-lib-0.15.0-cuda12-aarch64-linux.deb &&         curl -LO https://github.com/CVCUDA/CV-CUDA/releases/download/v0.15.0-beta/cvcuda-dev-0.15.0-cuda12-aarch64-linux.deb &&         dpkg -i cvcuda-lib-0.15.0-cuda12-aarch64-linux.deb &&         dpkg -i cvcuda-dev-0.15.0-cuda12-aarch64-linux.deb &&         rm cvcuda-lib-0.15.0-cuda12-aarch64-linux.deb &&         rm cvcuda-dev-0.15.0-cuda12-aarch64-linux.deb;     fi" did not complete successfully: exit code: 1
[2025-12-08T11:30:42.411Z] Non-zero exit code running command: docker build --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=gitlab-master.nvidia.com:5005/holoscan/holoscan-sdk/dev-cu12-aarch64-igpu:main --build-arg GPU_TYPE=igpu --build-arg BASE_SDK_VERSION=3.9.0 --build-arg COMPUTE_CAPACITY=8.7 --build-arg CUDA_MAJOR=12 --network=host --pull --cache-from gitlab-master.nvidia.com:5005/holoscan/holoscan-sdk/holohub-dev-cache:dev-cu12-aarch64-igpu-main --progress=plain -f /home/ubuntu/jenkins/workspace/holohub-app-device-nightly/holohub/applications/cvcuda_basic/Dockerfile -t holohub-cvcuda_basic:main -t holohub-cvcuda_basic:main-base /home/ubuntu/jenkins/workspace/holohub-app-device-nightly/holohub
[2025-12-08T11:30:42.412Z] Exit code: 1
[2025-12-08T11:30:42.571Z] ❌ Test cvcuda_basic failed with exit code 1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CV-CUDA dependencies to stable v0.15.0 release for both x86_64 and aarch64 architectures.
  * Updated copyright year to 2022-2025.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->