### PR TITLE
advanced_network: Workaround for CMake 3.31 installation

### DIFF
--- a/operators/advanced_network/Dockerfile
+++ b/operators/advanced_network/Dockerfile
@@ -46,8 +46,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm "$KW_KEYRING" \
     && apt-get install --no-install-recommends -y \
         kitware-archive-keyring \
-        cmake="3.*" \
-        cmake-data="3.*" \
+        cmake="3.31.11*" \
+        cmake-data="3.31.11*" \
     && rm -rf /var/lib/apt/lists/*
 
 # ============================================================


### PR DESCRIPTION
## Background

`apt install cmake=3.*` fails with latest CMake packages. See https://gitlab.kitware.com/cmake/cmake/-/work_items/27775

## Workaround

Pin to 3.31.11 pending fix for failing CMake 3.31.12 installation.

Unblocks `advanced_network` containerized build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Locked build tool versions to specific releases for improved build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->