### PR TITLE
Exclude Patterns for `cmakelint`

### DIFF
--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -37,6 +37,7 @@ import shutil
 import subprocess
 import tempfile
 from collections import defaultdict
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import List, Optional
 
@@ -1734,7 +1735,6 @@ class HoloHubCLI:
             cmake_files = list(Path(args.path).rglob("CMakeLists.txt"))
             cmake_files.extend(Path(args.path).rglob("*.cmake"))
             excluded_paths = ["build", "install", "data", "build-*", "install-*", "data-*", "tmp"]
-            from fnmatch import fnmatch
 
             cmake_files = [
                 f


### PR DESCRIPTION
This enables exclusion of directories with patterns for `cmakelint`, so the following directories can be excluded `build-*`, `install-*`, and `data-*`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CMake linting by implementing pattern-based directory exclusions for build, install, and data directories, enabling more efficient and targeted lint scanning.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->