### PR TITLE
add deprecation notices to AJA, Deltacast, and Yuan video operators

### DIFF
--- a/operators/aja_source/README.md
+++ b/operators/aja_source/README.md
@@ -1,5 +1,11 @@
 # AJA Source Operator
 
+> **Deprecation Notice:** This operator is deprecated and will be replaced by an SDK-native
+> `VideoAcquisitionOperator` subclass built on the `video_io` base library introduced in
+> Holoscan SDK. The `video_io` base provides a vendor-agnostic contract with standardized
+> multi-stream port allocation, capability reporting, and telemetry. New applications should
+> plan to migrate to the SDK-native AJA operator once available.
+
 The AJA Source operator provides functionality to capture high-quality video streams from AJA capture cards and devices. It offers comprehensive support for both SDI (Serial Digital Interface) and HDMI (High-Definition Multimedia Interface) input sources, allowing for professional video capture in various formats and resolutions. The operator is designed to work seamlessly with AJA's hardware capabilities, including features like frame synchronization and format detection. Additionally, it provides an optional overlay channel capability that enables real-time mixing and compositing of multiple video streams, making it suitable for applications requiring picture-in-picture, graphics overlay, or other video mixing scenarios.
 
 ## Requirements

--- a/operators/aja_source/README.md
+++ b/operators/aja_source/README.md
@@ -1,10 +1,12 @@
 # AJA Source Operator
 
