### PR TITLE
cli: strip ANSI color codes when stdout is not a TTY

### DIFF
--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -55,7 +55,11 @@ BUILD_TYPES = {
 
 
 class Color:
-    """Utility class for terminal color formatting"""
+    """Utility class for terminal color formatting.
+
+    ANSI codes are emitted only when stdout is a TTY. When piped or redirected,
+    all formatting is stripped so scripts can parse the output cleanly.
+    """
 
     # ANSI color codes
     RED = "\033[31m"
@@ -71,7 +75,12 @@ class Color:
 
     @staticmethod
     def format(text: str, color: str, bold: bool = False) -> str:
-        """Format text with color and optional bold attribute"""
+        """Format text with color and optional bold attribute.
+
+        Returns plain text (no ANSI codes) when stdout is not a TTY.
+        """
+        if not sys.stdout.isatty():
+            return text
         result = color
         if bold:
             result += Color.BOLD

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -57,8 +57,13 @@ BUILD_TYPES = {
 class Color:
     """Utility class for terminal color formatting.
 
-    ANSI codes are emitted only when stdout is a TTY. When piped or redirected,
-    all formatting is stripped so scripts can parse the output cleanly.
+    ANSI codes are emitted based on the destination stream and environment:
+      - NO_COLOR=<non-empty>    always strip colors (no-color.org)
+      - FORCE_COLOR=<non-empty> always emit colors
+      - otherwise: emit only when the destination stream is a TTY
+
+    Callers that write to stderr should pass stream=sys.stderr so the TTY
+    check targets the correct destination.
     """
 
     # ANSI color codes
@@ -74,12 +79,22 @@ class Color:
     RESET = "\033[0m"
 
     @staticmethod
-    def format(text: str, color: str, bold: bool = False) -> str:
+    def _should_color(stream=None) -> bool:
+        if os.environ.get("NO_COLOR"):
+            return False
+        if os.environ.get("FORCE_COLOR"):
+            return True
+        stream = stream or sys.stdout
+        return hasattr(stream, "isatty") and stream.isatty()
+
+    @staticmethod
+    def format(text: str, color: str, bold: bool = False, stream=None) -> str:
         """Format text with color and optional bold attribute.
 
-        Returns plain text (no ANSI codes) when stdout is not a TTY.
+        Returns plain text (no ANSI codes) when the destination stream is not
+        a TTY, or when NO_COLOR is set. Set FORCE_COLOR to override.
         """
-        if not sys.stdout.isatty():
+        if not Color._should_color(stream):
             return text
         result = color
         if bold:
@@ -90,8 +105,8 @@ class Color:
     def _create_color_method(color_code: str):
         """Create a color method for the given color code"""
 
-        def color_method(text: str, bold: bool = False) -> str:
-            return Color.format(text, color_code, bold)
+        def color_method(text: str, bold: bool = False, stream=None) -> str:
+            return Color.format(text, color_code, bold, stream=stream)
 
         return color_method
 
@@ -157,16 +172,19 @@ def check_skip_builds(args) -> Tuple[bool, bool]:
 
 def fatal(message: str) -> None:
     """Print fatal error and exit with backtrace"""
+    err = sys.stderr
     print(
-        f"{Color.red(get_timestamp())} {Color.red('[FATAL]', bold=True)} {message}", file=sys.stderr
+        f"{Color.red(get_timestamp(), stream=err)} "
+        f"{Color.red('[FATAL]', bold=True, stream=err)} {message}",
+        file=err,
     )
-    print("\nBacktrace: ...", file=sys.stderr)
-    traceback.print_list(traceback.extract_stack()[-3:], file=sys.stderr)
+    print("\nBacktrace: ...", file=err)
+    traceback.print_list(traceback.extract_stack()[-3:], file=err)
     sys.exit(1)
 
 
 def warn(message: str) -> None:
-    print(f"{Color.yellow('WARNING:')} {message}", file=sys.stderr)
+    print(f"{Color.yellow('WARNING:', stream=sys.stderr)} {message}", file=sys.stderr)
 
 
 def _get_holohub_root() -> Path:


### PR DESCRIPTION
## Summary

The `Color` class in `utilities/cli/util.py` unconditionally emitted ANSI escape codes, which leaked into scripts parsing CLI output (e.g., `./holohub list | awk ...`).

This PR makes color emission conditional on the destination stream and environment:
- **`NO_COLOR=<non-empty>`** - always strip colors ([no-color.org](https://no-color.org/))
- **`FORCE_COLOR=<non-empty>`** - always emit colors, even if piped
- Otherwise, emit only when the destination stream is a TTY

`Color.format()` and the color methods (`Color.red`, `Color.yellow`, etc.) now accept an optional `stream` parameter. `warn()` and `fatal()` pass `stream=sys.stderr` so the TTY check targets the correct destination (e.g., when stdout is piped but stderr still goes to the terminal).

This matches what `colorama` / `click` do and follows the standard Unix convention.

## Before / After

Before:
```
$ ./holohub list | head -3
\x1b[37m\x1b[1m== APPLICATIONS =================\x1b[0m

aja_source (cpp)
```

After:
```
$ ./holohub list | head -3
== APPLICATIONS =================

aja_source (cpp)
```

Interactive terminal output is unchanged.

## Test plan

- [x] `./holohub list` in a terminal - colors still appear
- [x] `./holohub list | cat` - no ANSI codes
- [x] `./holohub list | awk ...` from a script - clean output parseable with awk/sed
- [x] `NO_COLOR=1 ./holohub list` in a terminal - no colors
- [x] `FORCE_COLOR=1 ./holohub list | cat` - colors even when piped
- [x] Pipe stdout only (e.g. `./holohub foo | cat`) - warnings/errors on stderr still colored if stderr is a TTY