### PR TITLE
App: Fix object_detection_torch container build with Python != 3.12

### DIFF
--- a/applications/object_detection_torch/Dockerfile
+++ b/applications/object_detection_torch/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Updates the object_detection_torch application build check for "libtorch_cuda.so" installation to use the default Python3 site path for torch import check.

Previous check enforced Python 3.12, which failed when building with iGPU container with Python 3.10. See supported platforms: https://github.com/nvidia-holoscan/holohub/tree/main/applications/object_detection_torch#known-issues

+ @shekhardw  for viz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year to 2026.

* **Bug Fixes**
  * Improved robustness of installation verification by implementing dynamic library discovery, replacing hard-coded paths for enhanced cross-environment compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->