### PR TITLE
Remove noexcept from a constructor that can throw an exception

### DIFF
--- a/operators/xr/xr_swapchain_cuda.cpp
+++ b/operators/xr/xr_swapchain_cuda.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,7 +35,7 @@ vk::ImageLayout original_image_layout(XrSwapchainCuda::Format format);
 XrSwapchainUsageFlags swapchain_usage_flags(XrSwapchainCuda::Format format);
 
 XrSwapchainCuda::XrSwapchainCuda(XrSession& session, Format format, uint32_t width,
-                                 uint32_t height) noexcept
+                                 uint32_t height)
     : session_(session),
       format_(format),
       width_(width),

--- a/operators/xr/xr_swapchain_cuda.hpp
+++ b/operators/xr/xr_swapchain_cuda.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,7 +47,7 @@ class XrSwapchainCuda {
     D32_SFLOAT,
   };
 
-  XrSwapchainCuda(XrSession& session, Format format, uint32_t width, uint32_t height) noexcept;
+  XrSwapchainCuda(XrSession& session, Format format, uint32_t width, uint32_t height);
   ~XrSwapchainCuda();
 
   // Acquires a CUDA swapchain image to write into.


### PR DESCRIPTION
It throws at  https://github.com/nvidia-holoscan/holohub/blob/main/operators/xr/xr_swapchain_cuda.cpp#L126 and in 4 other places.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Initialization of the XR swapchain is no longer guaranteed to be non-throwing; failures may now propagate as exceptions. This can change how initialization errors are surfaced and may affect error-handling behavior at startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->