### PR TITLE
fix(cli): stop holohub container on SIGINT/SIGTERM/SIGHUP

### DIFF
--- a/holohub
+++ b/holohub
@@ -16,4 +16,4 @@
 # limitations under the License.
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-PYTHONPATH="${PYTHONPATH}:${SCRIPT_DIR}" exec python3 "${SCRIPT_DIR}/utilities/cli/holohub.py" "$@"
+PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${SCRIPT_DIR}" exec python3 "${SCRIPT_DIR}/utilities/cli/holohub.py" "$@"

--- a/holohub
+++ b/holohub
@@ -16,4 +16,4 @@
 # limitations under the License.
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-PYTHONPATH=${PYTHONPATH}:${SCRIPT_DIR} python3 ${SCRIPT_DIR}/utilities/cli/holohub.py "$@"
+PYTHONPATH="${PYTHONPATH}:${SCRIPT_DIR}" exec python3 "${SCRIPT_DIR}/utilities/cli/holohub.py" "$@"

--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -60,23 +60,6 @@ from .util import (
 SCCACHE_CONTAINER_DIR = "/.cache/sccache"
 
 
-def _extract_docker_opt_value(docker_opts: str, flag: str) -> Optional[str]:
-    """Return the value of a docker option flag from a free-form options string."""
-    if not docker_opts or flag not in docker_opts:
-        return None
-    try:
-        tokens = shlex.split(docker_opts)
-    except ValueError:
-        return None
-    prefix = f"{flag}="
-    for i, token in enumerate(tokens):
-        if token == flag and i + 1 < len(tokens):
-            return tokens[i + 1]
-        if token.startswith(prefix):
-            return token.split("=", 1)[1]
-    return None
-
-
 def _read_container_id(cidfile: Path) -> Optional[str]:
     """Read a Docker container ID from a cidfile if Docker has written it."""
     try:
@@ -670,18 +653,12 @@ class HoloHubContainer:
         add_volumes = add_volumes or []
         extra_args = extra_args or []
 
-        explicit_cidfile = _extract_docker_opt_value(docker_opts, "--cidfile")
-        if explicit_cidfile:
-            cidfile = Path(explicit_cidfile)
-            cidfile_args: List[str] = []
-        else:
-            cidfile = Path(tempfile.gettempdir()) / f"holohub-container-{os.getpid()}.cid"
-            cidfile_args = ["--cidfile", str(cidfile)]
+        cidfile = Path(tempfile.gettempdir()) / f"holohub-container-{os.getpid()}.cid"
 
         cmd = [self.DOCKER_EXE, "run"]
 
         cmd.extend(self.get_basic_args())
-        cmd.extend(cidfile_args)
+        cmd.extend(["--cidfile", str(cidfile)])
         cmd.extend(self.get_security_args(as_root))
         cmd.extend(self.get_volume_args(add_volumes, enable_mps))
         cmd.extend(self.get_gpu_runtime_args())
@@ -719,8 +696,7 @@ class HoloHubContainer:
 
         # Docker refuses to start if --cidfile already exists; clear stale files
         # left by a prior crashed run that happened to share this PID.
-        if not explicit_cidfile:
-            cidfile.unlink(missing_ok=True)
+        cidfile.unlink(missing_ok=True)
 
         try:
             try:
@@ -750,15 +726,13 @@ class HoloHubContainer:
             # os.kill below may terminate the process before the outer `finally`
             # runs, so unlink the cidfile here. The `finally` remains as a fallback
             # for the SystemExit path.
-            if not explicit_cidfile:
-                cidfile.unlink(missing_ok=True)
+            cidfile.unlink(missing_ok=True)
             # Re-raise via default handler so we exit with the conventional 128+N status.
             signal.signal(sig, signal.SIG_DFL)
             os.kill(os.getpid(), sig)
             sys.exit(128 + sig)
         finally:
-            if not explicit_cidfile:
-                cidfile.unlink(missing_ok=True)
+            cidfile.unlink(missing_ok=True)
 
     def get_basic_args(self) -> List[str]:
         """Basic container runtime arguments"""

--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -38,6 +38,7 @@ from .util import (
     fatal,
     find_hsdk_build_rel_dir,
     get_arch_gpu_str,
+    get_cli_arg_value,
     get_compute_capacity,
     get_cuda_tag,
     get_current_branch_slug,
@@ -670,12 +671,24 @@ class HoloHubContainer:
         add_volumes = add_volumes or []
         extra_args = extra_args or []
 
-        cidfile = Path(tempfile.gettempdir()) / f"holohub-container-{os.getpid()}.cid"
+        # If the caller already supplies --cidfile (via DEFAULT_DOCKER_RUN_ARGS or
+        # docker_opts), use that path for cleanup and skip injecting our own —
+        # Docker rejects duplicate --cidfile flags.
+        default_run_args = shlex.split(HoloHubContainer.DEFAULT_DOCKER_RUN_ARGS or "")
+        extra_run_args = shlex.split(docker_opts or "")
+        explicit_cidfile = get_cli_arg_value(default_run_args + extra_run_args, "--cidfile")
+        internal_cidfile: Optional[Path] = None
+        if explicit_cidfile:
+            cidfile = Path(explicit_cidfile)
+        else:
+            internal_cidfile = Path(tempfile.gettempdir()) / f"holohub-container-{os.getpid()}.cid"
+            cidfile = internal_cidfile
 
         cmd = [self.DOCKER_EXE, "run"]
 
         cmd.extend(self.get_basic_args())
-        cmd.extend(["--cidfile", str(cidfile)])
+        if internal_cidfile is not None:
+            cmd.extend(["--cidfile", str(internal_cidfile)])
         cmd.extend(self.get_security_args(as_root))
         cmd.extend(self.get_volume_args(add_volumes, enable_mps))
         cmd.extend(self.get_gpu_runtime_args())
@@ -694,12 +707,9 @@ class HoloHubContainer:
         if local_sdk_root or os.environ.get("HOLOSCAN_SDK_ROOT"):
             cmd.extend(self.get_local_sdk_options(local_sdk_root))
 
-        # Add default docker run arguments
-        if HoloHubContainer.DEFAULT_DOCKER_RUN_ARGS:
-            cmd.extend(shlex.split(HoloHubContainer.DEFAULT_DOCKER_RUN_ARGS))
-
-        if docker_opts:
-            cmd.extend(shlex.split(docker_opts))
+        # Default docker run arguments and caller-supplied docker_opts (parsed above).
+        cmd.extend(default_run_args)
+        cmd.extend(extra_run_args)
 
         cmd.append(img)
         cmd.extend(extra_args)
@@ -713,9 +723,11 @@ class HoloHubContainer:
                 run_command(cmd, dry_run=self.dryrun)
                 return
 
-            # Docker refuses to start if --cidfile already exists; clear stale files
-            # left by a prior crashed run that happened to share this PID.
-            cidfile.unlink(missing_ok=True)
+            # Docker refuses to start if --cidfile already exists; clear stale internal
+            # files left by a prior crashed run that happened to share this PID. Caller-
+            # provided cidfiles are the caller's responsibility — never remove them.
+            if internal_cidfile is not None:
+                internal_cidfile.unlink(missing_ok=True)
 
             try:
                 try:
@@ -744,14 +756,16 @@ class HoloHubContainer:
                     )
                 # os.kill below may terminate the process before the outer `finally`
                 # blocks run, so unlink the cidfile and clean display temp files here.
-                cidfile.unlink(missing_ok=True)
+                if internal_cidfile is not None:
+                    internal_cidfile.unlink(missing_ok=True)
                 self._cleanup_display_temp_files()
                 # Re-raise via default handler so we exit with the conventional 128+N status.
                 signal.signal(sig, signal.SIG_DFL)
                 os.kill(os.getpid(), sig)
                 sys.exit(128 + sig)
             finally:
-                cidfile.unlink(missing_ok=True)
+                if internal_cidfile is not None:
+                    internal_cidfile.unlink(missing_ok=True)
         finally:
             self._cleanup_display_temp_files()
 

--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -20,6 +20,7 @@ import os
 import re
 import shlex
 import shutil
+import signal
 import stat
 import subprocess
 import sys
@@ -57,6 +58,74 @@ from .util import (
 )
 
 SCCACHE_CONTAINER_DIR = "/.cache/sccache"
+
+
+def _extract_docker_opt_value(docker_opts: str, flag: str) -> Optional[str]:
+    """Return the value of a docker option flag from a free-form options string."""
+    if not docker_opts or flag not in docker_opts:
+        return None
+    try:
+        tokens = shlex.split(docker_opts)
+    except ValueError:
+        return None
+    prefix = f"{flag}="
+    for i, token in enumerate(tokens):
+        if token == flag and i + 1 < len(tokens):
+            return tokens[i + 1]
+        if token.startswith(prefix):
+            return token.split("=", 1)[1]
+    return None
+
+
+def _read_container_id(cidfile: Path) -> Optional[str]:
+    """Read a Docker container ID from a cidfile if Docker has written it."""
+    try:
+        container_id = cidfile.read_text().strip()
+    except OSError:
+        return None
+    return container_id or None
+
+
+class _ContainerTerminationSignal(Exception):
+    """Raised from the signal handler to return control to the parent CLI."""
+
+    def __init__(self, signum: int):
+        self.signum = signum
+        super().__init__(signum)
+
+
+class _ContainerTerminationHandler:
+    """Record termination signals so the parent CLI can clean up its container.
+
+    The handler intentionally only records the signal; it does not run subprocesses
+    from the signal context. The caller is expected to perform cleanup (e.g.
+    `docker stop`) on the main thread after the guarded block exits.
+    """
+
+    def __init__(self):
+        self._previous_handlers = {}
+
+    def __enter__(self):
+        for signal_name in ("SIGINT", "SIGTERM", "SIGHUP"):
+            signum = getattr(signal, signal_name, None)
+            if signum is None:
+                continue
+            try:
+                self._previous_handlers[signum] = signal.getsignal(signum)
+                signal.signal(signum, self._handle_signal)
+            except (OSError, RuntimeError, ValueError):
+                continue
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        for signum, handler in self._previous_handlers.items():
+            try:
+                signal.signal(signum, handler)
+            except (OSError, RuntimeError, ValueError):
+                continue
+
+    def _handle_signal(self, signum, frame) -> None:
+        raise _ContainerTerminationSignal(signum)
 
 
 class HoloHubContainer:
@@ -598,9 +667,18 @@ class HoloHubContainer:
         add_volumes = add_volumes or []
         extra_args = extra_args or []
 
+        explicit_cidfile = _extract_docker_opt_value(docker_opts, "--cidfile")
+        if explicit_cidfile:
+            cidfile = Path(explicit_cidfile)
+            cidfile_args: List[str] = []
+        else:
+            cidfile = Path(tempfile.gettempdir()) / f"holohub-container-{os.getpid()}.cid"
+            cidfile_args = ["--cidfile", str(cidfile)]
+
         cmd = [self.DOCKER_EXE, "run"]
 
         cmd.extend(self.get_basic_args())
+        cmd.extend(cidfile_args)
         cmd.extend(self.get_security_args(as_root))
         cmd.extend(self.get_volume_args(add_volumes, enable_mps))
         cmd.extend(self.get_gpu_runtime_args())
@@ -632,7 +710,45 @@ class HoloHubContainer:
             cmd_list = [f'"{arg}"' if " " in str(arg) else str(arg) for arg in cmd]
             print(f"Launch command: {' '.join(cmd_list)}")
 
-        run_command(cmd, dry_run=self.dryrun)
+        if self.dryrun:
+            run_command(cmd, dry_run=self.dryrun)
+            return
+
+        # Docker refuses to start if --cidfile already exists; clear stale files
+        # left by a prior crashed run that happened to share this PID.
+        if not explicit_cidfile:
+            cidfile.unlink(missing_ok=True)
+
+        try:
+            try:
+                with _ContainerTerminationHandler():
+                    run_command(cmd)
+                return
+            except _ContainerTerminationSignal as exc:
+                sig = exc.signum
+
+            try:
+                signal_name = signal.Signals(sig).name
+            except ValueError:
+                signal_name = str(sig)
+            container_id = _read_container_id(cidfile)
+            if container_id:
+                warn(f"Received {signal_name}; stopping HoloHub container {container_id}")
+                subprocess.run(
+                    [self.DOCKER_EXE, "stop", "--time", "10", container_id],
+                    check=False,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            else:
+                warn(f"Received {signal_name}; no HoloHub container ID was written to {cidfile}")
+            # Re-raise via default handler so we exit with the conventional 128+N status.
+            signal.signal(sig, signal.SIG_DFL)
+            os.kill(os.getpid(), sig)
+            sys.exit(128 + sig)
+        finally:
+            if not explicit_cidfile:
+                cidfile.unlink(missing_ok=True)
 
     def get_basic_args(self) -> List[str]:
         """Basic container runtime arguments"""

--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -119,9 +119,12 @@ class _ContainerTerminationHandler:
 
     def __exit__(self, exc_type, exc, tb):
         for signum, handler in self._previous_handlers.items():
+            # signal.getsignal returns None for natively-installed handlers,
+            # and signal.signal(None) raises TypeError — swallow it so we don't
+            # mask the original termination exception during cleanup.
             try:
                 signal.signal(signum, handler)
-            except (OSError, RuntimeError, ValueError):
+            except (OSError, RuntimeError, TypeError, ValueError):
                 continue
 
     def _handle_signal(self, signum, frame) -> None:
@@ -738,10 +741,17 @@ class HoloHubContainer:
                     [self.DOCKER_EXE, "stop", "--time", "10", container_id],
                     check=False,
                     stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
                 )
             else:
-                warn(f"Received {signal_name}; no HoloHub container ID was written to {cidfile}")
+                warn(
+                    f"Received {signal_name}; no container ID was written to {cidfile} yet — "
+                    "the container may still be starting. Run `docker ps` to check and stop it manually."
+                )
+            # os.kill below may terminate the process before the outer `finally`
+            # runs, so unlink the cidfile here. The `finally` remains as a fallback
+            # for the SystemExit path.
+            if not explicit_cidfile:
+                cidfile.unlink(missing_ok=True)
             # Re-raise via default handler so we exit with the conventional 128+N status.
             signal.signal(sig, signal.SIG_DFL)
             os.kill(os.getpid(), sig)

--- a/utilities/cli/tests/test_cli.py
+++ b/utilities/cli/tests/test_cli.py
@@ -457,6 +457,20 @@ class TestHoloHubCLI(unittest.TestCase):
         self.assertIn("-DHOLOHUB_BUILD_OPERATORS", cmake_args_str)
         self.assertIn(f'"{operators}"', cmake_args_str)
 
+    def test_holohub_wrapper_execs_python_cli(self):
+        """The shell wrapper should not stay as a parent process of the Python CLI."""
+        holohub_script = Path(os.getcwd()) / "holohub"
+        if not holohub_script.exists():
+            self.skipTest("holohub bash script not found")
+
+        commands = [
+            line.strip()
+            for line in holohub_script.read_text().splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+        self.assertIn(" exec python3 ", f" {commands[-1]} ")
+        self.assertIn('"${SCRIPT_DIR}/utilities/cli/holohub.py"', commands[-1])
+
     def test_custom_script_name_entry_point(self):
         """Test that CLI behaves as if it's called with the custom script name"""
         import subprocess

--- a/utilities/cli/tests/test_container.py
+++ b/utilities/cli/tests/test_container.py
@@ -157,9 +157,7 @@ class TestHoloHubContainer(unittest.TestCase):
         self.assertIsNotNone(docker_run_call, "Docker run command not found in mock calls")
         self.assertTrue("docker" in docker_run_call)
         self.assertTrue("run" in docker_run_call)
-        self.assertNotIn("--name", docker_run_call)
         self.assertIn("--cidfile", docker_run_call)
-        self.assertNotIn("--label", docker_run_call)
         self.assertTrue("--runtime" in docker_run_call and "nvidia" in docker_run_call)
         self.assertIn(self.container.image_names[0], docker_run_call)
 
@@ -227,6 +225,78 @@ class TestHoloHubContainer(unittest.TestCase):
             mock_subprocess_run.call_args[0][0],
             ["docker", "stop", "--time", "10", "container123"],
         )
+        mock_kill.assert_called_once_with(os.getpid(), 15)
+
+    @patch("utilities.cli.container.check_nvidia_ctk")
+    @patch("utilities.cli.container.get_image_pythonpath")
+    @patch("utilities.cli.container.os.kill")
+    @patch("utilities.cli.container.signal.signal")
+    @patch("utilities.cli.container.subprocess.run")
+    @patch("utilities.cli.container.run_command")
+    @patch("subprocess.check_output")
+    def test_run_warns_when_cidfile_empty_on_signal(
+        self,
+        mock_check_output,
+        mock_run_command,
+        mock_subprocess_run,
+        _mock_signal,
+        mock_kill,
+        mock_get_image_pythonpath,
+        mock_check_nvidia_ctk,
+    ):
+        """If Docker hasn't written the cidfile yet, no docker stop is issued."""
+        mock_check_nvidia_ctk.return_value = None
+        mock_check_output.return_value = ""
+        mock_get_image_pythonpath.return_value = ""
+
+        mock_run_command.side_effect = _ContainerTerminationSignal(2)
+
+        with self.assertRaises(SystemExit) as raised:
+            self.container.run()
+
+        self.assertEqual(raised.exception.code, 128 + 2)
+        mock_subprocess_run.assert_not_called()
+        mock_kill.assert_called_once_with(os.getpid(), 2)
+
+    @patch("utilities.cli.container.check_nvidia_ctk")
+    @patch("utilities.cli.container.get_image_pythonpath")
+    @patch("utilities.cli.container.os.kill")
+    @patch("utilities.cli.container.signal.signal")
+    @patch("utilities.cli.container.subprocess.run")
+    @patch("utilities.cli.container.run_command")
+    @patch("subprocess.check_output")
+    def test_run_preserves_explicit_cidfile_on_signal(
+        self,
+        mock_check_output,
+        mock_run_command,
+        mock_subprocess_run,
+        _mock_signal,
+        mock_kill,
+        mock_get_image_pythonpath,
+        mock_check_nvidia_ctk,
+    ):
+        """An explicit cidfile must not be unlinked by signal cleanup."""
+        mock_check_nvidia_ctk.return_value = None
+        mock_check_output.return_value = ""
+        mock_get_image_pythonpath.return_value = ""
+
+        explicit_path = Path(self.test_dir) / "external.cid"
+
+        def interrupt_after_cidfile(cmd, **_kwargs):
+            explicit_path.write_text("external-id\n")
+            raise _ContainerTerminationSignal(15)
+
+        mock_run_command.side_effect = interrupt_after_cidfile
+
+        with self.assertRaises(SystemExit):
+            self.container.run(docker_opts=f"--cidfile {explicit_path}")
+
+        self.assertEqual(
+            mock_subprocess_run.call_args[0][0],
+            ["docker", "stop", "--time", "10", "external-id"],
+        )
+        # The explicit cidfile is owned by the caller; we must not delete it.
+        self.assertTrue(explicit_path.exists())
         mock_kill.assert_called_once_with(os.getpid(), 15)
 
     @patch("subprocess.CompletedProcess")

--- a/utilities/cli/tests/test_container.py
+++ b/utilities/cli/tests/test_container.py
@@ -25,7 +25,7 @@ from unittest.mock import patch
 # Add the utilities directory to the Python path
 sys.path.append(str(Path(os.getcwd()) / "utilities"))
 
-from utilities.cli.container import HoloHubContainer
+from utilities.cli.container import HoloHubContainer, _ContainerTerminationSignal
 from utilities.cli.util import get_cuda_tag, get_default_cuda_version
 
 
@@ -157,8 +157,77 @@ class TestHoloHubContainer(unittest.TestCase):
         self.assertIsNotNone(docker_run_call, "Docker run command not found in mock calls")
         self.assertTrue("docker" in docker_run_call)
         self.assertTrue("run" in docker_run_call)
+        self.assertNotIn("--name", docker_run_call)
+        self.assertIn("--cidfile", docker_run_call)
+        self.assertNotIn("--label", docker_run_call)
         self.assertTrue("--runtime" in docker_run_call and "nvidia" in docker_run_call)
         self.assertIn(self.container.image_names[0], docker_run_call)
+
+    @patch("utilities.cli.container.check_nvidia_ctk")
+    @patch("utilities.cli.container.get_image_pythonpath")
+    @patch("subprocess.run")
+    @patch("subprocess.check_output")
+    def test_run_respects_explicit_cidfile(
+        self, mock_check_output, mock_run, mock_get_image_pythonpath, mock_check_nvidia_ctk
+    ):
+        """An explicit Docker cidfile should not be overwritten."""
+        mock_check_nvidia_ctk.return_value = None
+        mock_check_output.return_value = ""
+        mock_get_image_pythonpath.return_value = ""
+        self.container.run(docker_opts="--cidfile /tmp/custom-holohub.cid")
+
+        docker_run_call = None
+        for call in mock_run.call_args_list:
+            cmd = call[0][0]
+            if isinstance(cmd, list) and len(cmd) > 0 and cmd[0] == "docker" and "run" in cmd:
+                docker_run_call = cmd
+                break
+
+        self.assertIsNotNone(docker_run_call, "Docker run command not found in mock calls")
+        self.assertEqual(docker_run_call.count("--cidfile"), 1)
+        self.assertIn("/tmp/custom-holohub.cid", docker_run_call)
+
+    @patch("utilities.cli.container.check_nvidia_ctk")
+    @patch("utilities.cli.container.get_image_pythonpath")
+    @patch("utilities.cli.container.os.kill")
+    @patch("utilities.cli.container.signal.signal")
+    @patch("utilities.cli.container.subprocess.run")
+    @patch("utilities.cli.container.run_command")
+    @patch("subprocess.check_output")
+    def test_run_stops_cidfile_container_on_signal(
+        self,
+        mock_check_output,
+        mock_run_command,
+        mock_subprocess_run,
+        _mock_signal,
+        mock_kill,
+        mock_get_image_pythonpath,
+        mock_check_nvidia_ctk,
+    ):
+        """Signal cleanup should stop the exact container ID Docker wrote."""
+        mock_check_nvidia_ctk.return_value = None
+        mock_check_output.return_value = ""
+        mock_get_image_pythonpath.return_value = ""
+
+        def interrupt_after_cidfile(cmd, **_kwargs):
+            if "--cidfile" not in cmd:
+                return None
+            cidfile = Path(cmd[cmd.index("--cidfile") + 1])
+            cidfile.write_text("container123\n")
+            raise _ContainerTerminationSignal(15)
+
+        mock_run_command.side_effect = interrupt_after_cidfile
+
+        with self.assertRaises(SystemExit) as raised:
+            self.container.run()
+
+        self.assertEqual(raised.exception.code, 128 + 15)
+        mock_subprocess_run.assert_called_once()
+        self.assertEqual(
+            mock_subprocess_run.call_args[0][0],
+            ["docker", "stop", "--time", "10", "container123"],
+        )
+        mock_kill.assert_called_once_with(os.getpid(), 15)
 
     @patch("subprocess.CompletedProcess")
     def test_dry_run(self, mock_completed_process):
@@ -167,6 +236,7 @@ class TestHoloHubContainer(unittest.TestCase):
         self.container.run()
         cmd = mock_completed_process.call_args[0][0]
         self.assertIn(self.container.image_names[0], cmd)
+        self.assertIn("--cidfile", cmd)
         self.assertIn("c 81:* rmw", cmd)
         self.container.dryrun = False
 

--- a/utilities/cli/tests/test_container.py
+++ b/utilities/cli/tests/test_container.py
@@ -27,7 +27,7 @@ from unittest.mock import patch
 sys.path.append(str(Path(os.getcwd()) / "utilities"))
 
 from utilities.cli.container import HoloHubContainer, _ContainerTerminationSignal
-from utilities.cli.util import get_cuda_tag, get_default_cuda_version
+from utilities.cli.util import get_cli_arg_value, get_cuda_tag, get_default_cuda_version
 
 
 class TestHoloHubContainer(unittest.TestCase):
@@ -162,6 +162,7 @@ class TestHoloHubContainer(unittest.TestCase):
         self.assertTrue("--runtime" in docker_run_call and "nvidia" in docker_run_call)
         self.assertIn(self.container.image_names[0], docker_run_call)
 
+    @patch.dict(os.environ, {}, clear=True)
     @patch("utilities.cli.container.check_nvidia_ctk")
     @patch("utilities.cli.container.get_image_pythonpath")
     @patch("utilities.cli.container.os.kill")
@@ -204,6 +205,51 @@ class TestHoloHubContainer(unittest.TestCase):
         )
         mock_kill.assert_called_once_with(os.getpid(), 15)
 
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("utilities.cli.container.check_nvidia_ctk")
+    @patch("utilities.cli.container.get_image_pythonpath")
+    @patch("utilities.cli.container.os.kill")
+    @patch("utilities.cli.container.signal.signal")
+    @patch("utilities.cli.container.subprocess.run")
+    @patch("utilities.cli.container.run_command")
+    @patch("subprocess.check_output")
+    def test_run_stops_user_cidfile_container_on_signal(
+        self,
+        mock_check_output,
+        mock_run_command,
+        mock_subprocess_run,
+        _mock_signal,
+        mock_kill,
+        mock_get_image_pythonpath,
+        mock_check_nvidia_ctk,
+    ):
+        """Signal cleanup should follow a caller-provided Docker --cidfile and not
+        inject our own (Docker rejects duplicate --cidfile flags)."""
+        mock_check_nvidia_ctk.return_value = None
+        mock_check_output.return_value = ""
+        mock_get_image_pythonpath.return_value = ""
+        user_cidfile = self.test_dir_path / "user.cid"
+
+        def interrupt_after_cidfile(cmd, **_kwargs):
+            self.assertEqual(cmd.count("--cidfile"), 1)
+            self.assertEqual(get_cli_arg_value(cmd, "--cidfile"), str(user_cidfile))
+            user_cidfile.write_text("user-container\n")
+            raise _ContainerTerminationSignal(15)
+
+        mock_run_command.side_effect = interrupt_after_cidfile
+
+        with self.assertRaises(SystemExit) as raised:
+            self.container.run(docker_opts=f"--cidfile {user_cidfile}")
+
+        self.assertEqual(raised.exception.code, 128 + 15)
+        self.assertEqual(
+            mock_subprocess_run.call_args[0][0],
+            ["docker", "stop", "--time", "10", "user-container"],
+        )
+        self.assertTrue(user_cidfile.exists())
+        mock_kill.assert_called_once_with(os.getpid(), 15)
+
+    @patch.dict(os.environ, {}, clear=True)
     @patch("utilities.cli.container.check_nvidia_ctk")
     @patch("utilities.cli.container.get_image_pythonpath")
     @patch("utilities.cli.container.os.kill")

