### PR TITLE
Module: Fix README quick start commands

### DIFF
--- a/modules/template/{{cookiecutter.module_repo_name}}/README.md
+++ b/modules/template/{{cookiecutter.module_repo_name}}/README.md
@@ -14,10 +14,10 @@ A **Holoscan Module** — a self-contained, redistributable library that extends
 
 ```bash
 # 1. Run the Python demo application
-./{{ cookiecutter.module_slug }} run {{ cookiecutter.module_slug }}_demo --language python
+./holohub run {{ cookiecutter.module_slug }}_pipeline --language python
 {% if cookiecutter.language == 'cpp' %}
 # 2. Run the C++ demo application
-./{{ cookiecutter.module_slug }} run {{ cookiecutter.module_slug }}_demo
+./holohub run {{ cookiecutter.module_slug }}_pipeline
 {% endif %}
 ```
 


### PR DESCRIPTION
## Context

Introduced Holoscan Module scaffolding template in 92a306756c85fdf72c11fb9f6869b176233cb19e

## Update

- Fix wrapper script name: "./holohub" is the default wrapper script naming from the template project
- Fix default subproject name: "<module>_pipeline" is correct (see: https://github.com/nvidia-holoscan/holohub/tree/main/modules/template/%7B%7Bcookiecutter.module_repo_name%7D%7D/applications)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start instructions with new command syntax for running Python and C++ demos.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nvidia-holoscan/holohub/pull/1562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->