### PR TITLE
CLI: add `./holohub install --dev` dev-hook installer

### DIFF
--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -1257,9 +1257,10 @@ class HoloHubCLI:
             return
 
         try:
+            import site as _site
             import sys as _sys
             import sysconfig as _sysconfig
-            import site as _site
+
             if _sys.prefix != _sys.base_prefix:
                 site_path = _sysconfig.get_path("purelib")
             else:
@@ -1295,10 +1296,7 @@ class HoloHubCLI:
         else:
             cmd = f"./{slug} install --dev"
         if kind == "missing":
-            print(
-                f"\nTo make `import holoscan.{slug}` work in any shell, run:\n"
-                f"    {cmd}"
-            )
+            print(f"\nTo make `import holoscan.{slug}` work in any shell, run:\n" f"    {cmd}")
         else:
             print(
                 f"\nYour installed dev hook for `holoscan.{slug}` points at a "
@@ -2235,10 +2233,10 @@ class HoloHubCLI:
         depending on an external module (the module was pulled in via
         external_modules.cmake → add_subdirectory). Each unique slug found
         across `build/*/holoscan_<slug>_dev.py` is installed."""
+        import shutil as _shutil
+        import site as _site
         import sys as _sys
         import sysconfig as _sysconfig
-        import site as _site
-        import shutil as _shutil
 
         dryrun = getattr(args, "dryrun", False)
 
@@ -2317,7 +2315,7 @@ class HoloHubCLI:
         if args.project:
             target = args.project.replace("-", "_")
             if target.startswith("holoscan_"):
-                target = target[len("holoscan_"):]
+                target = target[len("holoscan_") :]
             if target in by_slug:
                 by_slug = {target: by_slug[target]}
             else:
@@ -2362,14 +2360,11 @@ class HoloHubCLI:
                 sole = next(iter(by_slug))
                 print(
                     "Verify with: "
-                    f"python -c \"import holoscan.{sole}; "
-                    f"print(holoscan.{sole}.__file__)\""
+                    f'python -c "import holoscan.{sole}; '
+                    f'print(holoscan.{sole}.__file__)"'
                 )
             else:
-                print(
-                    "Verify with: "
-                    "python -c \"import holoscan; print(holoscan.__path__)\""
-                )
+                print("Verify with: " 'python -c "import holoscan; print(holoscan.__path__)"')
             print(f"To remove:  ./{wrapper_name} install --dev --uninstall")
 
     def _collect_cache_dirs(self, patterns: list[str], default_dir=None) -> list:

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -374,10 +374,42 @@ class HoloHubCLI:
             parents=[container_build_argparse, container_run_argparse],
         )
         self.subparsers["install"] = install
-        install.add_argument("project", help="Project to install")
+        install.add_argument(
+            "project",
+            nargs="?",
+            default=None,
+            help="Project to install (omit with --dev to install every staged hook)",
+        )
         install.add_argument("mode", nargs="?", help="Mode to install (optional)")
         install.add_argument(
             "--local", action="store_true", help="Install locally instead of in container"
+        )
+        # --dev: opt-in dev hook. Copies the .pth + helper that the build
+        # stages into the user's Python site, so `import holoscan.<module>`
+        # works in any shell without a wheel install. Module-only mode; the
+        # rest of the install flags (--local, --build-type, …) are ignored.
+        install.add_argument(
+            "--dev",
+            action="store_true",
+            help=(
+                "Install the dev hook staged by the build, so `import "
+                "holoscan.<module>` resolves to the live build tree without a "
+                "wheel install. Copies into the active environment's site-packages."
+            ),
+        )
+        install.add_argument(
+            "--uninstall",
+            action="store_true",
+            help="Used with --dev: remove the previously-installed dev hook.",
+        )
+        install.add_argument(
+            "--build-dir",
+            type=Path,
+            default=None,
+            help=(
+                "Used with --dev: build directory whose staged dev hook should "
+                "be installed. Default: most-recently-modified <project>/build/<sub>/."
+            ),
         )
         install.add_argument(
             "--build-type",
@@ -1198,7 +1230,75 @@ class HoloHubCLI:
                 [str(restore_script), str(app_source_path)], dry_run=dryrun
             )
 
+        # If the build staged a holoscan dev hook (Holoscan Module project),
+        # check whether `install --dev` has been run and the user-site copy is in
+        # sync. Print a hint when the user needs to follow up — the build
+        # itself never touches the host's Python environment.
+        if not dryrun:
+            self._maybe_print_dev_hook_hint(build_dir)
+
         return build_dir, project_data
+
+    @staticmethod
+    def _maybe_print_dev_hook_hint(build_dir: Path) -> None:
+        """If `build_dir` contains a staged dev-hook helper, compare against
+        the user-site copy and emit a one-line follow-up hint when the user
+        hasn't run `install --dev` (or the install is stale)."""
+        try:
+            staged = sorted(Path(build_dir).glob("holoscan_*_dev.py"))
+        except OSError:
+            return
+        if not staged:
+            return
+        helper_src = staged[0]
+        # Filename: holoscan_<slug>_dev.py
+        slug = helper_src.stem.removeprefix("holoscan_").removesuffix("_dev")
+        if not slug:
+            return
+
+        try:
+            import sysconfig as _sysconfig
+            site_path = _sysconfig.get_path("purelib")
+            if not site_path:
+                return
+            site_dir = Path(site_path)
+        except (ImportError, KeyError):
+            return
+        helper_dst = site_dir / helper_src.name
+
+        try:
+            staged_text = helper_src.read_text()
+        except OSError:
+            return
+
+        if helper_dst.exists():
+            try:
+                if helper_dst.read_text() == staged_text:
+                    return  # already in sync, nothing to say
+                kind = "stale"
+            except OSError:
+                kind = "stale"
+        else:
+            kind = "missing"
+
+        # Pick a cwd-appropriate command. If the user is inside a HoloHub
+        # clone (./holohub script present), the wrapper for the external
+        # module isn't reachable from here — suggest the HoloHub CLI form.
+        cwd = Path.cwd()
+        if (cwd / "utilities" / "cli" / "holohub.py").is_file():
+            cmd = "./holohub install --dev"
+        else:
+            cmd = f"./{slug} install --dev"
+        if kind == "missing":
+            print(
+                f"\nTo make `import holoscan.{slug}` work in any shell, run:\n"
+                f"    {cmd}"
+            )
+        else:
+            print(
+                f"\nYour installed dev hook for `holoscan.{slug}` points at a "
+                f"different build. Refresh with:\n    {cmd}"
+            )
 
     def handle_build(self, args: argparse.Namespace) -> None:
         """Handle build command"""
@@ -1974,6 +2074,22 @@ class HoloHubCLI:
 
     def handle_install(self, args: argparse.Namespace) -> None:
         """Handle install command"""
+        # --dev short-circuits to the dev-hook installer (copies the .pth +
+        # helper that the build staged into the user's Python user-site).
+        # The rest of the install flags don't apply in this mode.
+        if getattr(args, "dev", False):
+            return self._handle_install_dev(args)
+        if getattr(args, "uninstall", False):
+            holohub_cli_util.fatal(
+                "--uninstall is only valid with --dev. To uninstall a regular "
+                "install, use the appropriate package manager (apt remove / "
+                "pip uninstall)."
+            )
+        if args.project is None:
+            self.subparsers["install"].error(
+                "the following arguments are required: project (unless --dev is used)"
+            )
+
         # Handle mode-specific configuration (if project has modes)
         project_data = self.find_project(args.project, language=args.language)
         mode_name, mode_config = self.resolve_mode(project_data, getattr(args, "mode", None))
@@ -2098,6 +2214,153 @@ class HoloHubCLI:
                 enable_mps=getattr(args, "mps", False),
                 extra_args=extra_args,
             )
