### PR TITLE
Mark an unused variable as [[maybe_unused]]

### DIFF
--- a/operators/xr/xr_session.cpp
+++ b/operators/xr/xr_session.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The variable is not used, but the call itself if important, it has an effect despite being called "get".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project copyright year.
  * Reduced compiler warnings by marking an internal variable as intentionally unused, improving build cleanliness without changing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->