### PR TITLE
Doc: Update links to address 404 errors reported by lychee

### DIFF
--- a/applications/vila_live/README.md
+++ b/applications/vila_live/README.md
@@ -83,6 +83,6 @@ This application downloads a pre-recorded video from [Pexels](https://www.pexels
     ffmpeg -stream_loop -1 -re -i <your_video_path> -pix_fmt yuyv422 -f v4l2 /dev/video3
     ```
 ## 🙌 Acknowledgements
-- Jetson AI Lab, [Live LLaVA](https://www.jetson-ai-lab.com/tutorial_live-llava.html): for the inspiration to create this app
+- Jetson AI Lab, [Live LLaVA](https://www.jetson-ai-lab.com/archive/tutorial_live-llava.html): for the inspiration to create this app
 - [Jetson-Containers](https://github.com/dusty-nv/jetson-containers/tree/master/packages/llm/llamaspeak) repo: For the Flask web-app with WebSockets
 - [LLM-AWQ](https://github.com/mit-han-lab/llm-awq) repo: For the example code to create AWQ-powered LLM servers

--- a/tutorials/integrate_external_libs_into_pipeline/README.md
+++ b/tutorials/integrate_external_libs_into_pipeline/README.md
@@ -70,7 +70,7 @@ The following Python libraries have adopted the [CUDA Array Interface](https://n
   - [cuDF](https://docs.rapids.ai/api/cudf/stable/user_guide/10min/)
   - [cuML](https://docs.rapids.ai/api/cuml/nightly/)
   - [cuSignal](https://github.com/rapidsai/cusignal)
-  - [RMM](https://docs.rapids.ai/api/rmm/stable/guide/)
+  - [RMM](https://docs.rapids.ai/api/rmm/stable/)
 
 For more details on using the CUDA Array Interface and DLPack with various libraries, see [CuPy's Interoperability guide](https://docs.cupy.dev/en/stable/user_guide/interoperability.html#).
 


### PR DESCRIPTION
Jetson AI Lab documentation was redesigned and the 'Live LLaVA' tutorial content is now archived.

RMM documentation was reorganized in rapidsai/rmm@a32ca26a ("Use PyData docs theme, reorganize C++ docs (#2137)", 2025-11-12)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external reference links in documentation to point to current versions of library documentation and related archive pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->