### PR TITLE
Pin ONNX version for Yolo Model Deployment

### DIFF
--- a/applications/yolo_model_deployment/Dockerfile
+++ b/applications/yolo_model_deployment/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update \
 
 RUN pip3 install \
     ultralytics \
-    onnx \
+    onnx==1.19.1 \
     onnx-graphsurgeon
 
 ARG GPU_TYPE


### PR DESCRIPTION
The most recent version of ONNX breaks onnx_surgeon with specific version of pytorch. 
Pinning the version of ONNX fixes the tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version pinning to improve deployment stability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->