--- a/utilities/cli/tests/test_container.py
+++ b/utilities/cli/tests/test_container.py
@@ -163,30 +163,6 @@ class TestHoloHubContainer(unittest.TestCase):
 
     @patch("utilities.cli.container.check_nvidia_ctk")
     @patch("utilities.cli.container.get_image_pythonpath")
-    @patch("subprocess.run")
-    @patch("subprocess.check_output")
-    def test_run_respects_explicit_cidfile(
-        self, mock_check_output, mock_run, mock_get_image_pythonpath, mock_check_nvidia_ctk
-    ):
-        """An explicit Docker cidfile should not be overwritten."""
-        mock_check_nvidia_ctk.return_value = None
-        mock_check_output.return_value = ""
-        mock_get_image_pythonpath.return_value = ""
-        self.container.run(docker_opts="--cidfile /tmp/custom-holohub.cid")
-
-        docker_run_call = None
-        for call in mock_run.call_args_list:
-            cmd = call[0][0]
-            if isinstance(cmd, list) and len(cmd) > 0 and cmd[0] == "docker" and "run" in cmd:
-                docker_run_call = cmd
-                break
-
-        self.assertIsNotNone(docker_run_call, "Docker run command not found in mock calls")
-        self.assertEqual(docker_run_call.count("--cidfile"), 1)
-        self.assertIn("/tmp/custom-holohub.cid", docker_run_call)
-
-    @patch("utilities.cli.container.check_nvidia_ctk")
-    @patch("utilities.cli.container.get_image_pythonpath")
     @patch("utilities.cli.container.os.kill")
     @patch("utilities.cli.container.signal.signal")
     @patch("utilities.cli.container.subprocess.run")
