### PR TITLE
Fix Torchvision package version

### DIFF
--- a/applications/object_detection_torch/Dockerfile
+++ b/applications/object_detection_torch/Dockerfile
@@ -44,6 +44,13 @@ FROM base AS torch
 ARG GPU_TYPE
 RUN set -eux; \
     if [ "${GPU_TYPE}" = "igpu" ]; then \
+        # Install cuDNN for PyTorch
+        # Some cuDNN libraries have been intentionally removed from the base image, so we need to reinstall them
+        apt-get update && \
+        apt-get install -y --reinstall --no-install-recommends \
+            libcudnn9-cuda-12 \
+            libcudnn9-dev-cuda-12 && \
+        rm -rf /var/lib/apt/lists/* && \
         PYTORCH_WHEEL_VERSION="2.8.0"; \
         TORCHVISION_WHEEL_VERSION="0.23.0"; \
         INDEX_URL="https://pypi.jetson-ai-lab.io/jp6/cu129"; \


### PR DESCRIPTION
Torchvision 0.23+cu129 does not exist, so getting the 0.23 instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Docker build robustness with stricter build shell behavior and better error handling.
  * Restored GPU-related runtime configuration to ensure deep learning libraries (cuDNN/PyTorch) are correctly available in GPU-enabled builds.
  * Adjusted packaged vision library variant for non-GPU builds to a CPU-compatible release for broader compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->