-> **Deprecation Notice:** This operator is deprecated and will be replaced by an SDK-native
-> `VideoAcquisitionOperator` subclass built on the `video_io` base library introduced in
-> Holoscan SDK. The `video_io` base provides a vendor-agnostic contract with standardized
-> multi-stream port allocation, capability reporting, and telemetry. New applications should
-> plan to migrate to the SDK-native AJA operator once available.
+> **Deprecation Notice (since Holoscan SDK v4.2.0):** This operator is deprecated and will
+> be replaced by an SDK-native `VideoAcquisitionOperator` subclass built on the `video_io`
+> base library introduced in Holoscan SDK. The `video_io` base provides a vendor-agnostic
+> contract with standardized multi-stream port allocation, capability reporting, and
+> telemetry. New applications should plan to migrate to the SDK-native AJA operator once
+> available. See the [Holoscan SDK v4.2.0 release notes](https://github.com/nvidia-holoscan/holoscan-sdk/releases/tag/v4.2.0)
+> for details on `VideoAcquisitionOperator` and `VideoTransmissionOperator`.
 
 The AJA Source operator provides functionality to capture high-quality video streams from AJA capture cards and devices. It offers comprehensive support for both SDI (Serial Digital Interface) and HDMI (High-Definition Multimedia Interface) input sources, allowing for professional video capture in various formats and resolutions. The operator is designed to work seamlessly with AJA's hardware capabilities, including features like frame synchronization and format detection. Additionally, it provides an optional overlay channel capability that enables real-time mixing and compositing of multiple video streams, making it suitable for applications requiring picture-in-picture, graphics overlay, or other video mixing scenarios.
 

--- a/operators/deltacast_videomaster/README.md
+++ b/operators/deltacast_videomaster/README.md
@@ -1,5 +1,11 @@
 # DELTACAST VideoMaster Operators
 
+> **Deprecation Notice:** These operators are deprecated and will be replaced by SDK-native
+> `VideoAcquisitionOperator` and `VideoTransmissionOperator` subclasses built on the `video_io`
+> base library introduced in Holoscan SDK. The `video_io` base provides a vendor-agnostic
+> contract with standardized multi-stream port allocation, capability reporting, and telemetry.
+> New applications should plan to migrate to the SDK-native Deltacast operators once available.
+
 The DELTACAST VideoMaster operator provides functionality to capture and stream high-quality video streams from DELTACAST cards. It supports both SDI and HDMI input and output sources, enabling professional video capture in various formats and resolutions. DELTACAST VideoMaster operators are designed to work seamlessly with DELTACAST's hardware capabilities.
 
 This library contains two operators:

--- a/operators/deltacast_videomaster/README.md
+++ b/operators/deltacast_videomaster/README.md
@@ -1,10 +1,12 @@
 # DELTACAST VideoMaster Operators
 
-> **Deprecation Notice:** These operators are deprecated and will be replaced by SDK-native
-> `VideoAcquisitionOperator` and `VideoTransmissionOperator` subclasses built on the `video_io`
-> base library introduced in Holoscan SDK. The `video_io` base provides a vendor-agnostic
-> contract with standardized multi-stream port allocation, capability reporting, and telemetry.
-> New applications should plan to migrate to the SDK-native Deltacast operators once available.
+> **Deprecation Notice (since Holoscan SDK v4.2.0):** These operators are deprecated and
+> will be replaced by SDK-native `VideoAcquisitionOperator` and `VideoTransmissionOperator`
+> subclasses built on the `video_io` base library introduced in Holoscan SDK. The `video_io`
+> base provides a vendor-agnostic contract with standardized multi-stream port allocation,
+> capability reporting, and telemetry. New applications should plan to migrate to the
+> SDK-native Deltacast operators once available. See the [Holoscan SDK v4.2.0 release notes](https://github.com/nvidia-holoscan/holoscan-sdk/releases/tag/v4.2.0)
+> for details on `VideoAcquisitionOperator` and `VideoTransmissionOperator`.
 
 The DELTACAST VideoMaster operator provides functionality to capture and stream high-quality video streams from DELTACAST cards. It supports both SDI and HDMI input and output sources, enabling professional video capture in various formats and resolutions. DELTACAST VideoMaster operators are designed to work seamlessly with DELTACAST's hardware capabilities.
 

--- a/operators/yuan_qcap/README.md
+++ b/operators/yuan_qcap/README.md
@@ -1,10 +1,12 @@
 # YUAN QCAP Source Operator
 
-> **Deprecation Notice:** This operator is deprecated and will be replaced by an SDK-native
-> `VideoAcquisitionOperator` subclass built on the `video_io` base library introduced in
-> Holoscan SDK. The `video_io` base provides a vendor-agnostic contract with standardized
-> multi-stream port allocation, capability reporting, and telemetry. New applications should
-> plan to migrate to the SDK-native Yuan operator once available.
+> **Deprecation Notice (since Holoscan SDK v4.2.0):** This operator is deprecated and will
+> be replaced by an SDK-native `VideoAcquisitionOperator` subclass built on the `video_io`
+> base library introduced in Holoscan SDK. The `video_io` base provides a vendor-agnostic
+> contract with standardized multi-stream port allocation, capability reporting, and
+> telemetry. New applications should plan to migrate to the SDK-native Yuan operator once
+> available. See the [Holoscan SDK v4.2.0 release notes](https://github.com/nvidia-holoscan/holoscan-sdk/releases/tag/v4.2.0)
+> for details on `VideoAcquisitionOperator` and `VideoTransmissionOperator`.
 
 The `QCAPSourceOp` operator provides video stream capture from YUAN High-Tech capture cards, supporting various video formats and configurations for professional video acquisition.
 

--- a/operators/yuan_qcap/README.md
+++ b/operators/yuan_qcap/README.md
@@ -1,5 +1,11 @@
 # YUAN QCAP Source Operator
 
+> **Deprecation Notice:** This operator is deprecated and will be replaced by an SDK-native
+> `VideoAcquisitionOperator` subclass built on the `video_io` base library introduced in
+> Holoscan SDK. The `video_io` base provides a vendor-agnostic contract with standardized
+> multi-stream port allocation, capability reporting, and telemetry. New applications should
+> plan to migrate to the SDK-native Yuan operator once available.
+
 The `QCAPSourceOp` operator provides video stream capture from YUAN High-Tech capture cards, supporting various video formats and configurations for professional video acquisition.
 
 ## Overview


### PR DESCRIPTION
## Summary
- Adds deprecation notices to the README files of the three vendor-specific video
  capture/output operators: `aja_source`, `deltacast_videomaster`, and `yuan_qcap`.
- Each notice informs users that these operators will be replaced by SDK-native
  `VideoAcquisitionOperator` / `VideoTransmissionOperator` subclasses built on the
  `video_io` base library in Holoscan SDK, which provides a vendor-agnostic contract
  with standardized multi-stream port allocation, capability reporting, and telemetry.
- No functional code changes — README-only updates.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation notices to three video operator documentation pages (AJA Source, DELTACAST VideoMaster, Yuan QCAP), informing users of upcoming replacements with standardized alternatives built on a vendor-agnostic base library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->