### PR TITLE
Depth Anything v2: fix build error

### DIFF
--- a/applications/depth_anything_v2/Dockerfile
+++ b/applications/depth_anything_v2/Dockerfile
@@ -45,7 +45,7 @@ RUN git clone --depth 1 https://github.com/DepthAnything/Depth-Anything-V2.git \
     && mv depth-anything-tensorrt/depth_anything_v2/dpt.py Depth-Anything-V2/depth_anything_v2 \
     && mv depth-anything-tensorrt/depth_anything_v2/export_v2.py Depth-Anything-V2
 
-RUN pip install onnx==1.19.1 onnx-graphsurgeon onnxscript \
+RUN pip install onnx==1.19.1 onnx-graphsurgeon==0.5.8 onnxscript==0.5.6 \
     && pip install -r Depth-Anything-V2/requirements.txt
 
 # Change to the repository directory


### PR DESCRIPTION
Depth Anything V2 does not work.

onnx.helper.float32_to_bfloat16 is deprecated.
<https://github.com/onnx/onnx/commit/c9d9c556425ba67ba2f64e10456f90a805f08773>

```
$ ./holohub run depth_anything_v2 --ssh-x11 --run-args="--source replayer"

...
6.119 Saving to: 'graph_surgeon.py'
6.119
6.119      0K .                                                     100% 65.3M=0s
6.119
6.119 2025-12-15 06:35:52 (65.3 MB/s) - 'graph_surgeon.py' saved [1452/1452]
6.119
6.255 Traceback (most recent call last):
6.255   File "/app/Depth-Anything-V2/./graph_surgeon.py", line 22, in <module>
6.255     import onnx_graphsurgeon as gs
6.255   File "/usr/local/lib/python3.12/dist-packages/onnx_graphsurgeon/__init__.py", line 1, in <module>
6.255     from onnx_graphsurgeon.exporters.onnx_exporter import export_onnx
6.255   File "/usr/local/lib/python3.12/dist-packages/onnx_graphsurgeon/exporters/onnx_exporter.py", line 134, in <module>
6.255     np.uint16, onnx.helper.float32_to_bfloat16
6.255                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
6.255 AttributeError: module 'onnx.helper' has no attribute 'float32_to_bfloat16'
```

work around here <https://github.com/NVIDIA/TensorRT/issues/4635>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions to ensure build stability and compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->