### PR TITLE
object_detection_torch: handle pre-release PyTorch version strings

### DIFF
--- a/applications/object_detection_torch/Dockerfile
+++ b/applications/object_detection_torch/Dockerfile
@@ -58,7 +58,7 @@ RUN INDEX_URL=""; \
     else \
         echo "Error: Unsupported GPU_TYPE (${GPU_TYPE}) or CUDA_MAJOR (${CUDA_MAJOR})" && exit 1; \
     fi \
-    && TORCH_VERSION=$(python3 -c "import torch; print(torch.__version__.split('+')[0])") \
+    && TORCH_VERSION=$(python3 -c "import torch, re; print(re.match(r'[\d.]+', torch.__version__).group())") \
     && echo "Detected PyTorch version: ${TORCH_VERSION}" \
     && if [ "${TORCH_VERSION}" = "2.8.0" ]; then \
         TORCHVISION_VERSION="0.23.0"; \

--- a/applications/object_detection_torch/Dockerfile
+++ b/applications/object_detection_torch/Dockerfile
@@ -58,7 +58,7 @@ RUN INDEX_URL=""; \
     else \
         echo "Error: Unsupported GPU_TYPE (${GPU_TYPE}) or CUDA_MAJOR (${CUDA_MAJOR})" && exit 1; \
     fi \
-    && TORCH_VERSION=$(python3 -c "import torch, re; print(re.match(r'[\d.]+', torch.__version__).group())") \
+    && TORCH_VERSION=$(python3 -c "import torch, re; m = re.match(r'\d+\.\d+\.\d+', torch.__version__); print(m.group() if m else torch.__version__)") \
     && echo "Detected PyTorch version: ${TORCH_VERSION}" \
     && if [ "${TORCH_VERSION}" = "2.8.0" ]; then \
         TORCHVISION_VERSION="0.23.0"; \


### PR DESCRIPTION
## Motivation

Supporting Holoscan Production Branch coverage.

## Issue

`object_detection_torch` container fails to build with DLFW PyTorch installation.

```bash
#16 [10/10] RUN INDEX_URL="";     if [ "dgpu" = "igpu" ] && [ "13" = "12" ]; then         apt-get update &&         apt-get install -y --reinstall --no-install-recommends             libcudnn9-cuda-12             libcudnn9-dev-cuda-12 &&         rm -rf /var/lib/apt/lists/* &&         INDEX_URL="https://pypi.jetson-ai-lab.io/jp6/cu126";     elif [ "13" = "12" ]; then         INDEX_URL="https://download.pytorch.org/whl/cu129";     elif [ "13" = "13" ]; then         INDEX_URL="https://download.pytorch.org/whl/cu130";     else         echo "Error: Unsupported GPU_TYPE (dgpu) or CUDA_MAJOR (13)" && exit 1;     fi     && TORCH_VERSION=$(python3 -c "import torch; print(torch.__version__.split('+')[0])")     && echo "Detected PyTorch version: ${TORCH_VERSION}"     && if [ "${TORCH_VERSION}" = "2.8.0" ]; then         TORCHVISION_VERSION="0.23.0";     elif [ "${TORCH_VERSION}" = "2.9.0" ]; then         TORCHVISION_VERSION="0.24.0";     elif [ "${TORCH_VERSION}" = "2.9.1" ]; then         TORCHVISION_VERSION="0.24.1";     elif [ "${TORCH_VERSION}" = "2.10.0" ]; then         TORCHVISION_VERSION="0.25.0";     elif [ "${TORCH_VERSION}" = "2.11.0" ]; then         TORCHVISION_VERSION="0.26.0";     else         echo "Error: Unsupported PyTorch version ${TORCH_VERSION}" && exit 1;     fi     && echo "Installing torchvision ${TORCHVISION_VERSION}"     && python3 -m pip install torchvision==${TORCHVISION_VERSION} --no-cache-dir --index-url ${INDEX_URL}
#16 0.904 Detected PyTorch version: 2.11.0a0
#16 0.904 Error: Unsupported PyTorch version 2.11.0a0
```

## Overview

Extract only the numeric X.Y.Z portion of the PyTorch version so that pre-release builds (e.g. 2.11.0a0+...) match the torchvision version table. Fixes build failure when relying on DLFW PyTorch 26.03.

Assisted-by: Claude:claude-sonnet-4.6

## Result

Verified latest logic in DLFW PyTorch 26.03 container:
```bash
# python3 -c "import torch, re; print(re.match(r'\d+\.\d+\.\d+', torch.__version__).group())"
2.11.0
```

Verified successful container build on x86 + CUDA 13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PyTorch version detection in Docker builds. The build process now correctly handles PyTorch version strings with additional build metadata, ensuring proper compatibility with torchvision version selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nvidia-holoscan/holohub/pull/1558)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->