### PR TITLE
Dev: Update metadata.json templates for latest schema

### DIFF
--- a/applications/holoviz/template/cookiecutter-holoviz/{{cookiecutter.project_slug}}/metadata.json
+++ b/applications/holoviz/template/cookiecutter-holoviz/{{cookiecutter.project_slug}}/metadata.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "urn:holohub:application:v1",
 	"application": {
 		"name": "{{ cookiecutter.project_name }}",
 		"authors": [

--- a/applications/template/metadata.json.template
+++ b/applications/template/metadata.json.template
@@ -1,4 +1,5 @@
 {
+	"$schema": "urn:holohub:application:v1",
 	"application": {
 		"name": "My Project",
 		"authors": [
@@ -19,8 +20,8 @@
 			]
 		},
 		"platforms": [
-			"amd64",
-			"arm64"
+			"x86_64",
+			"aarch64"
 		],
 		"tags": [
 			"Sensor",
@@ -28,6 +29,6 @@
             "Example"
 		],
 		"ranking": 1,
-		"dependencies": {}
+		"requirements": {}
 	}
 }

--- a/applications/template/{{cookiecutter.project_slug}}/metadata.json
+++ b/applications/template/{{cookiecutter.project_slug}}/metadata.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "urn:holohub:application:v1",
 	"application": {
 		"name": "{{ cookiecutter.project_name }}",
 		"description": "{{ cookiecutter.description }}",

--- a/modules/template/{{cookiecutter.module_repo_name}}/applications/{{cookiecutter.module_slug}}_pipeline/metadata.json
+++ b/modules/template/{{cookiecutter.module_repo_name}}/applications/{{cookiecutter.module_slug}}_pipeline/metadata.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "urn:holohub:application:v1",
     "application": {
         "name": "{{ cookiecutter.module_slug }}_pipeline",
         "authors": [
@@ -19,9 +20,6 @@
         "platforms": ["x86_64", "aarch64"],
         "tags": ["TODO: add tags"],
         "ranking": 3,
-        "dependencies": {
-            "operators": ["{{ cookiecutter.operator_slug }}"]
-        },
         "requirements": {},
         "run": {
             {% if cookiecutter.language == "cpp" %}"command": "<holohub_app_bin>/{{ cookiecutter.module_slug }}_pipeline",

--- a/modules/template/{{cookiecutter.module_repo_name}}/metadata.json
+++ b/modules/template/{{cookiecutter.module_repo_name}}/metadata.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "holoscan/module/v2",
+  "$schema": "urn:holohub:module:v2",
   "module": {
     "name": "holoscan-{{ cookiecutter.module_slug.replace('_', '-') }}",
     "version": "{{ cookiecutter.version }}",

--- a/modules/template/{{cookiecutter.module_repo_name}}/operators/{{cookiecutter.operator_slug}}/metadata.json
+++ b/modules/template/{{cookiecutter.module_repo_name}}/operators/{{cookiecutter.operator_slug}}/metadata.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "urn:holohub:operator:v1",
     "operator": {
         "name": "{{ cookiecutter.operator_slug.split('_')|map('capitalize')|join('') }}",
         "authors": [

--- a/operators/template/metadata.json.template
+++ b/operators/template/metadata.json.template
@@ -1,4 +1,5 @@
 {
+	"$schema": "urn:holohub:operator:v1",
 	"operator": {
 		"name": "MyOperatorOp",
 		"authors": [
@@ -19,8 +20,8 @@
 			]
 		},
 		"platforms": [
-			"amd64",
-			"arm64"
+			"x86_64",
+			"aarch64"
 		],
 		"tags": [
 			"Sensor",
@@ -28,6 +29,6 @@
             "Example"
 		],
 		"ranking": 1,
-		"dependencies": {}
+		"requirements": {}
 	}
 }

--- a/tutorials/template/metadata.json.template
+++ b/tutorials/template/metadata.json.template
@@ -1,4 +1,5 @@
 {
+	"$schema": "urn:holohub:tutorial:v1",
 	"tutorial": {
 		"name": "My Tutorial",
 		"description": "Demonstrates how to use Holoscan in a certain fashion.",
@@ -20,8 +21,8 @@
 			]
 		},
 		"platforms": [
-			"amd64",
-			"arm64"
+			"x86_64",
+			"aarch64"
 		],
 		"tags": [
 			"Sensor",
@@ -29,6 +30,6 @@
             "Tutorial"
 		],
 		"ranking": 1,
-		"dependencies": {}
+		"requirements": {}
 	}
 }

--- a/utilities/metadata/application.schema.json
+++ b/utilities/metadata/application.schema.json
@@ -6,6 +6,7 @@
     "application"
   ],
   "properties": {
+    "$schema": { "type": "string" },
     "application": {
       "type": "object",
       "properties": {

--- a/utilities/metadata/operator.schema.json
+++ b/utilities/metadata/operator.schema.json
@@ -3,6 +3,7 @@
   "$id": "urn:holohub:operator:v1",
   "type": "object",
   "properties": {
+    "$schema": { "type": "string" },
     "operator": {
       "type": "object",
       "properties": {

--- a/utilities/metadata/tests/test_template_schema_headers.py
+++ b/utilities/metadata/tests/test_template_schema_headers.py
@@ -49,6 +49,14 @@ class TestStaticTemplateFiles(unittest.TestCase):
                 data = json.loads(full_path.read_text())
                 validator = _make_validator(schema_name)
                 validator.validate(data)
+                schema_id = json.loads(
+                    (SCHEMA_DIR / f"{schema_name}.schema.json").read_text()
+                )["$id"]
+                self.assertEqual(
+                    data.get("$schema"),
+                    schema_id,
+                    f"$schema in {rel_path} does not match schema $id {schema_id!r}",
+                )
 
 
 if __name__ == "__main__":

--- a/utilities/metadata/tests/test_template_schema_headers.py
+++ b/utilities/metadata/tests/test_template_schema_headers.py
@@ -49,9 +49,9 @@ class TestStaticTemplateFiles(unittest.TestCase):
                 data = json.loads(full_path.read_text())
                 validator = _make_validator(schema_name)
                 validator.validate(data)
-                schema_id = json.loads(
-                    (SCHEMA_DIR / f"{schema_name}.schema.json").read_text()
-                )["$id"]
+                schema_id = json.loads((SCHEMA_DIR / f"{schema_name}.schema.json").read_text())[
+                    "$id"
+                ]
                 self.assertEqual(
                     data.get("$schema"),
                     schema_id,

--- a/utilities/metadata/tests/test_template_schema_headers.py
+++ b/utilities/metadata/tests/test_template_schema_headers.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Validates the three static metadata.json.template files that ship with the
+# holohub application, operator, and tutorial scaffolding tools. These files
+# are excluded from the corpus validator (metadata_validator.py) by design, so
+# this suite provides the only automated schema-correctness check for them.
+# It specifically guards the "$schema" header addition and the platform enum
+# fix (x86_64/aarch64) that were introduced alongside the Draft 2020-12
+# migration.
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+from referencing import Registry
+from referencing.jsonschema import DRAFT202012
+
+THIS_DIR = Path(__file__).resolve().parent
+SCHEMA_DIR = THIS_DIR.parent  # utilities/metadata/
+REPO_ROOT = SCHEMA_DIR.parents[1]  # holohub/
+
+# (template_path_relative_to_repo_root, schema_name)
+_TEMPLATE_CASES = [
+    ("applications/template/metadata.json.template", "application"),
+    ("operators/template/metadata.json.template", "operator"),
+    ("tutorials/template/metadata.json.template", "tutorial"),
+]
+
+
+def _make_validator(schema_name: str) -> Draft202012Validator:
+    base_schema = json.loads((SCHEMA_DIR / "project.schema.json").read_text())
+    entity_schema = json.loads((SCHEMA_DIR / f"{schema_name}.schema.json").read_text())
+    registry = Registry().with_resource(
+        base_schema["$id"], DRAFT202012.create_resource(base_schema)
+    )
+    return Draft202012Validator(entity_schema, registry=registry)
+
+
+class TestStaticTemplateFiles(unittest.TestCase):
+    def test_static_templates_are_schema_valid(self) -> None:
+        for rel_path, schema_name in _TEMPLATE_CASES:
+            with self.subTest(template=rel_path):
+                full_path = REPO_ROOT / rel_path
+                self.assertTrue(full_path.exists(), f"template file not found: {full_path}")
+                data = json.loads(full_path.read_text())
+                validator = _make_validator(schema_name)
+                validator.validate(data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utilities/metadata/tutorial.schema.json
+++ b/utilities/metadata/tutorial.schema.json
@@ -3,6 +3,7 @@
   "$id": "urn:holohub:tutorial:v1",
   "type": "object",
   "properties": {
+    "$schema": { "type": "string" },
     "tutorial": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
## Context

Reviewing HoloHub subproject template files following schema updates in 8be5cab49e9d9f5945587b25670f55d900969ae6

## Issue

The Draft 2020-12 schema migration introduced URN-style $id values but left all template metadata files without $schema declarations. Three static .json.template files also carried invalid platform enum values (amd64/arm64 instead of x86_64/aarch64) and were missing the required requirements field.

## Changes

- Updated application.schema.json, operator.schema.json, and tutorial.schema.json to formally accept an optional $schema string property, then added correct urn:holohub:* header declarations to all 7 template metadata files.
- Fixed the three static .json.template files (applications, operators, tutorials) by correcting platform enum values to x86_64/aarch64, adding the missing required requirements field, and removing spurious dependencies fields.
- Added utilities/metadata/tests/test_template_schema_headers.py to validate the static template files against their schemas, providing the only automated coverage for template metadata correctness.

## Results

- 100% unit tests pass
- Manual test with generated stub project from module template indicates CLI compatibility preserved
```
$ ./holohub list

== APPLICATIONS =================

my_module_schema_test_pipeline (['C++', 'Python'])

== OPERATORS =================

my_module_schema_test_op (['C++', 'Python'])

=================================
```

Assisted-by: Claude:claude-sonnet-4-6