### PR TITLE
Fix Holoscan DevContainer Issue for v3.10+ iGPU

### DIFF
--- a/tutorials/debugging/holoscan_container_vscode/.devcontainer/Dockerfile
+++ b/tutorials/debugging/holoscan_container_vscode/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
iGPU HSDK containers for 3.10+ (`3.10.0-cuda12-igpu`, `3.11.0-cuda12-igpu`) do not have TensorRT and its associated README in `/workspace`. However, the Docker in debugging tutorial tries to rename it anyways, which causes the devcontainer setup fails.

This PR makes the renaming conditional to the existence of that `README.md` file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container build robustness by handling cases where README.md may be absent, preventing unexpected errors during setup.

* **Documentation**
  * Updated copyright year range in project header.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->