### PR TITLE
cdash: support non-nightly dashboard models

### DIFF
--- a/utilities/testing/holohub.container.ctest
+++ b/utilities/testing/holohub.container.ctest
@@ -108,7 +108,12 @@ endif()
 # Default nightly start time
 set(CTEST_NIGHTLY_START_TIME "06:00:00 UTC")
 
-ctest_start(Nightly)
+# Dashboard model: Nightly (scheduled), Experimental (manual), or Continuous (CI)
+if(NOT DASHBOARD_MODEL)
+  set(DASHBOARD_MODEL "Nightly")
+endif()
+
+ctest_start(${DASHBOARD_MODEL})
 ctest_configure(OPTIONS "${configure_options}")
 ctest_build()
 ctest_test(RETURN_VALUE test_result)


### PR DESCRIPTION
https://cmake.org/cmake/help/latest/command/ctest_start.html

Want to be able to configure ctest runs to push Experimental or Continuous builds too, not just Nightly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Testing pipeline updated to use a configurable dashboard model with an automatic fallback to the default model, improving flexibility and ensuring tests run with a valid configuration when no explicit model is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->