+
+    def _handle_install_dev(self, args: argparse.Namespace) -> None:
+        """Internal: implementation of `./holohub install --dev`.
+
+        Scan build dirs for dev hooks staged by the build (a `.pth` + a small
+        helper Python module — emitted by Holoscan-Module CMakeLists.txt at
+        configure time), and copy them into the active environment's site-packages so
+        `import holoscan.<module>` works against the live build tree without
+        a wheel install.
+
+        Build-tree-driven, not project-metadata-driven: this works whether
+        the staged hooks come from a module monorepo cwd (the module is the
+        top-level project) or from a HoloHub-clone cwd that built an app
+        depending on an external module (the module was pulled in via
+        external_modules.cmake → add_subdirectory). Each unique slug found
+        across `build/*/holoscan_<slug>_dev.py` is installed."""
+        import sysconfig as _sysconfig
+        import shutil as _shutil
+
+        dryrun = getattr(args, "dryrun", False)
+
+        site_path = _sysconfig.get_path("purelib")
+        if not site_path:
+            holohub_cli_util.fatal("Could not determine site-packages directory.")
+        site_dir = Path(site_path)
+
+        # Uninstall: enumerate installed hooks from site-packages; no build tree needed.
+        if args.uninstall:
+            if args.project:
+                slugs = [args.project.replace("-", "_").removeprefix("holoscan_")]
+            else:
+                slugs = sorted(
+                    p.stem.removeprefix("holoscan-").removesuffix("-dev").replace("-", "_")
+                    for p in site_dir.glob("holoscan-*-dev.pth")
+                )
+            if not slugs:
+                print("No installed dev hooks found.")
+                return
+            for slug in slugs:
+                kebab = slug.replace("_", "-")
+                pth_dst = site_dir / f"holoscan-{kebab}-dev.pth"
+                helper_dst = site_dir / f"holoscan_{slug}_dev.py"
+                removed_any = False
+                for p in (pth_dst, helper_dst):
+                    if p.exists():
+                        if dryrun:
+                            print(f"Would remove {p}")
+                        else:
+                            p.unlink()
+                            print(f"Removed {p}")
+                            removed_any = True
+                if not removed_any and not dryrun:
+                    print(f"No dev hook installed for '{slug}'.")
+            return
+
+        # Build dirs to scan. --build-dir wins; otherwise scan
+        # ${HOLOHUB_BUILD_PARENT_DIR}/*/ for whichever build(s) most recently
+        # staged a hook.
+        if args.build_dir is not None:
+            search_dirs = [args.build_dir.resolve()]
+            if not search_dirs[0].is_dir():
+                holohub_cli_util.fatal(f"--build-dir {search_dirs[0]} is not a directory.")
+        else:
+            build_parent = HoloHubCLI.DEFAULT_BUILD_PARENT_DIR
+            if not build_parent.is_dir():
+                holohub_cli_util.fatal(
+                    f"No build directory at {build_parent}. Run a build first, "
+                    f"or pass --build-dir <path>."
+                )
+            search_dirs = [d for d in build_parent.iterdir() if d.is_dir()]
+
+        # Collect staged hooks keyed by module slug. Most-recently-modified
+        # helper wins per slug, so building a different subproject (which
+        # restages with a fresh _BUILD_PATH) is what gets installed.
+        by_slug: dict[str, tuple[Path, float]] = {}
+        for d in search_dirs:
+            for helper in d.glob("holoscan_*_dev.py"):
+                if not helper.is_file():
+                    continue
+                slug = helper.stem.removeprefix("holoscan_").removesuffix("_dev")
+                if not slug:
+                    continue
+                pth = d / f"holoscan-{slug.replace('_', '-')}-dev.pth"
+                if not pth.exists():
+                    continue
+                mtime = helper.stat().st_mtime
+                if slug not in by_slug or by_slug[slug][1] < mtime:
+                    by_slug[slug] = (d, mtime)
+
+        # If a project arg is given, treat it as a slug filter.
+        if args.project:
+            target = args.project.replace("-", "_")
+            if target.startswith("holoscan_"):
+                target = target[len("holoscan_"):]
+            if target in by_slug:
+                by_slug = {target: by_slug[target]}
+            else:
+                holohub_cli_util.fatal(
+                    f"No staged dev hook found for module '{args.project}'. "
+                    f"Looked under: {', '.join(str(d) for d in search_dirs)}"
+                )
+
+        if not by_slug:
+            holohub_cli_util.fatal(
+                f"No staged dev hooks (holoscan_*_dev.py) found under "
+                f"{', '.join(str(d) for d in search_dirs)}. Run a build of a "
+                f"Holoscan Module (or an app that depends on one) first."
+            )
+
+        if not dryrun:
+            site_dir.mkdir(parents=True, exist_ok=True)
+        wrapper_name = Path(self.script_name).name
+
+        # Install path: copy each staged pair into site-packages.
+        for slug in sorted(by_slug):
+            build_dir, _ = by_slug[slug]
+            kebab = slug.replace("_", "-")
+            helper_name = f"holoscan_{slug}_dev.py"
+            pth_name = f"holoscan-{kebab}-dev.pth"
+            helper_dst = site_dir / helper_name
+            pth_dst = site_dir / pth_name
+            if dryrun:
+                print(f"Would install {pth_dst} from {build_dir}")
+                print(f"Would install {helper_dst} from {build_dir}")
+            else:
+                _shutil.copy2(build_dir / helper_name, helper_dst)
+                _shutil.copy2(build_dir / pth_name, pth_dst)
+                print(f"Installed {pth_dst}")
+                print(f"          {helper_dst}")
+                print(f"  → wiring `import holoscan.{slug}` to {build_dir}")
+
+        # Multi-line tail (printed once across however many slugs).
+        if not dryrun:
+            print()
+            if len(by_slug) == 1:
+                sole = next(iter(by_slug))
+                print(
+                    "Verify with: "
+                    f"python -c \"import holoscan.{sole}; "
+                    f"print(holoscan.{sole}.__file__)\""
+                )
+            else:
+                print(
+                    "Verify with: "
+                    "python -c \"import holoscan; print(holoscan.__path__)\""
+                )
+            print(f"To remove:  ./{wrapper_name} install --dev --uninstall")
 
     def _collect_cache_dirs(self, patterns: list[str], default_dir=None) -> list:
         """Helper to collect cache directories matching patterns."""

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -412,6 +412,12 @@ class HoloHubCLI:
             ),
         )
         install.add_argument(
+            "--site-dir",
+            type=Path,
+            default=None,
+            help=argparse.SUPPRESS,
+        )
+        install.add_argument(
             "--build-type",
             help="Build type (debug, release, rel-debug). "
             "If not specified, uses CMAKE_BUILD_TYPE environment variable or defaults to 'release'",
@@ -1241,19 +1247,18 @@ class HoloHubCLI:
 
     @staticmethod
     def _maybe_print_dev_hook_hint(build_dir: Path) -> None:
-        """If `build_dir` contains a staged dev-hook helper, compare against
-        the user-site copy and emit a one-line follow-up hint when the user
-        hasn't run `install --dev` (or the install is stale)."""
+        """If `build_dir` contains staged dev-hook helpers, compare each against
+        the installed site-packages copy and emit a hint when missing or stale.
+
+        Staleness is detected by comparing both the `.py` helper content and the
+        `.pth` content (which encodes the build path), so a rebuild to a new
+        output directory is correctly reported even when the helper is unchanged.
+        All staged slugs are checked, not just the first."""
         try:
             staged = sorted(Path(build_dir).glob("holoscan_*_dev.py"))
         except OSError:
             return
         if not staged:
-            return
-        helper_src = staged[0]
-        # Filename: holoscan_<slug>_dev.py
-        slug = helper_src.stem.removeprefix("holoscan_").removesuffix("_dev")
-        if not slug:
             return
 
         try:
@@ -1270,38 +1275,60 @@ class HoloHubCLI:
             site_dir = Path(site_path)
         except (ImportError, KeyError, AttributeError):
             return
-        helper_dst = site_dir / helper_src.name
 
-        try:
-            staged_text = helper_src.read_text()
-        except OSError:
-            return
-
-        if helper_dst.exists():
-            try:
-                if helper_dst.read_text() == staged_text:
-                    return  # already in sync, nothing to say
-                kind = "stale"
-            except OSError:
-                kind = "stale"
-        else:
-            kind = "missing"
-
-        # Pick a cwd-appropriate command. If the user is inside a HoloHub
-        # clone (./holohub script present), the wrapper for the external
-        # module isn't reachable from here — suggest the HoloHub CLI form.
+        # Pick a cwd-appropriate command once, reuse for all slugs.
         cwd = Path.cwd()
-        if (cwd / "utilities" / "cli" / "holohub.py").is_file():
-            cmd = "./holohub install --dev"
-        else:
-            cmd = f"./{slug} install --dev"
-        if kind == "missing":
-            print(f"\nTo make `import holoscan.{slug}` work in any shell, run:\n" f"    {cmd}")
-        else:
-            print(
-                f"\nYour installed dev hook for `holoscan.{slug}` points at a "
-                f"different build. Refresh with:\n    {cmd}"
-            )
+        cmd = (
+            "./holohub install --dev"
+            if (cwd / "utilities" / "cli" / "holohub.py").is_file()
+            else None  # filled per-slug below
+        )
+
+        for helper_src in staged:
+            slug = helper_src.stem.removeprefix("holoscan_").removesuffix("_dev")
+            if not slug:
+                continue
+
+            kebab = slug.replace("_", "-")
+            pth_src = helper_src.parent / f"holoscan-{kebab}-dev.pth"
+            helper_dst = site_dir / helper_src.name
+            pth_dst = site_dir / pth_src.name
+
+            try:
+                helper_staged = helper_src.read_text()
+            except OSError:
+                continue
+
+            pth_staged: str | None = None
+            if pth_src.exists():
+                try:
+                    pth_staged = pth_src.read_text()
+                except OSError:
+                    pass
+
+            if helper_dst.exists() and pth_dst.exists():
+                try:
+                    helper_match = helper_dst.read_text() == helper_staged
+                    pth_match = pth_staged is None or pth_dst.read_text() == pth_staged
+                    if helper_match and pth_match:
+                        continue  # in sync, nothing to say
+                    kind = "stale"
+                except OSError:
+                    kind = "stale"
+            else:
+                kind = "missing"
+
+            slug_cmd = cmd if cmd is not None else f"./{slug} install --dev"
+            if kind == "missing":
+                print(
+                    f"\nTo make `import holoscan.{slug}` work in any shell, run:\n"
+                    f"    {slug_cmd}"
+                )
+            else:
+                print(
+                    f"\nYour installed dev hook for `holoscan.{slug}` points at a "
+                    f"different build. Refresh with:\n    {slug_cmd}"
+                )
 
     def handle_build(self, args: argparse.Namespace) -> None:
         """Handle build command"""
@@ -2240,13 +2267,17 @@ class HoloHubCLI:
 
         dryrun = getattr(args, "dryrun", False)
 
-        if _sys.prefix != _sys.base_prefix:
-            site_path = _sysconfig.get_path("purelib")
+        site_dir_override = getattr(args, "site_dir", None)
+        if site_dir_override is not None:
+            site_dir = site_dir_override.resolve()
         else:
-            site_path = _site.getusersitepackages()
-        if not site_path:
-            holohub_cli_util.fatal("Could not determine site-packages directory.")
-        site_dir = Path(site_path)
+            if _sys.prefix != _sys.base_prefix:
+                site_path = _sysconfig.get_path("purelib")
+            else:
+                site_path = _site.getusersitepackages()
+            if not site_path:
+                holohub_cli_util.fatal("Could not determine site-packages directory.")
+            site_dir = Path(site_path)
 
         # Uninstall: enumerate installed hooks from site-packages; no build tree needed.
         if args.uninstall:
@@ -2254,8 +2285,14 @@ class HoloHubCLI:
                 slugs = [args.project.replace("-", "_").removeprefix("holoscan_")]
             else:
                 slugs = sorted(
-                    p.stem.removeprefix("holoscan-").removesuffix("-dev").replace("-", "_")
-                    for p in site_dir.glob("holoscan-*-dev.pth")
+                    {
+                        p.stem.removeprefix("holoscan-").removesuffix("-dev").replace("-", "_")
+                        for p in site_dir.glob("holoscan-*-dev.pth")
+                    }
+                    | {
+                        p.stem.removeprefix("holoscan_").removesuffix("_dev")
+                        for p in site_dir.glob("holoscan_*_dev.py")
+                    }
                 )
             if not slugs:
                 print("No installed dev hooks found.")
@@ -2347,8 +2384,18 @@ class HoloHubCLI:
                 print(f"Would install {pth_dst} from {build_dir}")
                 print(f"Would install {helper_dst} from {build_dir}")
             else:
-                _shutil.copy2(build_dir / helper_name, helper_dst)
-                _shutil.copy2(build_dir / pth_name, pth_dst)
+                try:
+                    _shutil.copy2(build_dir / pth_name, pth_dst)
+                    _shutil.copy2(build_dir / helper_name, helper_dst)
+                except OSError as exc:
+                    for p in (pth_dst, helper_dst):
+                        try:
+                            p.unlink(missing_ok=True)
+                        except OSError:
+                            pass
+                    holohub_cli_util.fatal(
+                        f"Failed to install dev hook for '{slug}': {exc}"
+                    )
                 print(f"Installed {pth_dst}")
                 print(f"          {helper_dst}")
                 print(f"  → wiring `import holoscan.{slug}` to {build_dir}")

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -1257,12 +1257,17 @@ class HoloHubCLI:
             return
 
         try:
+            import sys as _sys
             import sysconfig as _sysconfig
-            site_path = _sysconfig.get_path("purelib")
+            import site as _site
+            if _sys.prefix != _sys.base_prefix:
+                site_path = _sysconfig.get_path("purelib")
+            else:
+                site_path = _site.getusersitepackages()
             if not site_path:
                 return
             site_dir = Path(site_path)
-        except (ImportError, KeyError):
+        except (ImportError, KeyError, AttributeError):
             return
         helper_dst = site_dir / helper_src.name
 
@@ -2230,12 +2235,17 @@ class HoloHubCLI:
         depending on an external module (the module was pulled in via
         external_modules.cmake → add_subdirectory). Each unique slug found
         across `build/*/holoscan_<slug>_dev.py` is installed."""
+        import sys as _sys
         import sysconfig as _sysconfig
+        import site as _site
         import shutil as _shutil
 
         dryrun = getattr(args, "dryrun", False)
 
-        site_path = _sysconfig.get_path("purelib")
+        if _sys.prefix != _sys.base_prefix:
+            site_path = _sysconfig.get_path("purelib")
+        else:
+            site_path = _site.getusersitepackages()
         if not site_path:
             holohub_cli_util.fatal("Could not determine site-packages directory.")
         site_dir = Path(site_path)

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -2393,9 +2393,7 @@ class HoloHubCLI:
                             p.unlink(missing_ok=True)
                         except OSError:
                             pass
-                    holohub_cli_util.fatal(
-                        f"Failed to install dev hook for '{slug}': {exc}"
-                    )
+                    holohub_cli_util.fatal(f"Failed to install dev hook for '{slug}': {exc}")
                 print(f"Installed {pth_dst}")
                 print(f"          {helper_dst}")
                 print(f"  → wiring `import holoscan.{slug}` to {build_dir}")

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -2307,7 +2307,10 @@ class HoloHubCLI:
                         if dryrun:
                             print(f"Would remove {p}")
                         else:
-                            p.unlink()
+                            try:
+                                p.unlink()
+                            except OSError as exc:
+                                holohub_cli_util.fatal(f"Failed to remove {p}: {exc}")
                             print(f"Removed {p}")
                             removed_any = True
                 if not removed_any and not dryrun:
@@ -2369,7 +2372,10 @@ class HoloHubCLI:
             )
 
         if not dryrun:
-            site_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                site_dir.mkdir(parents=True, exist_ok=True)
+            except OSError as exc:
+                holohub_cli_util.fatal(f"Cannot create site-packages directory {site_dir}: {exc}")
         wrapper_name = Path(self.script_name).name
 
         # Install path: copy each staged pair into site-packages.

--- a/utilities/cli/tests/CMakeLists.txt
+++ b/utilities/cli/tests/CMakeLists.txt
@@ -502,3 +502,61 @@ add_test(
 set_property(TEST test_holohub_run_container_extra_scripts_xvfb PROPERTY
     PASS_REGULAR_EXPRESSION "SCRIPT=utilities/setup/xvfb.sh"
 )
+
+# ───── install --dev: dev-hook installer ─────
+# Coverage for `./holohub install --dev`, which copies the .pth + helper
+# that a Holoscan-Module build stages into the user's Python user-site so
+# `import holoscan.<module>` resolves to the live build tree.
+
+# `--dev` is wired into the install command's argparse: surface it in
+# --help to catch accidental removal. COLUMNS=200 keeps argparse from
+# wrapping the usage line — the regex is single-line (cmsys's `.` does
+# not match newline).
+add_test(
+    NAME test_holohub_install_dev_help_advertises_flags
+    COMMAND sh -c "COLUMNS=200 ${CMAKE_SOURCE_DIR}/holohub install --help"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_tests_properties(test_holohub_install_dev_help_advertises_flags PROPERTIES
+    PASS_REGULAR_EXPRESSION "--dev.*--uninstall.*--build-dir"
+)
+
+# `install --dev` against an empty build dir must hit the
+# no-staged-hooks fatal path (and not crash with a stack trace from
+# elsewhere). Use --build-dir to avoid touching whatever the user has
+# in their default build dir at test time.
+add_test(
+    NAME test_holohub_install_dev_no_staged_hooks
+    COMMAND sh -c "rm -rf ${CMAKE_BINARY_DIR}/test_install_dev_empty && \
+        mkdir -p ${CMAKE_BINARY_DIR}/test_install_dev_empty && \
+        ${CMAKE_SOURCE_DIR}/holohub install --dev --build-dir ${CMAKE_BINARY_DIR}/test_install_dev_empty 2>&1 || true"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_tests_properties(test_holohub_install_dev_no_staged_hooks PROPERTIES
+    PASS_REGULAR_EXPRESSION "No staged dev hooks .holoscan_.*_dev.py."
+    FAIL_REGULAR_EXPRESSION "Traceback"
+)
+
+# `install --dev --build-dir <missing-path>` must hit the "is not a
+# directory" fatal path before any user-site work.
+add_test(
+    NAME test_holohub_install_dev_missing_build_dir
+    COMMAND sh -c "${CMAKE_SOURCE_DIR}/holohub install --dev --build-dir /tmp/holohub-test-nonexistent-$$ 2>&1 || true"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_tests_properties(test_holohub_install_dev_missing_build_dir PROPERTIES
+    PASS_REGULAR_EXPRESSION "is not a directory"
+    FAIL_REGULAR_EXPRESSION "Traceback"
+)
+
+# `--uninstall` without `--dev` must be rejected — the regular install
+# path doesn't own user-site files.
+add_test(
+    NAME test_holohub_install_uninstall_requires_dev
+    COMMAND sh -c "${CMAKE_SOURCE_DIR}/holohub install some_project --uninstall --dryrun 2>&1 || true"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_tests_properties(test_holohub_install_uninstall_requires_dev PROPERTIES
+    PASS_REGULAR_EXPRESSION "--uninstall is only valid with --dev"
+    FAIL_REGULAR_EXPRESSION "Traceback"
+)

--- a/utilities/cli/tests/CMakeLists.txt
+++ b/utilities/cli/tests/CMakeLists.txt
@@ -514,7 +514,7 @@ set_property(TEST test_holohub_run_container_extra_scripts_xvfb PROPERTY
 # not match newline).
 add_test(
     NAME test_holohub_install_dev_help_advertises_flags
-    COMMAND sh -c "COLUMNS=200 ${CMAKE_SOURCE_DIR}/holohub install --help"
+    COMMAND sh -c "COLUMNS=200 \"${CMAKE_SOURCE_DIR}/holohub\" install --help"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 set_tests_properties(test_holohub_install_dev_help_advertises_flags PROPERTIES
@@ -527,9 +527,10 @@ set_tests_properties(test_holohub_install_dev_help_advertises_flags PROPERTIES
 # in their default build dir at test time.
 add_test(
     NAME test_holohub_install_dev_no_staged_hooks
-    COMMAND sh -c "rm -rf ${CMAKE_BINARY_DIR}/test_install_dev_empty && \
-        mkdir -p ${CMAKE_BINARY_DIR}/test_install_dev_empty && \
-        ${CMAKE_SOURCE_DIR}/holohub install --dev --build-dir ${CMAKE_BINARY_DIR}/test_install_dev_empty 2>&1 || true"
+    COMMAND sh -c "rm -rf \"${CMAKE_BINARY_DIR}/test_install_dev_empty\" && \
+        mkdir -p \"${CMAKE_BINARY_DIR}/test_install_dev_empty\" && \
+        \"${CMAKE_SOURCE_DIR}/holohub\" install --dev \
+            --build-dir \"${CMAKE_BINARY_DIR}/test_install_dev_empty\" 2>&1 || true"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 set_tests_properties(test_holohub_install_dev_no_staged_hooks PROPERTIES
@@ -541,7 +542,8 @@ set_tests_properties(test_holohub_install_dev_no_staged_hooks PROPERTIES
 # directory" fatal path before any user-site work.
 add_test(
     NAME test_holohub_install_dev_missing_build_dir
-    COMMAND sh -c "${CMAKE_SOURCE_DIR}/holohub install --dev --build-dir /tmp/holohub-test-nonexistent-$$ 2>&1 || true"
+    COMMAND sh -c "\"${CMAKE_SOURCE_DIR}/holohub\" install --dev \
+        --build-dir /tmp/holohub-test-nonexistent-$$ 2>&1 || true"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 set_tests_properties(test_holohub_install_dev_missing_build_dir PROPERTIES
@@ -553,10 +555,39 @@ set_tests_properties(test_holohub_install_dev_missing_build_dir PROPERTIES
 # path doesn't own user-site files.
 add_test(
     NAME test_holohub_install_uninstall_requires_dev
-    COMMAND sh -c "${CMAKE_SOURCE_DIR}/holohub install some_project --uninstall --dryrun 2>&1 || true"
+    COMMAND sh -c "\"${CMAKE_SOURCE_DIR}/holohub\" install some_project \
+        --uninstall --dryrun 2>&1 || true"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 set_tests_properties(test_holohub_install_uninstall_requires_dev PROPERTIES
     PASS_REGULAR_EXPRESSION "--uninstall is only valid with --dev"
+    FAIL_REGULAR_EXPRESSION "Traceback"
+)
+
+# Round-trip: stage a fake hook pair into a temp build dir, install into a
+# sandboxed site dir via --site-dir, verify the files land, then uninstall
+# and confirm removal is reported. Uses --site-dir to avoid touching the
+# real Python environment.
+add_test(
+    NAME test_holohub_install_dev_round_trip
+    COMMAND sh -c "rm -rf \
+            \"${CMAKE_BINARY_DIR}/test_rt_build\" \
+            \"${CMAKE_BINARY_DIR}/test_rt_site\" && \
+        mkdir -p \
+            \"${CMAKE_BINARY_DIR}/test_rt_build\" \
+            \"${CMAKE_BINARY_DIR}/test_rt_site\" && \
+        printf 'pass\n' > \
+            \"${CMAKE_BINARY_DIR}/test_rt_build/holoscan_mymod_dev.py\" && \
+        printf 'holoscan_mymod_dev\n' > \
+            \"${CMAKE_BINARY_DIR}/test_rt_build/holoscan-mymod-dev.pth\" && \
+        \"${CMAKE_SOURCE_DIR}/holohub\" install --dev \
+            --build-dir \"${CMAKE_BINARY_DIR}/test_rt_build\" \
+            --site-dir \"${CMAKE_BINARY_DIR}/test_rt_site\" && \
+        \"${CMAKE_SOURCE_DIR}/holohub\" install --dev --uninstall \
+            --site-dir \"${CMAKE_BINARY_DIR}/test_rt_site\" 2>&1"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_tests_properties(test_holohub_install_dev_round_trip PROPERTIES
+    PASS_REGULAR_EXPRESSION "Removed.*holoscan"
     FAIL_REGULAR_EXPRESSION "Traceback"
 )

--- a/utilities/cli/tests/CMakeLists.txt
+++ b/utilities/cli/tests/CMakeLists.txt
@@ -543,7 +543,7 @@ set_tests_properties(test_holohub_install_dev_no_staged_hooks PROPERTIES
 add_test(
     NAME test_holohub_install_dev_missing_build_dir
     COMMAND sh -c "\"${CMAKE_SOURCE_DIR}/holohub\" install --dev \
-        --build-dir /tmp/holohub-test-nonexistent-$$ 2>&1 || true"
+        --build-dir \"${CMAKE_BINARY_DIR}/test_install_dev_missing\" 2>&1 || true"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
 set_tests_properties(test_holohub_install_dev_missing_build_dir PROPERTIES


### PR DESCRIPTION
## Overview

Adds CLI support to install Python environment hooks so that `import <my_holohub_module>` succeeds without explicit PYTHONPATH updates.

## Background

- HoloHub Python projects typically write to a build output path at `build/<my_project>/python/lib/holohub/<my_project>`. This path is not known to the Python environment by default, and needs some custom handling. Today:
    - HoloHub CLI commands append this path to PYTHONPATH, so `./holohub run <my_app>` runs without issue
    - Advanced users can explicitly add this path to their PYTHONPATH for development. Requires knowledge of the build tree structure and does not persist across sessions.
- Holoscan SDK <=4.2 wheels strictly enforce a single import path. The strategies above are sufficient to resolve `import holohub.<module>` but not `import holoscan.<module>`.
- The Holoscan Module Template's CMakeLists.txt can stage a `.pth` + helper at configure time so that `import holoscan.<module>` resolves to the live build tree. Today these files must be hand-copied to the site-packages folder to be effective.

## Update

`./holohub install --dev` scans build dirs for staged hooks (`holoscan_<slug>_dev.py` + `holoscan-<kebab>-dev.pth`), copies the most-recent pair per slug into Python user-site, and prints verify/remove instructions. `--uninstall` removes them; `--build-dir` overrides the scan path.

## Result

Verified a toy module example:

```bash
$ ./holohub create mod --template modules/template
...  # set up the module, enter the container, build the project
2026-05-19 18:42:51 $ cmake --build /workspace/mod/build/mod_op --config Release -j 32
ninja: no work to do.

To make `import holoscan.mod` work in any shell, run:
    ./mod install --dev

# Validate .pth installation succeeds
$ ./holohub install --dev
...
Installed /workspace/mod/.local/lib/python3.12/site-packages/holoscan-mod-dev.pth
          /workspace/mod/.local/lib/python3.12/site-packages/holoscan_mod_dev.py
  → wiring `import holoscan.mod` to /workspace/mod/build/mod_op

Verify with: python -c "import holoscan.mod; print(holoscan.mod.__file__)"
To remove:  ./holohub install --dev --uninstall

# Verify the module is importable
$ python3
Python 3.12.3 (main, Mar  3 2026, 12:15:18) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import holoscan.mod
>>> dir(holoscan.mod)
['ModOp', '__all__', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', 'mod_op']
>>> print(holoscan.mod.__file__)
/workspace/mod/build/mod_op/python/holoscan/mod/__init__.py
>>> print(holoscan.__version__)
4.2.0

# Validate uninstall
$ ./holohub install --dev --uninstall
...
Removed /workspace/mod/.local/lib/python3.12/site-packages/holoscan-mod-dev.pth
Removed /workspace/mod/.local/lib/python3.12/site-packages/holoscan_mod_dev.py

# Validate .pth is no longer observed
$ python3 -c "import holoscan.mod"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'holoscan.mod'
```

## Looking Ahead

- Upcoming Holoscan SDK planning: `import holoscan.<my_module>` from multiple paths will be supported out-of-the-box. Dev-hook workaround is not strictly required for modules extending the `holoscan` namespace.
- Dev-hook remains convenient for advanced users seeking persistent build dir reference in their virtual environment.

Assisted-by: Claude:claude-opus-4.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--dev` mode for development hook installation and management.
  * Added `--uninstall` flag to remove dev hooks (only with `--dev`).
  * Added `--build-dir` and `--site-dir` options to control staging and installation locations.
  * Project argument is optional when using `--dev`.
  * Builds now display follow-up hints when dev hooks were staged, with instructions to install/refresh them.

* **Tests**
  * Added end-to-end tests covering `install --dev` install/uninstall and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nvidia-holoscan/holohub/pull/1566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->