### PR TITLE
Op: Fix NVIDIA Video Codec SDK eager download

### DIFF
--- a/operators/nvidia_video_codec/CMakeLists.txt
+++ b/operators/nvidia_video_codec/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,28 +13,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Download and extract NVIDIA Video Codec SDK
-set(NVC_SDK_URL "https://edge.urm.nvidia.com/artifactory/sw-holoscan-thirdparty-generic-local/holohub/operators/holohub_nvc_13.0.19.zip")
-set(NVC_SDK_ZIP "${CMAKE_BINARY_DIR}/holohub_nvc_13.0.19.zip")
-set(NVC_SDK_DIR "${CMAKE_BINARY_DIR}/_deps/nvc_sdk")
+if(OP_nv_video_encoder OR
+    OP_nv_video_decoder OR
+    OP_nv_video_reader OR
+    nv_video_encoder IN_LIST HOLOHUB_BUILD_OPERATORS OR
+    nv_video_decoder IN_LIST HOLOHUB_BUILD_OPERATORS OR
+    nv_video_reader IN_LIST HOLOHUB_BUILD_OPERATORS)
+    # Download and extract NVIDIA Video Codec SDK
+    set(NVC_SDK_URL "https://edge.urm.nvidia.com/artifactory/sw-holoscan-thirdparty-generic-local/holohub/operators/holohub_nvc_13.0.19.zip")
+    set(NVC_SDK_ZIP "${CMAKE_BINARY_DIR}/holohub_nvc_13.0.19.zip")
+    set(NVC_SDK_DIR "${CMAKE_BINARY_DIR}/_deps/nvc_sdk")
 
-# Download the SDK if it doesn't exist
-if(NOT EXISTS ${NVC_SDK_ZIP})
-    file(DOWNLOAD ${NVC_SDK_URL} ${NVC_SDK_ZIP} SHOW_PROGRESS EXPECTED_MD5 "a08c33c282bc92469ab8cf863aca9087")
+    # Download the SDK if it doesn't exist
+    if(NOT EXISTS ${NVC_SDK_ZIP})
+        file(DOWNLOAD ${NVC_SDK_URL} ${NVC_SDK_ZIP} SHOW_PROGRESS EXPECTED_MD5 "a08c33c282bc92469ab8cf863aca9087")
+    endif()
+
+    # Extract the SDK if it hasn't been extracted
+    if(NOT EXISTS ${NVC_SDK_DIR})
+        file(MAKE_DIRECTORY ${NVC_SDK_DIR})
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} -E tar xzf ${NVC_SDK_ZIP}
+            WORKING_DIRECTORY ${NVC_SDK_DIR}
+        )
+    endif()
+
+    # Set the SDK path for the operators to use
+    set(NVC_SDK_PATH ${NVC_SDK_DIR} CACHE PATH "Path to NVIDIA Video Codec SDK")
 endif()
-
-# Extract the SDK if it hasn't been extracted
-if(NOT EXISTS ${NVC_SDK_DIR})
-    file(MAKE_DIRECTORY ${NVC_SDK_DIR})
-    execute_process(
-        COMMAND ${CMAKE_COMMAND} -E tar xzf ${NVC_SDK_ZIP}
-        WORKING_DIRECTORY ${NVC_SDK_DIR}
-    )
-endif()
-
-# Set the SDK path for the operators to use
-set(NVC_SDK_PATH ${NVC_SDK_DIR} CACHE PATH "Path to NVIDIA Video Codec SDK")
-
 
 add_holohub_operator(nv_video_encoder)
 add_holohub_operator(nv_video_decoder)


### PR DESCRIPTION
Fix issue wherre NVIDIA Video Codec SDK files were eagerly download by any project configuration regardless of whether the Video Codec SDK operator was to be built or not.

Verified locally:
- Previous: `holohub_nvc_13.0.19.zip` always present in build directory
- Updated:
  - `./holohub build endoscopy_tool_tracking`: `holohub_nvc_13.0.19.zip` no longer present
  - `./holohub build endoscopy_tool_tracking --build-with nv_video_encoder`: download runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NVIDIA Video Reader operator is now available and integrated into the build system.

* **Chores**
  * Improved conditional build configuration for NVIDIA Video Codec SDK to support multiple video codec operators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->