### PR TITLE
Upgrade `cpplint` to Avoid Deprecation Warning

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,3 +1,3 @@
-filter=-build/header_guard,-readability/todo,-runtime/references,-build/c++11,-build/c++17,-runtime/int,-build/include_subdir,-build/namespaces,-readability/casting,-build/include,-runtime/threadsafe_fn,-whitespace/newline
+filter=-build/header_guard,-readability/todo,-runtime/references,-build/c++11,-build/c++17,-runtime/int,-build/include_subdir,-build/namespaces,-readability/casting,-build/include,-runtime/threadsafe_fn,-whitespace/newline,-whitespace/indent_namespace,-readability/nolint
 exclude_files=\.cache|build|build-|install|data
 linelength=100

--- a/applications/pipeline_visualization/cpp/pipeline_visualization.cpp
+++ b/applications/pipeline_visualization/cpp/pipeline_visualization.cpp
@@ -300,7 +300,7 @@ class TimeSeriesApp : public holoscan::Application {
  */
 int main(int argc, char** argv) {
   // Define command-line options
-  // NOLINTBEGIN
+  // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
   struct option long_options[] = {{"help", no_argument, nullptr, 'h'},
                                   {"disable_logger", no_argument, nullptr, 'd'},
                                   {"config", required_argument, nullptr, 'c'},
@@ -308,7 +308,7 @@ int main(int argc, char** argv) {
                                   {"subject_prefix", required_argument, nullptr, 'p'},
                                   {"publish_rate", required_argument, nullptr, 'r'},
                                   {nullptr, 0, nullptr, 0}};
-  // NOLINTEND
+  // NOLINTEND(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 
   // Set default values for configuration parameters
   bool disable_logger = false;
@@ -320,10 +320,10 @@ int main(int argc, char** argv) {
   // Parse command-line arguments
   while (true) {
     int option_index = 0;
-    // NOLINTBEGIN
+    // NOLINTBEGIN(concurrency-mt-unsafe)
     const int c =
         getopt_long(argc, argv, "hdc:u:p:r:", static_cast<option*>(long_options), &option_index);
-    // NOLINTEND
+    // NOLINTEND(concurrency-mt-unsafe)
 
     // Break when no more options to parse
     if (c == -1) {


### PR DESCRIPTION
Current deprecation warning:
```console
/workspace/venvqa/lib/python3.12/site-packages/cpplint.py:57: DeprecationWarning: module 'sre_compile' is deprecated
  import sre_compile
```
and here are the list of newly flagged by this upgrade which are filtered:

| Warning Type | Description | Count |
|--------------|-------------|-------|
| `whitespace/newline` | Controlled statements inside brackets of if/for/while clause should be on a separate line | ~470 |
| `build/c++17` | `<filesystem>` is an unapproved C++17 header | 20 |
| `whitespace/indent_namespace` | Do not indent within a namespace | 46 |
| `readability/nolint` | Not in a NOLINT block | 2 |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code linting configuration to refine quality checks.
  * Upgraded linting tool to the latest version for improved code analysis capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->