### PR TITLE
feat(cli): auto-detect X11/Wayland display forwarding

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,6 +41,7 @@
         // X11 support
         "DISPLAY": "${localEnv:DISPLAY}",
         // Wayland support
+        "WAYLAND_DISPLAY": "${localEnv:WAYLAND_DISPLAY}",
         "XDG_RUNTIME_DIR": "${localEnv:XDG_RUNTIME_DIR}",
         "XDG_SESSION_TYPE": "${localEnv:XDG_SESSION_TYPE}",
         "NVIDIA_DRIVER_CAPABILITIES": "all",

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -155,11 +155,10 @@ To launch custom HoloHub container with fully qualified name, e.g. "holohub:ngc-
 ./holohub run-container --img holohub:ngc-sdk-sample-app --no-docker-build
 ```
 
-### Forward X11 Graphics Over SSH
+### Forward Graphics From Containers
 
-```bash
-  ./holohub run-container --ssh-x11
-```
+HoloHub automatically forwards X11 and Wayland displays when `DISPLAY` or
+`WAYLAND_DISPLAY` is set on the host.
 
 ### Support Nsight Systems profiling in the HoloHub Container
 

--- a/utilities/cli/cli_reference.md
+++ b/utilities/cli/cli_reference.md
@@ -79,7 +79,7 @@ Used by: `run-container`, `build`, `run`, `install`.
 | Option                    | Description                                                                   |
 | ------------------------- | ----------------------------------------------------------------------------- |
 | `--docker-opts <opts>`    | Additional options to `docker run` (for example `--docker-opts='--gpus=all'`) |
-| `--ssh-x11`               | Enable X11 forwarding over SSH                                                |
+| `--ssh-x11`               | Deprecated; display forwarding is auto-detected from `DISPLAY`                |
 | `--nsys-profile`          | Support Nsight Systems profiling in container                                 |
 | `--local-sdk-root <path>` | Path to Holoscan SDK on host for local SDK container                          |
 | `--init`                  | Use tini entry point                                                          |
@@ -88,7 +88,7 @@ Used by: `run-container`, `build`, `run`, `install`.
 | `--as-root`               | Run container as root                                                         |
 | `--nsys-location <path>`  | Nsight Systems installation path on host                                      |
 | `--mps`                   | Mount CUDA MPS host directories into container (if MPS enabled on host)       |
-| `--enable-x11`            | Enable X11 forwarding (default: true)                                         |
+| `--enable-x11`            | Deprecated; X11/Wayland forwarding is auto-detected                           |
 
 ---
 

--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -99,6 +99,9 @@ class HoloHubContainer:
     DEFAULT_DOCKER_BUILD_ARGS = os.environ.get("HOLOHUB_DEFAULT_DOCKER_BUILD_ARGS", "")
     # Additional Default run arguments for docker run command
     DEFAULT_DOCKER_RUN_ARGS = os.environ.get("HOLOHUB_DEFAULT_DOCKER_RUN_ARGS", "")
+    DISPLAY_FORWARDING_DISABLED_MESSAGE = (
+        "No DISPLAY or WAYLAND_DISPLAY set; skipping display forwarding."
+    )
 
     @classmethod
     def default_base_image(cls, cuda_version: Optional[Union[str, int]] = None) -> str:
@@ -452,6 +455,7 @@ class HoloHubContainer:
         self.cuda_version = None  # None means use default from get_cuda_tag
         self.dryrun = False
         self.verbose = False
+        self._display_temp_files: List[Path] = []
 
     def build(
         self,
@@ -610,6 +614,7 @@ class HoloHubContainer:
         cmd.extend(self.ucx_args())
         cmd.extend(self.get_device_mounts())
         cmd.extend(self.group_args())
+        self._display_temp_files = []
         cmd.extend(self.get_display_options(enable_x11, ssh_x11))
         cmd.extend(self.get_nsys_options(nsys_profile, nsys_location))
         cmd.extend(self.get_pythonpath_options(local_sdk_root, img))
@@ -632,7 +637,10 @@ class HoloHubContainer:
             cmd_list = [f'"{arg}"' if " " in str(arg) else str(arg) for arg in cmd]
             print(f"Launch command: {' '.join(cmd_list)}")
 
-        run_command(cmd, dry_run=self.dryrun)
+        try:
+            run_command(cmd, dry_run=self.dryrun)
+        finally:
+            self._cleanup_display_temp_files()
 
     def get_basic_args(self) -> List[str]:
         """Basic container runtime arguments"""
@@ -772,74 +780,99 @@ class HoloHubContainer:
             )
         return args
 
-    def enable_x11_access(self) -> None:
-        if (
-            "DISPLAY" in os.environ
-            and shutil.which("xhost")
-            and os.environ.get("XDG_SESSION_TYPE", "x11") in ["x11", "tty", ""]
-        ):
-            run_command(["xhost", "+local:docker"], check=False, dry_run=self.dryrun)
-
     def get_display_options(self, enable_x11: bool, ssh_x11: bool) -> List[str]:
-        """Get display-related options"""
+        """Get display-related Docker options from DISPLAY and WAYLAND_DISPLAY."""
         options = []
-        if "XDG_SESSION_TYPE" in os.environ:
+        del enable_x11, ssh_x11
+
+        display = os.environ.get("DISPLAY")
+        wayland_display = os.environ.get("WAYLAND_DISPLAY")
+        if not display and not wayland_display:
+            info(self.DISPLAY_FORWARDING_DISABLED_MESSAGE)
+            return options
+
+        if os.environ.get("XDG_SESSION_TYPE"):
             options.extend(["-e", "XDG_SESSION_TYPE"])
-            if os.environ["XDG_SESSION_TYPE"] == "wayland":
-                options.extend(["-e", "WAYLAND_DISPLAY"])
 
-        if "XDG_RUNTIME_DIR" in os.environ:
-            options.extend(["-e", "XDG_RUNTIME_DIR"])
-            if os.path.isdir(os.environ["XDG_RUNTIME_DIR"]):
-                options.extend(
-                    ["-v", f"{os.environ['XDG_RUNTIME_DIR']}:{os.environ['XDG_RUNTIME_DIR']}"]
-                )
+        # Required by Vulkan, dconf, pipewire, etc. on both X11 and Wayland.
+        runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+        if runtime_dir and Path(runtime_dir).is_dir():
+            options.extend(["-e", "XDG_RUNTIME_DIR", "-v", f"{runtime_dir}:{runtime_dir}"])
 
-        # Handle X11 forwarding
-        if enable_x11 or ssh_x11:
-            # Enable X11 access for Docker containers
-            self.enable_x11_access()
-            options.extend(["-v", "/tmp/.X11-unix:/tmp/.X11-unix", "-e", "DISPLAY"])
+        if wayland_display:
+            options.extend(["-e", "WAYLAND_DISPLAY"])
 
-        # Handle SSH X11 forwarding
-        if ssh_x11:
-            if "DISPLAY" not in os.environ:
-                warn(
-                    "SSH X11 forwarding requested but DISPLAY environment variable is not set; skipping SSH X11 forwarding setup."
-                )
-            else:
-                if not shutil.which("xauth"):
-                    warn(
-                        "SSH X11 forwarding requested but xauth was not found; skipping xauth setup."
-                    )
-                else:
-                    result = run_command(
-                        ["xauth", "nlist", os.environ["DISPLAY"]],
-                        check=False,
-                        capture_output=True,
-                        text=True,
-                        dry_run=self.dryrun,
-                    )
-                    if result.stdout and result.returncode == 0:
-                        xauth_file = "/tmp/.docker.xauth"
-                        with tempfile.NamedTemporaryFile(mode="w+t", delete=True) as tmp:
-                            for line in result.stdout.splitlines(True):
-                                tmp.write("ffff" + line[4:])
-                            tmp.flush()
-
-                            if not self.dryrun:
-                                Path(xauth_file).touch(mode=0o600)
-
-                            run_command(
-                                ["xauth", "-f", xauth_file, "nmerge", tmp.name],
-                                check=False,
-                                dry_run=self.dryrun,
-                            )
-                        options.extend(
-                            ["-v", f"{xauth_file}:{xauth_file}", "-e", f"XAUTHORITY={xauth_file}"]
-                        )
+        if display:
+            if Path("/tmp/.X11-unix").is_dir() and not self._is_ssh_x11_display(display):
+                options.extend(["-v", "/tmp/.X11-unix:/tmp/.X11-unix:ro"])
+            options.extend(["-e", "DISPLAY"])
+            options.extend(self._get_xauth_options(display))
 
         return options
+
+    @staticmethod
+    def _is_ssh_x11_display(display: str) -> bool:
+        return display.startswith(("localhost:", "127.0.0.1:", "[::1]:", "::1:"))
+
+    def _get_xauth_options(self, display: str) -> List[str]:
+        if not shutil.which("xauth"):
+            warn(
+                "xauth not found on host; install xauth (or x11-xauth) so X11 "
+                "applications can authenticate inside the container."
+            )
+            return []
+
+        if self.dryrun:
+            placeholder = "/tmp/.docker.xauth"
+            return ["-v", f"{placeholder}:{placeholder}:ro", "-e", f"XAUTHORITY={placeholder}"]
+
+        result = run_command(
+            ["xauth", "nlist", display],
+            check=False,
+            capture_output=True,
+            text=True,
+            dry_run=self.dryrun,
+        )
+        if result.returncode != 0 or not result.stdout:
+            warn(
+                f"xauth nlist returned no entries for DISPLAY={display}; "
+                "X11 may not authenticate inside the container."
+            )
+            return []
+
+        xauth_fd, xauth_file = tempfile.mkstemp(prefix=".docker.xauth-")
+        os.close(xauth_fd)
+        xauth_path = Path(xauth_file)
+
+        xauth_entries = "".join(
+            f"ffff{line[4:]}" for line in result.stdout.splitlines(keepends=True) if len(line) >= 4
+        )
+        merge_result = run_command(
+            ["xauth", "-f", str(xauth_path), "nmerge", "-"],
+            check=False,
+            input=xauth_entries,
+            text=True,
+            dry_run=self.dryrun,
+        )
+        if merge_result.returncode != 0:
+            xauth_path.unlink(missing_ok=True)
+            warn(
+                f"xauth nmerge failed for DISPLAY={display}; "
+                "X11 may not authenticate inside the container."
+            )
+            return []
+
+        self._display_temp_files.append(xauth_path)
+        return ["-v", f"{xauth_path}:{xauth_path}:ro", "-e", f"XAUTHORITY={xauth_path}"]
+
+    def _cleanup_display_temp_files(self) -> None:
+        for path in self._display_temp_files:
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                # Suppress I/O errors so cleanup doesn't mask the original exception.
+                pass
+        self._display_temp_files.clear()
 
     def get_ngc_options(self) -> List[str]:
         """Get NGC-related options"""

--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -159,6 +159,16 @@ class HoloHubContainer:
     @staticmethod
     def get_run_argparse() -> argparse.ArgumentParser:
         """Get argument parser for container run options"""
+
+        class _DeprecatedDisplayFlagAction(argparse.Action):
+            def __call__(self, parser, namespace, values, option_string=None):
+                warn(
+                    f"{option_string} is deprecated and ignored; X11 and Wayland "
+                    "forwarding now happens automatically when DISPLAY or "
+                    "WAYLAND_DISPLAY is set."
+                )
+                setattr(namespace, self.dest, True)
+
         parser = argparse.ArgumentParser(add_help=False)
         parser.add_argument(
             "--docker-opts",
@@ -168,8 +178,10 @@ class HoloHubContainer:
         )
         parser.add_argument(
             "--ssh-x11",
-            action="store_true",
-            help="Enable X11 forwarding of graphical HoloHub applications over SSH",
+            action=_DeprecatedDisplayFlagAction,
+            nargs=0,
+            default=False,
+            help="[DEPRECATED] X11 over SSH is now auto-detected from DISPLAY",
         )
         parser.add_argument(
             "--nsys-profile",
@@ -204,9 +216,10 @@ class HoloHubContainer:
         )
         parser.add_argument(
             "--enable-x11",
-            action="store_true",
+            action=_DeprecatedDisplayFlagAction,
+            nargs=0,
             default=True,
-            help="Enable X11 forwarding (default: True)",
+            help="[DEPRECATED] X11/Wayland forwarding is now auto-detected",
         )
         return parser
 

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -2285,8 +2285,6 @@ class HoloHubCLI:
         devcontainer_env_options = container.get_devcontainer_args(
             docker_opts=getattr(args, "docker_opts", None) or ""
         )
-        # Enable X11 access for Docker containers
-        container.enable_x11_access()
 
         devcontainer_content = holohub_cli_util.get_devcontainer_config(
             holohub_root=self.HOLOHUB_ROOT, project_name=args.project, dry_run=args.dryrun

--- a/utilities/cli/tests/test_container.py
+++ b/utilities/cli/tests/test_container.py
@@ -16,6 +16,7 @@
 
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -159,6 +160,75 @@ class TestHoloHubContainer(unittest.TestCase):
         self.assertTrue("run" in docker_run_call)
         self.assertTrue("--runtime" in docker_run_call and "nvidia" in docker_run_call)
         self.assertIn(self.container.image_names[0], docker_run_call)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_get_display_options_without_display_returns_empty(self):
+        """No display environment should skip display forwarding."""
+        self.assertEqual(self.container.get_display_options(True, False), [])
+
+    @patch.dict(os.environ, {"DISPLAY": ":0"}, clear=True)
+    def test_get_display_options_native_x11_uses_socket_and_xauth(self):
+        """Native X11 should mount the UNIX socket and a generated Xauthority file."""
+
+        def fake_run_command(cmd, **kwargs):
+            if cmd[:2] == ["xauth", "nlist"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="0100 0000 0000\n")
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with (
+            patch("utilities.cli.container.Path.is_dir", return_value=True),
+            patch("utilities.cli.container.shutil.which", return_value="/usr/bin/xauth"),
+            patch("utilities.cli.container.run_command", side_effect=fake_run_command) as mock_run,
+        ):
+            options = self.container.get_display_options(True, False)
+
+        self.assertIn("-v", options)
+        self.assertIn("/tmp/.X11-unix:/tmp/.X11-unix:ro", options)
+        self.assertIn("-e", options)
+        self.assertIn("DISPLAY", options)
+        self.assertTrue(any(opt.endswith(":ro") and ".docker.xauth-" in opt for opt in options))
+        self.assertTrue(any(opt.startswith("XAUTHORITY=") for opt in options))
+        self.assertEqual(mock_run.call_count, 2)
+        self.assertTrue(mock_run.call_args_list[1].kwargs["input"].startswith("ffff"))
+
+        xauth_mount = next(opt for opt in options if ".docker.xauth-" in opt)
+        xauth_path = Path(xauth_mount.split(":", 1)[0])
+        self.assertTrue(xauth_path.exists())
+        self.container._cleanup_display_temp_files()
+        self.assertFalse(xauth_path.exists())
+
+    @patch.dict(os.environ, {"DISPLAY": "localhost:10.0"}, clear=True)
+    def test_get_display_options_tcp_x11_skips_unix_socket(self):
+        """SSH-forwarded X11 uses TCP and should not mount /tmp/.X11-unix."""
+        with (
+            patch("utilities.cli.container.Path.is_dir", return_value=True),
+            patch("utilities.cli.container.shutil.which", return_value=None),
+        ):
+            options = self.container.get_display_options(True, True)
+
+        self.assertIn("DISPLAY", options)
+        self.assertNotIn("/tmp/.X11-unix:/tmp/.X11-unix:ro", options)
+        self.assertFalse(any(opt.startswith("XAUTHORITY=") for opt in options))
+
+    @patch.dict(
+        os.environ,
+        {
+            "WAYLAND_DISPLAY": "wayland-0",
+            "XDG_RUNTIME_DIR": "/run/user/1000",
+            "XDG_SESSION_TYPE": "wayland",
+        },
+        clear=True,
+    )
+    def test_get_display_options_wayland_forwards_runtime_dir(self):
+        """Wayland should forward XDG_RUNTIME_DIR (mounted) and WAYLAND_DISPLAY."""
+        with patch("utilities.cli.container.Path.is_dir", return_value=True):
+            options = self.container.get_display_options(True, False)
+
+        self.assertIn("XDG_SESSION_TYPE", options)
+        self.assertIn("WAYLAND_DISPLAY", options)
+        self.assertIn("XDG_RUNTIME_DIR", options)
+        self.assertIn("/run/user/1000:/run/user/1000", options)
+        self.assertNotIn("DISPLAY", options)
 
     @patch("subprocess.CompletedProcess")
     def test_dry_run(self, mock_completed_process):


### PR DESCRIPTION
## Summary

- Replace flag-driven display forwarding with environment-based auto-detection
- Drop `xhost +local:docker` in favor of cookie-based xauth (per-run mktemp, mode 0600, ro mount, FamilyWild rewrite)
- Add Wayland support (mount only the socket, not the whole runtime dir)
- Deprecate `--enable-x11` and `--ssh-x11` flags (kept as no-ops with a stderr warning, removal in a follow-up release)

## Why

The container CLI previously required `--ssh-x11` to handle SSH-forwarded displays and called `xhost +local:docker`, which opens X access to every process in the host docker group. It also used a stable `/tmp/.docker.xauth` path that races between concurrent users on the same host, and did not handle Wayland sessions.

The new code path detects the environment from `DISPLAY` and `WAYLAND_DISPLAY` and supports native local X11, SSH-forwarded TCP X11, Wayland, and Xwayland in a single code path with cookie-based auth scoped to the calling user:

- per-run mktemp xauth file (mode 0600, mounted read-only)
- SSH-forwarded displays (`localhost:N`, `127.0.0.1:N`, `[::1]:N`) skip the `/tmp/.X11-unix` mount
- Wayland: bind-mount only `$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY`, not the whole runtime dir
- cookie temp file removed after `docker run` returns
- no flag, no manual `xhost`, no manual `xauth merge`

Also adds `WAYLAND_DISPLAY` passthrough to the devcontainer environment so VS Code Remote Containers picks up the new path.

## Test plan

- [x] `python3 -m unittest utilities.cli.tests.test_container` (23 tests pass)
- [x] `./holohub run-container` on a native X11 desktop (`DISPLAY=:0`): GUI renders
- [ ] `./holohub run-container` over SSH `-X` (`DISPLAY=localhost:NN`): GUI renders
- [ ] `./holohub run-container` on a Wayland session (Ubuntu 24.04+): GUI renders via Xwayland
- [x] `./holohub run-container --ssh-x11` prints deprecation warning and still works
- [x] `./holohub run-container --enable-x11` prints deprecation warning and still works
- [x] Headless (no `DISPLAY`/`WAYLAND_DISPLAY`): runs without errors, info message logged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graphics forwarding now auto-detects and forwards X11 or Wayland from host DISPLAY or WAYLAND_DISPLAY (including devcontainer support).

* **Documentation**
  * Updated container graphics docs to reflect automatic detection.
  * Marked `--ssh-x11` and `--enable-x11` CLI options as deprecated.

* **Tests**
  * Added tests for no-display, native X11, TCP X11, and Wayland forwarding scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->