### PR TITLE
Infra: Use generic paths in holoscan_download_data

### DIFF
--- a/cmake/modules/holoscan_download_data.cmake
+++ b/cmake/modules/holoscan_download_data.cmake
@@ -72,6 +72,7 @@ function(holoscan_download_data dataname)
       /opt/nvidia/holoscan
       /opt/nvidia/holoscan/bin
     NO_DEFAULT_PATH
+    REQUIRED
   )
   cmake_path(GET DOWNLOAD_NGC_DATA PARENT_PATH DOWNLOAD_NGC_DATA_WORKDIR)
 

--- a/cmake/modules/holoscan_download_data.cmake
+++ b/cmake/modules/holoscan_download_data.cmake
@@ -65,16 +65,26 @@ function(holoscan_download_data dataname)
     list(APPEND extra_data_options --model)
   endif()
 
+  find_program(DOWNLOAD_NGC_DATA
+    NAMES download_ngc_data
+    PATHS
+      ${CMAKE_SOURCE_DIR}/utilities
+      /opt/nvidia/holoscan
+      /opt/nvidia/holoscan/bin
+    NO_DEFAULT_PATH
+  )
+  cmake_path(GET DOWNLOAD_NGC_DATA PARENT_PATH DOWNLOAD_NGC_DATA_WORKDIR)
+
   # Using a custom_command attached to a custom target allows to run only the custom command
   # if the stamp is not generated
   add_custom_command(OUTPUT "${DATA_DOWNLOAD_DIR}/${dataname}/${DATA_DOWNLOAD_NAME}.stamp"
-     COMMAND ${CMAKE_SOURCE_DIR}/utilities/download_ngc_data
+     COMMAND ${DOWNLOAD_NGC_DATA}
      --url ${DATA_URL}
      --dataset_name ${dataname}
      --download_dir ${DATA_DOWNLOAD_DIR}
      --download_name ${DATA_DOWNLOAD_NAME}
      ${extra_data_options}
-     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/utilities"
+     WORKING_DIRECTORY "${DOWNLOAD_NGC_DATA_WORKDIR}"
   )
 
   # If the target should be run all the time


### PR DESCRIPTION
Context: Using "holoscan_download_data" helper module in external Holoscan Modules outside of HoloHub project repository structure

Issue: "utilities/download_ngc_data" folder may not exist in external module structures

Update: Search for download_ngc_data helper at Holoscan SDK installation locations. External modules can copy and use the
"holoscan_download_data" helper with a Holoscan SDK installation delivering the download_ngc_data program.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved data download utility discovery in the build process to support flexible installation paths and enhance compatibility across different environments and system configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nvidia-holoscan/holohub/pull/1565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->