@@ -257,47 +233,6 @@ class TestHoloHubContainer(unittest.TestCase):
         self.assertEqual(raised.exception.code, 128 + 2)
         mock_subprocess_run.assert_not_called()
         mock_kill.assert_called_once_with(os.getpid(), 2)
-
-    @patch("utilities.cli.container.check_nvidia_ctk")
-    @patch("utilities.cli.container.get_image_pythonpath")
-    @patch("utilities.cli.container.os.kill")
-    @patch("utilities.cli.container.signal.signal")
-    @patch("utilities.cli.container.subprocess.run")
-    @patch("utilities.cli.container.run_command")
-    @patch("subprocess.check_output")
-    def test_run_preserves_explicit_cidfile_on_signal(
-        self,
-        mock_check_output,
-        mock_run_command,
-        mock_subprocess_run,
-        _mock_signal,
-        mock_kill,
-        mock_get_image_pythonpath,
-        mock_check_nvidia_ctk,
-    ):
-        """An explicit cidfile must not be unlinked by signal cleanup."""
-        mock_check_nvidia_ctk.return_value = None
-        mock_check_output.return_value = ""
-        mock_get_image_pythonpath.return_value = ""
-
-        explicit_path = Path(self.test_dir) / "external.cid"
-
-        def interrupt_after_cidfile(cmd, **_kwargs):
-            explicit_path.write_text("external-id\n")
-            raise _ContainerTerminationSignal(15)
-
-        mock_run_command.side_effect = interrupt_after_cidfile
-
-        with self.assertRaises(SystemExit):
-            self.container.run(docker_opts=f"--cidfile {explicit_path}")
-
-        self.assertEqual(
-            mock_subprocess_run.call_args[0][0],
-            ["docker", "stop", "--time", "10", "external-id"],
-        )
-        # The explicit cidfile is owned by the caller; we must not delete it.
-        self.assertTrue(explicit_path.exists())
-        mock_kill.assert_called_once_with(os.getpid(), 15)
 
     @patch("subprocess.CompletedProcess")
     def test_dry_run(self, mock_completed_process):

