### PR TITLE
Fix operators missing io_context include for HSDK 3.11+

### DIFF
--- a/operators/nvidia_video_codec/nv_video_decoder/nv_video_decoder.cpp
+++ b/operators/nvidia_video_codec/nv_video_decoder/nv_video_decoder.cpp
@@ -26,6 +26,7 @@
 #include "holoscan/core/execution_context.hpp"
 #include "holoscan/core/executor.hpp"
 #include "holoscan/core/gxf/entity.hpp"
+#include "holoscan/core/io_context.hpp"
 
 #include "gxf/core/entity.hpp"    // nvidia::gxf::Entity::Shared
 #include "gxf/std/allocator.hpp"  // nvidia::gxf::Allocator, nvidia::gxf::MemoryStorageType

--- a/operators/nvidia_video_codec/nv_video_encoder/nv_video_encoder.cpp
+++ b/operators/nvidia_video_codec/nv_video_encoder/nv_video_encoder.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +26,7 @@
 #include "holoscan/core/execution_context.hpp"
 #include "holoscan/core/executor.hpp"
 #include "holoscan/core/gxf/entity.hpp"
+#include "holoscan/core/io_context.hpp"
 
 #include "gxf/core/entity.hpp"    // nvidia::gxf::Entity::Shared
 #include "gxf/std/allocator.hpp"  // nvidia::gxf::Allocator, nvidia::gxf::MemoryStorageType

--- a/operators/nvidia_video_codec/nv_video_reader/nv_video_reader.cpp
+++ b/operators/nvidia_video_codec/nv_video_reader/nv_video_reader.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +26,7 @@
 #include "holoscan/core/execution_context.hpp"
 #include "holoscan/core/executor.hpp"
 #include "holoscan/core/gxf/entity.hpp"
+#include "holoscan/core/io_context.hpp"
 
 #include "gxf/std/tensor.hpp"     // nvidia::gxf::Tensor etc.
 #include "gxf/std/timestamp.hpp"  // nvidia::gxf::Timestamp

--- a/operators/tensor_to_file/tensor_to_file.cpp
+++ b/operators/tensor_to_file/tensor_to_file.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,7 @@
 #include "holoscan/core/execution_context.hpp"
 #include "holoscan/core/executor.hpp"
 #include "holoscan/core/gxf/entity.hpp"
+#include "holoscan/core/io_context.hpp"
 
 #include "gxf/core/entity.hpp"    // nvidia::gxf::Entity::Shared
 #include "gxf/std/allocator.hpp"  // nvidia::gxf::Allocator, nvidia::gxf::MemoryStorageType


### PR DESCRIPTION
Add missing `holoscan/core/io_context.hpp` include to `nv_video_encoder`, `nv_video_decoder`, `nv_video_reader`, and `tensor_to_file` operators. This header provides the full definitions of `InputContext` and `OutputContext` needed for `receive()` and `emit()` method calls.

This change is backward compatible.

Change similar to the one introduced in https://github.com/nvidia-holoscan/holohub/pull/1356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated copyright and licensing years across media and file operators.
  * Integrated internal I/O context support across video, reader, encoder/decoder, and tensor file components to standardize internal handling.
  * No changes to public interfaces or runtime behavior; purely internal infrastructure and maintainability updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->