### PR TITLE
feat(cli): name and label containers started by the holohub CLI

### DIFF
--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -635,7 +635,7 @@ class HoloHubContainer:
             cmd.extend(shlex.split(docker_opts))
 
         if container_name:
-            cmd.extend(["--name", container_name, "--label", "holohub.cli"])
+            cmd.extend(["--name", container_name, "--label", "holohub.cli=true"])
 
         cmd.append(img)
         cmd.extend(extra_args)

--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -59,6 +59,14 @@ from .util import (
 SCCACHE_CONTAINER_DIR = "/.cache/sccache"
 
 
+def make_container_name(app_name: str, mode_name: Optional[str] = None) -> str:
+    """Return a deterministic Docker container name for a HoloHub app run."""
+    slug = app_name.replace("_", "-")
+    if mode_name:
+        return f"holohub-{slug}-{mode_name.replace('_', '-')}"
+    return f"holohub-{slug}"
+
+
 class HoloHubContainer:
     """
     Describes the container environment for a HoloHub project.
@@ -585,6 +593,7 @@ class HoloHubContainer:
         add_volumes: List[str] = None,
         enable_mps: bool = False,
         extra_args: List[str] = None,
+        container_name: Optional[str] = None,
     ) -> None:
         """Launch the container"""
 
@@ -624,6 +633,9 @@ class HoloHubContainer:
 
         if docker_opts:
             cmd.extend(shlex.split(docker_opts))
+
+        if container_name:
+            cmd.extend(["--name", container_name, "--label", "holohub.cli"])
 
         cmd.append(img)
         cmd.extend(extra_args)

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -46,7 +46,7 @@ from typing import List, Optional
 
 import utilities.cli.util as holohub_cli_util
 import utilities.metadata.gather_metadata as metadata_util
-from utilities.cli.container import HoloHubContainer
+from utilities.cli.container import HoloHubContainer, make_container_name
 from utilities.cli.util import Color
 from utilities.metadata.utils import get_schema_path, list_normalized_languages, normalize_language
 
@@ -817,6 +817,7 @@ class HoloHubCLI:
         # Resolve mode for docker_build_args / docker_run_args if project with modes
         build_args = args.build_args
         docker_opts = args.docker_opts
+        mode_name = None
         if args.project:
             project_data = self.find_project(args.project, language=getattr(args, "language", None))
             mode_name, mode_config = self.resolve_mode(project_data, getattr(args, "mode", None))
@@ -874,6 +875,7 @@ class HoloHubCLI:
             add_volumes=args.add_volume,
             enable_mps=getattr(args, "mps", False),
             extra_args=trailing_args,
+            container_name=make_container_name(args.project, mode_name) if args.project else None,
         )
 
     def handle_test(self, args: argparse.Namespace) -> None:
@@ -1556,6 +1558,7 @@ class HoloHubCLI:
                 add_volumes=getattr(args, "add_volume", None),
                 enable_mps=getattr(args, "mps", False),
                 extra_args=extra_args,
+                container_name=make_container_name(args.project, mode_name),
             )
 
     def handle_list(self, args: argparse.Namespace) -> None:


### PR DESCRIPTION
Assigns a deterministic --name (holohub-<app>[-<mode>]) and --label holohub.cli to every docker run invoked by the run and run-container commands. This lets external tooling identify and stop containers without guessing random Docker-assigned names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker containers launched by HoloHub now get deterministic, human-friendly names derived from the app and optional mode (underscores normalized to dashes).
  * Runs can accept a custom container name when needed.
  * Containers are automatically labeled for easier identification and namespacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->