### PR TITLE
advanced_network: Fix CMake installation

### DIFF
--- a/operators/advanced_network/advanced_network/managers/rdma/CMakeLists.txt
+++ b/operators/advanced_network/advanced_network/managers/rdma/CMakeLists.txt
@@ -16,7 +16,10 @@ cmake_minimum_required(VERSION 3.20)
 
 message(STATUS "PROJECT_NAME: ${PROJECT_NAME}")
 
-target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+include(GNUInstallDirs)
+target_include_directories(${PROJECT_NAME} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 target_sources(${PROJECT_NAME} PRIVATE adv_network_rdma_mgr.cpp)
 


### PR DESCRIPTION
## Background

Addresses failure to install holoscan_networking RDMA build.

## Overview

Previous: CMAKE_SOURCE_DIR is an absolute path in the build environment, not suitable for portable installation and results in CMake install-time error

Updated: Use CMake generator expressions to rely on absolute path at build, relative path at installation time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-visible changes.** This release includes internal build system enhancements to improve the packaging and installation process for development components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->