### PR TITLE
feat(cli): skip xauth setup when peer-credential auth is sufficient

### DIFF
--- a/utilities/cli/container.py
+++ b/utilities/cli/container.py
@@ -941,7 +941,37 @@ class HoloHubContainer:
     def _is_ssh_x11_display(display: str) -> bool:
         return display.startswith(("localhost:", "127.0.0.1:", "[::1]:", "::1:"))
 
+    @staticmethod
+    def _peer_creds_sufficient(display: str) -> bool:
+        """Probe whether the X server already accepts connections without a cookie.
+
+        Tries to query the X server with `XAUTHORITY=/dev/null` so Xlib has no
+        cookies to offer; if the query still succeeds, a non-cookie auth family
+        (typically SI:localuser) is granting access. The container runs as the
+        same UID via `-u $(id -u):$(id -g)`, so the same auth applies inside.
+        """
+        if not shutil.which("xset"):
+            return False
+        try:
+            return (
+                subprocess.run(
+                    ["xset", "-display", display, "q"],
+                    env={**os.environ, "XAUTHORITY": "/dev/null"},
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=2,
+                ).returncode
+                == 0
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+
     def _get_xauth_options(self, display: str) -> List[str]:
+        # Run the read-only probe even in dryrun so the printed command reflects
+        # the path a real launch would take.
+        if self._peer_creds_sufficient(display):
+            return []
+
         if not shutil.which("xauth"):
             warn(
                 "xauth not found on host; install xauth (or x11-xauth) so X11 "

--- a/utilities/cli/tests/test_container.py
+++ b/utilities/cli/tests/test_container.py
@@ -286,6 +286,61 @@ class TestHoloHubContainer(unittest.TestCase):
         """No display environment should skip display forwarding."""
         self.assertEqual(self.container.get_display_options(True, False), [])
 
+    def test_peer_creds_sufficient_returns_false_when_xset_missing(self):
+        """If xset is not on PATH, peer-creds probe must short-circuit to False."""
+        with patch("utilities.cli.container.shutil.which", return_value=None):
+            self.assertFalse(HoloHubContainer._peer_creds_sufficient(":0"))
+
+    def test_peer_creds_sufficient_true_when_probe_exits_zero(self):
+        """A successful no-cookie xset query means the server accepts us already."""
+        with (
+            patch("utilities.cli.container.shutil.which", return_value="/usr/bin/xset"),
+            patch("utilities.cli.container.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+            self.assertTrue(HoloHubContainer._peer_creds_sufficient(":0"))
+            # Probe must override XAUTHORITY so the server cannot pick up a cached cookie.
+            self.assertEqual(mock_run.call_args.kwargs["env"]["XAUTHORITY"], "/dev/null")
+            self.assertEqual(mock_run.call_args.kwargs["timeout"], 2)
+
+    def test_peer_creds_sufficient_false_when_probe_exits_nonzero(self):
+        """Probe returning non-zero means cookie-based auth is still needed."""
+        with (
+            patch("utilities.cli.container.shutil.which", return_value="/usr/bin/xset"),
+            patch("utilities.cli.container.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=1)
+            self.assertFalse(HoloHubContainer._peer_creds_sufficient(":0"))
+
+    def test_peer_creds_sufficient_false_on_timeout(self):
+        """A hung xset call must not propagate; treat it as probe failure."""
+        with (
+            patch("utilities.cli.container.shutil.which", return_value="/usr/bin/xset"),
+            patch(
+                "utilities.cli.container.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="xset", timeout=2),
+            ),
+        ):
+            self.assertFalse(HoloHubContainer._peer_creds_sufficient(":0"))
+
+    @patch.dict(os.environ, {"DISPLAY": ":0"}, clear=True)
+    def test_get_display_options_native_x11_skips_xauth_when_peer_creds_ok(self):
+        """When the X server accepts no-cookie connections, skip xauth setup."""
+        with (
+            patch("utilities.cli.container.Path.is_dir", return_value=True),
+            patch(
+                "utilities.cli.container.HoloHubContainer._peer_creds_sufficient",
+                return_value=True,
+            ),
+            patch("utilities.cli.container.run_command") as mock_run,
+        ):
+            options = self.container.get_display_options(True, False)
+
+        self.assertIn("DISPLAY", options)
+        self.assertIn("/tmp/.X11-unix:/tmp/.X11-unix:ro", options)
+        self.assertFalse(any(opt.startswith("XAUTHORITY=") for opt in options))
+        mock_run.assert_not_called()
+
     @patch.dict(os.environ, {"DISPLAY": ":0"}, clear=True)
     def test_get_display_options_native_x11_uses_socket_and_xauth(self):
         """Native X11 should mount the UNIX socket and a generated Xauthority file."""
@@ -298,6 +353,10 @@ class TestHoloHubContainer(unittest.TestCase):
         with (
             patch("utilities.cli.container.Path.is_dir", return_value=True),
             patch("utilities.cli.container.shutil.which", return_value="/usr/bin/xauth"),
+            patch(
+                "utilities.cli.container.HoloHubContainer._peer_creds_sufficient",
+                return_value=False,
+            ),
             patch("utilities.cli.container.run_command", side_effect=fake_run_command) as mock_run,
         ):
             options = self.container.get_display_options(True, False)
@@ -323,6 +382,10 @@ class TestHoloHubContainer(unittest.TestCase):
         with (
             patch("utilities.cli.container.Path.is_dir", return_value=True),
             patch("utilities.cli.container.shutil.which", return_value=None),
+            patch(
+                "utilities.cli.container.HoloHubContainer._peer_creds_sufficient",
+                return_value=False,
+            ),
         ):
             options = self.container.get_display_options(True, True)
 


### PR DESCRIPTION
## Summary

Probe the X server with `XAUTHORITY=/dev/null xset -display $DISPLAY q` before attempting the xauth cookie setup. If that succeeds, a non-cookie auth family (typically `SI:localuser`, granted to the same UID via the X server's peer-credential check on the UNIX socket) is already accepting the connection. The container runs as the same UID via `-u $(id -u):$(id -g)` and shares the X socket, so the same auth applies inside. Cookie setup, temp file, and the "no entries" warning are all skipped in that case.

## Why

A user reported this warning after the original X11/Wayland auto-detect PR landed:

```
Warning: xauth nlist returned no entries for DISPLAY=:1; X11 may not authenticate inside the container.
```

with X11 still working fine inside the container. Root cause: on most modern Linux desktops, the cookie for the active local display is written to a display-manager-owned Xauthority file (`/run/user/<uid>/gdm/Xauthority`, etc.), not the user's default `~/.Xauthority`. When `xauth nlist` reads the default file in a fresh shell, it finds nothing. The container still works because the X server is granting access via `SI:localuser:<user>` peer-credential auth on the UNIX socket, which does not require a cookie at all.

## Probe cost

One `xset` invocation (~5 ms), `timeout=2` so a stale `DISPLAY` cannot hang. Read-only, no side effects.

## Behavior

- **Peer-creds works** (most local UNIX-socket displays): skip xauth entirely; no warning, no temp file, no extra mount.
- **Peer-creds does not work** (SSH-forwarded TCP `DISPLAY`, or a host without `SI:localuser`): fall through to existing cookie path; warning fires only if cookie path also fails.
- **`xset` not installed**: probe returns `False`, behavior identical to today.

## Test plan

- [x] `python3 -m unittest utilities.cli.tests.test_container` -> 27 tests pass (1 new)
- [x] On a local UNIX-socket DISPLAY where `xauth nlist` is empty: no warning, GUI still renders inside container
- [x] On a TCP `DISPLAY` (`localhost:N` SSH-forwarded): probe fails, cookie path runs, warning silent
- [x] On a host without `xset`: probe returns False, cookie path runs as today