### PR TITLE
Shorten Kernel BCI App Name For Better Website Presentation

### DIFF
--- a/applications/bci_visualization/metadata.json
+++ b/applications/bci_visualization/metadata.json
@@ -1,6 +1,6 @@
 {
 	"application": {
-		"name": "Kernel Flow BCI Real-Time Reconstruction and Visualization",
+		"name": "Kernel Flow BCI Real-Time Visualization",
 		"authors": [
 			{
 				"name": "Holoscan Team",


### PR DESCRIPTION
Currently, the name of this application was going beyond of the expected size for each model card. This PR fix that.