### PR TITLE
Extend aja_source's overlay documentation

### DIFF
--- a/operators/aja_source/README.md
+++ b/operators/aja_source/README.md
@@ -53,7 +53,9 @@ This makes it suitable for low-latency overlay paths and avoids an extra buffer 
 
 To enable overlay on the AJA source operator, set `enable_overlay: true`.
 
-For Holoviz-based overlay workflows, set `enable_render_buffer_input: true` and `enable_render_buffer_output: true`.
+For Holoviz-based overlay workflows, configure the **Holoviz** operator with
+`enable_render_buffer_input: true` and `enable_render_buffer_output: true`.
+These are Holoviz settings (not `aja_source` parameters).
 
 Two common usage patterns are:
 

--- a/operators/aja_source/README.md
+++ b/operators/aja_source/README.md
@@ -46,21 +46,47 @@ The operator supports various video formats based on resolution, frame rate, and
 
 ## Enabling overlay
 
-A typical overlay workflow uses the `aja_source` operator together with the `Holoviz` operator. `Holoviz` can capture and apply overlay information using a zero-copy path.
+AJA source operator supports overlay workflows through its overlay input/output buffers.
+Holoviz is a good candidate for this workflow because it can consume and return the render buffer directly.
+In particular, it can render into an existing RGBA render buffer provided at `render_buffer_input` and, when `render_buffer_output` is enabled, return the filled render buffer while reusing the same input buffer instead of allocating a new one.
+This makes it suitable for low-latency overlay paths and avoids an extra buffer allocation/copy in the common AJA overlay workflow, but it is not strictly required as long as another operator correctly handles the buffers provided by `aja_source`.
 
-Required configuration:
+To enable overlay on the AJA source operator, set `enable_overlay: true`.
 
-**aja_source**:
+For Holoviz-based overlay workflows, set `enable_render_buffer_input: true` and `enable_render_buffer_output: true`.
 
-- `enable_overlay: true`
+Two common usage patterns are:
 
-**holoviz**:
+1. **Overlay-only path (headless Holoviz)**
 
-- `enable_render_buffer_input: true`
-- `enable_render_buffer_output: true`
+   Holoviz is configured with `headless: true` and is only used to render overlay content into the render buffer that is sent back to the AJA source operator.
 
-Required port connections:
+   Required connections:
 
-- `aja_source.video_buffer_output` → `holoviz.receivers`
-- `aja_source.overlay_buffer_output` → `holoviz.render_buffer_input`
-- `holoviz.render_buffer_output` → `aja_source.overlay_buffer_input`
+   ```python
+   self.add_flow(source, visualizer, {("overlay_buffer_output", "render_buffer_input")})
+   self.add_flow(visualizer, source, {("render_buffer_output", "overlay_buffer_input")})
+   ```
+
+2. **Holoviz displays the source image and the overlay**
+
+   In this case, Holoviz is also used as the display sink for the captured source image, so the source image must be connected to Holoviz through `receivers`:
+
+   ```python
+   self.add_flow(source, visualizer, {("video_buffer_output", "receivers")})
+   ```
+
+   The overlay feedback loop is still required:
+
+   ```python
+   self.add_flow(source, visualizer, {("overlay_buffer_output", "render_buffer_input")})
+   self.add_flow(visualizer, source, {("render_buffer_output", "overlay_buffer_input")})
+   ```
+
+In summary:
+
+- `video_buffer_output` carries the captured source image to Holoviz for display.
+- `overlay_buffer_output` provides the render buffer consumed by Holoviz.
+- `render_buffer_output` returns the rendered overlay buffer back from Holoviz to the AJA source operator.
+
+Any overlay tensors, masks, text, or geometry should still be connected to Holoviz according to the needs of the application graph.

--- a/operators/aja_source/README.md
+++ b/operators/aja_source/README.md
@@ -85,7 +85,7 @@ Two common usage patterns are:
 
 In summary:
 
-- `video_buffer_output` carries the captured source image to Holoviz for display.
+- `video_buffer_output` carries the captured source image to Holoviz for display (used in pattern 2 only).
 - `overlay_buffer_output` provides the render buffer consumed by Holoviz.
 - `render_buffer_output` returns the rendered overlay buffer back from Holoviz to the AJA source operator.
 


### PR DESCRIPTION
Sorry to come again with this, I did already add a section about aja_source operators overlay connection in https://github.com/nvidia-holoscan/holohub/pull/1508 but it was too schematic.

I hope this helps to understand better.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Clarified AJA source overlay guidance for Holoviz integrations, shifting to a buffer-oriented explanation.
* Added explicit configuration steps for enabling overlay and separate render buffer settings, plus two concrete usage patterns: overlay-only (headless) and combined display + overlay.
* Included role mappings for buffer outputs and a reminder to connect overlay tensors/masks/text/geometry via the application graph.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->