--- a/utilities/cli/tests/test_util.py
+++ b/utilities/cli/tests/test_util.py
@@ -65,5 +65,29 @@ class TestUtilGitHelpers(unittest.TestCase):
         mock_run_info_command.assert_called()
 
 
+class TestGetCliArgValue(unittest.TestCase):
+    def test_returns_none_when_flag_absent(self):
+        self.assertIsNone(util.get_cli_arg_value(["docker", "run", "image"], "--cidfile"))
+
+    def test_space_form(self):
+        args = ["docker", "run", "--cidfile", "/tmp/a.cid", "image"]
+        self.assertEqual(util.get_cli_arg_value(args, "--cidfile"), "/tmp/a.cid")
+
+    def test_equals_form(self):
+        args = ["docker", "run", "--cidfile=/tmp/a.cid", "image"]
+        self.assertEqual(util.get_cli_arg_value(args, "--cidfile"), "/tmp/a.cid")
+
+    def test_last_occurrence_wins(self):
+        args = ["--cidfile", "/tmp/first.cid", "--cidfile=/tmp/last.cid"]
+        self.assertEqual(util.get_cli_arg_value(args, "--cidfile"), "/tmp/last.cid")
+
+    def test_dangling_flag_returns_none(self):
+        self.assertIsNone(util.get_cli_arg_value(["--cidfile"], "--cidfile"))
+
+    def test_does_not_match_prefix_collision(self):
+        # "--cidfilex" should not satisfy a "--cidfile" lookup.
+        self.assertIsNone(util.get_cli_arg_value(["--cidfilex=/tmp/a.cid"], "--cidfile"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -1035,6 +1035,28 @@ def build_holohub_path_mapping(
     return path_mapping
 
 
+def get_cli_arg_value(args: List[str], flag: str) -> Optional[str]:
+    """Return the last value of ``flag`` in a CLI argument list.
+
+    Supports both ``--flag value`` and ``--flag=value`` forms. Returns ``None``
+    if the flag is not present. The last-wins rule mirrors typical CLI behavior
+    where later occurrences override earlier ones.
+    """
+    value: Optional[str] = None
+    prefix = f"{flag}="
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == flag and i + 1 < len(args):
+            value = args[i + 1]
+            i += 2
+            continue
+        if arg.startswith(prefix):
+            value = arg.removeprefix(prefix)
+        i += 1
+    return value
+
+
 def docker_args_to_devcontainer_format(docker_args: List[str]) -> List[str]:
     """Convert Docker argument format to devcontainer format (--flag value -> --flag=value)"""
     standalone = {"--rm", "--init", "--no-cache"}
@@ -1061,20 +1083,12 @@ def get_entrypoint_command_args(
 ) -> tuple[str, List[str]]:
     """Determine how to execute a shell command in a Docker container."""
 
-    # Check if user provided a custom entrypoint
-    entrypoint = None
-    if "--entrypoint" in docker_opts:
-        try:
-            tokens = shlex.split(docker_opts)
-            for i, token in enumerate(tokens):
-                if token == "--entrypoint" and i + 1 < len(tokens):
-                    entrypoint = tokens[i + 1]
-                    break
-                elif token.startswith("--entrypoint="):
-                    entrypoint = token.split("=", 1)[1]
-                    break
-        except ValueError:
-            pass
+    # Check if user provided a custom entrypoint.
+    entrypoint: Optional[str] = None
+    try:
+        entrypoint = get_cli_arg_value(shlex.split(docker_opts), "--entrypoint")
+    except ValueError:
+        pass
 
     if entrypoint:  # If user provided a custom entrypoint
         if entrypoint in ["/bin/sh", "/bin/bash", "sh", "bash"]:


### PR DESCRIPTION
## Summary
- Capture the launched container's ID via Docker `--cidfile` and `docker stop` it when the CLI is signalled, so killing the CLI no longer leaves an orphan container running.
- Re-raise the signal via the default handler after cleanup so the CLI exits with the conventional 128+N status.
- Honor a user-supplied `--cidfile` in `docker_opts` so external orchestration is not overwritten.

## Test plan
- [x] `python -m pytest utilities/cli/tests/test_container.py`
- [x] Manual: launch a container via `holohub run`, send SIGINT, confirm the container is gone (`docker ps`).
- [x] Manual: pass `--cidfile /tmp/custom.cid` via `docker_opts` and confirm it is not overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Containers now gracefully handle termination signals, automatically stopping and cleaning up temporary resources.

* **Bug Fixes**
  * Improved script path handling with better quoting for enhanced reliability.

* **Tests**
  * Added test coverage for shell wrapper invocation and signal-based container lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->