### PR TITLE
App: Add find_package(holoscan) to CMakeLists.txt of Python-only apps

### DIFF
--- a/applications/colonoscopy_segmentation/CMakeLists.txt
+++ b/applications/colonoscopy_segmentation/CMakeLists.txt
@@ -15,6 +15,11 @@
 
 project(ColonoscopySegmentation NONE)
 
+# Find holoscan to ensure CMAKE_CUDA_COMPILER is consumed (silences CMake warning
+# about unused variable for Python-only apps with project(NONE))
+find_package(holoscan 1.0 REQUIRED CONFIG
+             PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
+
 # Default to download datasets
 option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)
 

--- a/applications/holochat/CMakeLists.txt
+++ b/applications/holochat/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,11 @@
 # limitations under the License.
 
 project(holochat NONE)
+
+# Find holoscan to ensure CMAKE_CUDA_COMPILER is consumed (silences CMake warning
+# about unused variable for Python-only apps with project(NONE))
+find_package(holoscan 1.0 REQUIRED CONFIG
+             PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
 if(BUILD_TESTING)
   add_subdirectory(tests)

--- a/applications/isaac_sim_holoscan_bridge/CMakeLists.txt
+++ b/applications/isaac_sim_holoscan_bridge/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,11 @@
 cmake_minimum_required(VERSION 3.20)
 
 project(isaac_sim_holoscan_bridge LANGUAGES NONE)
+
+# Find holoscan to ensure CMAKE_CUDA_COMPILER is consumed (silences CMake warning
+# about unused variable for Python-only apps with project(NONE))
+find_package(holoscan 1.0 REQUIRED CONFIG
+             PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
 # Add testing
 if(BUILD_TESTING)

--- a/applications/polyp_detection/CMakeLists.txt
+++ b/applications/polyp_detection/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,11 @@
 # limitations under the License.
 
 project(polyp_detection NONE)
+
+# Find holoscan to ensure CMAKE_CUDA_COMPILER is consumed (silences CMake warning
+# about unused variable for Python-only apps with project(NONE))
+find_package(holoscan 1.0 REQUIRED CONFIG
+             PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
 # Download the associated dataset if needed
 option(HOLOHUB_DOWNLOAD_DATASETS "Download datasets" ON)

--- a/applications/simple_radar_pipeline/CMakeLists.txt
+++ b/applications/simple_radar_pipeline/CMakeLists.txt
@@ -18,4 +18,9 @@
 #  - Python application doesn't have anything to build.
 if(NOT HOLOHUB_BUILD_PYTHON)
   add_subdirectory(cpp)
+else()
+  # Find holoscan to ensure CMAKE_CUDA_COMPILER is consumed when building
+  # Python-only (the python/ subdirectory has no CMakeLists.txt to build)
+  find_package(holoscan 1.0 REQUIRED CONFIG
+               PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 endif()


### PR DESCRIPTION
## Context

When building HoloHub with a specific application enabled (e.g., `-DAPP_colonoscopy_segmentation=ON`) and an explicit `CMAKE_CUDA_COMPILER` specified (e.g., `-D CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc`), CMake reports a warning:

```
CMake Warning:
  Manually-specified variables were not used by the project:
    CMAKE_CUDA_COMPILER
```

This occurs because Python-only apps using `project(... NONE)` don't enable any languages, so the compiler variable is never consumed.

## Root Cause

The holoscan package uses `rapids_export()` with `LANGUAGES C CXX CUDA`, which enables these languages when `find_package(holoscan)` is called. This consumes the `CMAKE_CUDA_COMPILER` variable.

Most Python-only apps (e.g., `body_pose_estimation`) already call `find_package(holoscan ...)` and don't trigger the warning. A few apps were missing this call.

## Description

Add `find_package(holoscan ...)` to 5 Python-only apps that were missing it:
- `colonoscopy_segmentation`
- `holochat`
- `isaac_sim_holoscan_bridge`
- `polyp_detection`
- `simple_radar_pipeline` (Python build path only)

This ensures consistency with other HoloHub applications and provides access to holoscan CMake utilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configurations across multiple applications to ensure required runtime components are discovered and to reduce build-system warnings, improving reliability for Python-only and mixed builds.
  * Updated license header years in a few application files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->