### PR TITLE
Infra: Install libatomic1 to fix Ubuntu 24.04 linting check in CI

### DIFF
--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -1855,7 +1855,16 @@ class HoloHubCLI:
 
         if not args.scripts:
             holohub_cli_util.install_packages_if_missing(
-                ["wget", "xvfb", "git", "unzip", "ffmpeg", "ninja-build", "libv4l-dev"],
+                [
+                    "wget",
+                    "xvfb",
+                    "git",
+                    "unzip",
+                    "ffmpeg",
+                    "ninja-build",
+                    "libv4l-dev",
+                    "libatomic1",
+                ],
                 dry_run=args.dryrun,
             )
 


### PR DESCRIPTION
fix(docker): install libatomic1 to fix pre-commit Node.js on Ubuntu 24.04

## Context

Reproducible `main` pipeline failure: https://github.com/nvidia-holoscan/holohub/actions/runs/25920934471/job/76189460877

## Overview
    
nodeenv-managed Node.js binaries (used by the markdownlint-cli pre-commit
    hook) require libatomic.so.1, which is absent from minimal Ubuntu 24.04
    base images. Adding it to the holohub setup package list ensures it is
    installed at root-level during the Docker build (via RUN ./holohub setup),
    fixing the check-docker-build (24.04) CI failure.
    
## Result

Validated with:
```bash
./holohub run-container --base-img ubuntu:24.04 -- "./holohub lint --install-dependencies; ./holohub lint"
```

Assisted-by: Claude:claude-opus-4.7
Signed-off-by: Tom Birdsong <tbirdsong@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code formatting improvements for enhanced readability and maintainability.

**Note:** This release contains no user-visible changes. Updates are limited to internal code organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nvidia-holoscan/holohub/pull/1560)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->