### PR TITLE
fix(object_detection_torch): support CUDA 13 on iGPU (AGX Orin + JetPack 7)

### DIFF
--- a/applications/object_detection_torch/Dockerfile
+++ b/applications/object_detection_torch/Dockerfile
@@ -43,7 +43,7 @@ ARG GPU_TYPE
 ARG CUDA_MAJOR
 RUN INDEX_URL=""; \
     if [ "${GPU_TYPE}" = "igpu" ] && [ "${CUDA_MAJOR}" = "12" ]; then \
-        # Install cuDNN for PyTorch
+        # Install cuDNN for Jetpack 6.x PyTorch
         # Some cuDNN libraries have been intentionally removed from the base image, so we need to reinstall them
         apt-get update && \
         apt-get install -y --reinstall --no-install-recommends \

--- a/applications/object_detection_torch/Dockerfile
+++ b/applications/object_detection_torch/Dockerfile
@@ -42,24 +42,15 @@ RUN echo $(python3 -c "import torch; print(torch.__path__[0])")/lib > /etc/ld.so
 ARG GPU_TYPE
 ARG CUDA_MAJOR
 RUN INDEX_URL=""; \
-    if [ "${GPU_TYPE}" = "igpu" ]; then \
+    if [ "${GPU_TYPE}" = "igpu" ] && [ "${CUDA_MAJOR}" = "12" ]; then \
         # Install cuDNN for PyTorch
         # Some cuDNN libraries have been intentionally removed from the base image, so we need to reinstall them
         apt-get update && \
-        if [ "${CUDA_MAJOR}" = "12" ]; then \
-            apt-get install -y --reinstall --no-install-recommends \
-                libcudnn9-cuda-12 \
-                libcudnn9-dev-cuda-12 && \
-            INDEX_URL="https://pypi.jetson-ai-lab.io/jp6/cu126"; \
-        elif [ "${CUDA_MAJOR}" = "13" ]; then \
-            apt-get install -y --reinstall --no-install-recommends \
-                libcudnn9-cuda-13 \
-                libcudnn9-dev-cuda-13 && \
-            INDEX_URL="https://pypi.jetson-ai-lab.io/sbsa/cu130"; \
-        else \
-            echo "Error: Unsupported CUDA_MAJOR (${CUDA_MAJOR}) for iGPU" && exit 1; \
-        fi && \
-        rm -rf /var/lib/apt/lists/*; \
+        apt-get install -y --reinstall --no-install-recommends \
+            libcudnn9-cuda-12 \
+            libcudnn9-dev-cuda-12 && \
+        rm -rf /var/lib/apt/lists/* && \
+        INDEX_URL="https://pypi.jetson-ai-lab.io/jp6/cu126"; \
     elif [ "${CUDA_MAJOR}" = "12" ]; then \
         INDEX_URL="https://download.pytorch.org/whl/cu129"; \
     elif [ "${CUDA_MAJOR}" = "13" ]; then \

--- a/applications/object_detection_torch/Dockerfile
+++ b/applications/object_detection_torch/Dockerfile
@@ -46,11 +46,20 @@ RUN INDEX_URL=""; \
         # Install cuDNN for PyTorch
         # Some cuDNN libraries have been intentionally removed from the base image, so we need to reinstall them
         apt-get update && \
-        apt-get install -y --reinstall --no-install-recommends \
-            libcudnn9-cuda-12 \
-            libcudnn9-dev-cuda-12 && \
-        rm -rf /var/lib/apt/lists/* && \
-        INDEX_URL="https://pypi.jetson-ai-lab.io/jp6/cu126"; \
+        if [ "${CUDA_MAJOR}" = "12" ]; then \
+            apt-get install -y --reinstall --no-install-recommends \
+                libcudnn9-cuda-12 \
+                libcudnn9-dev-cuda-12 && \
+            INDEX_URL="https://pypi.jetson-ai-lab.io/jp6/cu126"; \
+        elif [ "${CUDA_MAJOR}" = "13" ]; then \
+            apt-get install -y --reinstall --no-install-recommends \
+                libcudnn9-cuda-13 \
+                libcudnn9-dev-cuda-13 && \
+            INDEX_URL="https://pypi.jetson-ai-lab.io/sbsa/cu130"; \
+        else \
+            echo "Error: Unsupported CUDA_MAJOR (${CUDA_MAJOR}) for iGPU" && exit 1; \
+        fi && \
+        rm -rf /var/lib/apt/lists/*; \
     elif [ "${CUDA_MAJOR}" = "12" ]; then \
         INDEX_URL="https://download.pytorch.org/whl/cu129"; \
     elif [ "${CUDA_MAJOR}" = "13" ]; then \


### PR DESCRIPTION
## Description

The iGPU branch in `applications/object_detection_torch/Dockerfile` was hardcoded to install `libcudnn9-cuda-12` packages and use the JetPack 6 PyTorch wheel index (`pypi.jetson-ai-lab.io/jp6/cu126`). When building with a CUDA 13 base image (e.g. `holoscan:v4.2.0.0-cuda13` on JetPack 7.2 / AGX Orin), this causes a cuDNN header conflict:

```
libcudnn9-headers-cuda-12 : Conflicts: libcudnn9-headers
libcudnn9-headers-cuda-13 : Conflicts: libcudnn9-headers
E: Error, pkgProblemResolver::Resolve generated breaks
```

## Fix

Make the iGPU branch `CUDA_MAJOR`-aware, mirroring the logic already present in the dGPU path:

- **CUDA 12** (JetPack 6): install `libcudnn9-cuda-12/dev`, use `pypi.jetson-ai-lab.io/jp6/cu126`
- **CUDA 13** (JetPack 7): install `libcudnn9-cuda-13/dev`, use `pypi.jetson-ai-lab.io/jp7/sbsa/cu130`

## Test Environment

- HW: AGX Orin
- SW: JetPack 7.2, HSDK v4.2.0.0
- Base image: `nvcr.io/nvstaging/holoscan/holoscan:v4.2.0.0-cuda13`

## Test Plan
- [ ] Build with `holoscan:v4.2.0.0-cuda13` base on AGX Orin (JetPack 7.2) — cuDNN conflict resolved
- [ ] Build with a CUDA 12 base on AGX Orin (JetPack 6) — existing behavior unchanged

Fixes: nvbug 6120077

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Docker build process for GPU configurations to properly handle different CUDA versions, ensuring unnecessary dependency reinstallation is skipped when not required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->