### PR TITLE
Modules: Extend Module schema with presentation metadata

### DIFF
--- a/modules/template/{{cookiecutter.module_repo_name}}/metadata.json
+++ b/modules/template/{{cookiecutter.module_repo_name}}/metadata.json
@@ -23,9 +23,15 @@
     "platforms": ["x86_64", "aarch64"],
     "tags": ["TODO: add tags"],
     "source_repository": "https://github.com/TODO/holoscan-{{ cookiecutter.module_slug.replace('_', '-') }}",
+    "operators": ["{{ cookiecutter.operator_slug }}"],
+    "dockerfile": "Dockerfile",
     "binary_packages": {
       "debian": "holoscan-{{ cookiecutter.module_slug.replace('_', '-') }}",
-      "pypi": "holoscan-{{ cookiecutter.module_slug.replace('_', '-') }}"
+      "pypi": "holoscan-{{ cookiecutter.module_slug.replace('_', '-') }}",
+      "install_commands": ["pip install holoscan-{{ cookiecutter.module_slug.replace('_', '-') }}"]
+    },
+    "documentation": {
+      "readme": "README.md"
     },
     "testing": {
       {% if cookiecutter.language == "cpp" %}"cpp": "ctest",

--- a/utilities/metadata/module.schema.json
+++ b/utilities/metadata/module.schema.json
@@ -79,6 +79,7 @@
         },
         "date": {
           "type": "string",
+          "format": "date",
           "description": "ISO 8601 date of the test run (e.g. '2026-05-01')."
         },
         "holoscan_sdk_version": {
@@ -215,6 +216,7 @@
         },
         "homepage": {
           "type": "string",
+          "format": "uri",
           "description": "URL of the module's primary landing page or repository."
         },
         "source_repository": {

--- a/utilities/metadata/module.schema.json
+++ b/utilities/metadata/module.schema.json
@@ -65,7 +65,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Relative paths to images, GIFs, or other assets the documentation builder must fetch for webpage rendering."
+          "description": "Relative paths to images, GIFs, or other assets the documentation builder must fetch for webpage rendering. Assumed relative to the project root."
         }
       },
       "additionalProperties": false

--- a/utilities/metadata/module.schema.json
+++ b/utilities/metadata/module.schema.json
@@ -23,6 +23,13 @@
         },
         "pypi": {
           "type": "string"
+        },
+        "install_commands": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Recommended shell commands to install this module's binary packages."
         }
       },
       "additionalProperties": false
@@ -41,6 +48,79 @@
           "enum": [
             "pytest"
           ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "documentation_block": {
+      "type": "object",
+      "description": "Paths used by the Holoscan documentation builder to locate this module's README and media assets.",
+      "properties": {
+        "readme": {
+          "type": "string",
+          "description": "Relative path from this metadata.json to the module README. Defaults to README.md in the same directory when absent."
+        },
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Relative paths to images, GIFs, or other assets the documentation builder must fetch for webpage rendering."
+        }
+      },
+      "additionalProperties": false
+    },
+    "quality_test_record": {
+      "type": "object",
+      "description": "A single test-result snapshot, typically populated by CI for one HSDK version and platform combination.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "date": {
+          "type": "string",
+          "description": "ISO 8601 date of the test run (e.g. '2026-05-01')."
+        },
+        "holoscan_sdk_version": {
+          "type": "string"
+        },
+        "platforms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tests_passing": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "tests_failing": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "code_coverage_pct": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        }
+      },
+      "additionalProperties": false
+    },
+    "quality_reporting_block": {
+      "type": "object",
+      "properties": {
+        "testing": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/quality_test_record"
+          },
+          "description": "Test-result records, one per HSDK version or test run. Populated by CI."
+        },
+        "quality_metric": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 5,
+          "description": "Self-reported quality score on a 0–5 scale."
         }
       },
       "additionalProperties": false
@@ -80,7 +160,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Operators this dependency supplies to the consumer. The CLI resolver fetches this module only when at least one of these operators is in the set being built \u2014 letting consumers declare many module dependencies without paying the fetch cost for unused ones. The resolver validates this list against the module's own metadata.json:module.operators after fetch and warns on drift."
+          "description": "Operators this dependency supplies to the consumer. The CLI resolver fetches this module only when at least one of these operators is in the set being built — letting consumers declare many module dependencies without paying the fetch cost for unused ones. The resolver validates this list against the module's own metadata.json:module.operators after fetch and warns on drift."
         }
       },
       "required": [
@@ -126,6 +206,17 @@
         "holoscan_sdk": {
           "$ref": "urn:holohub:project:v1#/$defs/sdk_version"
         },
+        "sensor_hardware": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Sensor or capture hardware this module supports (e.g. 'AJA KONA', 'Deltacast VideoMaster')."
+        },
+        "homepage": {
+          "type": "string",
+          "description": "URL of the module's primary landing page or repository."
+        },
         "source_repository": {
           "type": "string"
         },
@@ -141,8 +232,14 @@
         "testing": {
           "$ref": "#/$defs/testing_block"
         },
+        "quality_reporting": {
+          "$ref": "#/$defs/quality_reporting_block"
+        },
         "dockerfile": {
           "type": "string"
+        },
+        "documentation": {
+          "$ref": "#/$defs/documentation_block"
         },
         "subprojects": {
           "type": "object",

--- a/utilities/metadata/tests/fixtures/valid/module_with_documentation_and_quality.json
+++ b/utilities/metadata/tests/fixtures/valid/module_with_documentation_and_quality.json
@@ -1,0 +1,39 @@
+{
+    "module": {
+        "name": "module_with_documentation_and_quality",
+        "description": "Fixture covering documentation, sensor_hardware, homepage, quality_reporting, and install_commands.",
+        "authors": [{ "name": "NVIDIA", "affiliation": "NVIDIA" }],
+        "version": "1.0.0",
+        "language": ["C++"],
+        "platforms": ["x86_64"],
+        "tags": ["example"],
+        "holoscan_sdk": {
+            "minimum_required_version": "4.0.0",
+            "tested_versions": ["4.0.0"]
+        },
+        "sensor_hardware": ["AJA KONA HDMI"],
+        "homepage": "https://example.invalid/my-module",
+        "binary_packages": {
+            "pypi": "holoscan-example",
+            "install_commands": ["pip install holoscan-example"]
+        },
+        "documentation": {
+            "readme": "README.md",
+            "assets": ["docs/diagram.png"]
+        },
+        "quality_reporting": {
+            "testing": [
+                {
+                    "description": "Unit tests on x86_64",
+                    "date": "2026-05-01",
+                    "holoscan_sdk_version": "4.0.0",
+                    "platforms": ["x86_64"],
+                    "tests_passing": 12,
+                    "tests_failing": 0,
+                    "code_coverage_pct": 87.5
+                }
+            ],
+            "quality_metric": 4
+        }
+    }
+}


### PR DESCRIPTION
## Context

Piloting presentation of Holoscan Module domain-specific libraries leveraging existing Holoscan ecosystem tooling
    
## Changes
    - Add sensor_hardware, homepage, documentation, and quality_reporting fields to module.schema.json
    - Extend binary_packages with install_commands support
    - Add module_with_documentation_and_quality.json fixture to cover new fields in schema regression tests

## Results

Unit tests pass locally

## Not In Scope (Planned for Later)

- Fetch and validate external module information

Assisted-by: Claude:claude-sonnet-4-6[1m]
Signed-off-by: Tom Birdsong <tbirdsong@nvidia.com>