### PR TITLE
Clarify usage of aja_source for overlay

### DIFF
--- a/operators/aja_source/README.md
+++ b/operators/aja_source/README.md
@@ -52,12 +52,12 @@ Required configuration:
 
 **aja_source**:
 
-- enable_overlay: true
+- `enable_overlay: true`
 
 **holoviz**:
 
-- enable_render_buffer_input: true
-- enable_render_buffer_output: true
+- `enable_render_buffer_input: true`
+- `enable_render_buffer_output: true`
 
 Required port connections:
 

--- a/operators/aja_source/README.md
+++ b/operators/aja_source/README.md
@@ -61,6 +61,6 @@ Required configuration:
 
 Required port connections:
 
-`aja_source.overlay_buffer_output` → `holoviz.render_buffer_input`
-
-`holoviz.render_buffer_output` → `aja_source.overlay_buffer_input`
+- `aja_source.video_buffer_output` → `holoviz.receivers`
+- `aja_source.overlay_buffer_output` → `holoviz.render_buffer_input`
+- `holoviz.render_buffer_output` → `aja_source.overlay_buffer_input`

--- a/operators/aja_source/README.md
+++ b/operators/aja_source/README.md
@@ -43,3 +43,24 @@ The operator supports various video formats based on resolution, frame rate, and
 
 - **video_buffer_output**: Video buffer containing the captured frame
 - **overlay_buffer_output** (optional): Empty video buffer for overlay when `enable_overlay` is true
+
+## Enabling overlay
+
+A typical overlay workflow uses the `aja_source` operator together with the `Holoviz` operator. `Holoviz` can capture and apply overlay information using a zero-copy path.
+
+Required configuration:
+
+**aja_source**:
+
+- enable_overlay: true
+
+**holoviz**:
+
+- enable_render_buffer_input: true
+- enable_render_buffer_output: true
+
+Required port connections:
+
+`aja_source.overlay_buffer_output` → `holoviz.render_buffer_input`
+
+`holoviz.render_buffer_output` → `aja_source.overlay_buffer_input`


### PR DESCRIPTION
I had a miss understanding of `aja_source` operator usage when applying the overlay.
An extension of the documentation is proposed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing how to enable overlay workflows between the aja_source and Holoviz operators, including required configuration flags and the two mandatory port connections to route render buffers between them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->