### PR TITLE
Infra: Introduce in-tree Holoscan Module support and add Holoscan GStreamer reference

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,9 @@ include(${CMAKE_BINARY_DIR}/external_operators_manifest.cmake OPTIONAL)
 # Build packaging
 add_subdirectory(pkg)
 
+# Build modules
+add_subdirectory(modules)
+
 # Build the workflows
 add_subdirectory(workflows)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,27 @@ if(HOLOHUB_BUILD_PYTHON)
   if(NOT CMAKE_INSTALL_LIBDIR)
     set(CMAKE_INSTALL_LIBDIR lib)
   endif()
-  set(HOLOHUB_PYTHON_MODULE_OUT_DIR ${CMAKE_BINARY_DIR}/python/${CMAKE_INSTALL_LIBDIR}/holohub)
+  if(DEFINED SKBUILD)
+    # When scikit-build-core drives the build it sets SKBUILD. Use a flat
+    # output path so the wheel installs the holohub package directly into
+    # site-packages rather than three directories deep (python/lib/holohub).
+    set(HOLOHUB_PYTHON_MODULE_OUT_DIR ${CMAKE_BINARY_DIR}/holohub)
+  else()
+    set(HOLOHUB_PYTHON_MODULE_OUT_DIR ${CMAKE_BINARY_DIR}/python/${CMAKE_INSTALL_LIBDIR}/holohub)
+  endif()
   file(MAKE_DIRECTORY ${HOLOHUB_PYTHON_MODULE_OUT_DIR})
+  if(DEFINED SKBUILD)
+    set(_holohub_py_dest ".")
+  else()
+    set(_holohub_py_dest "python/lib")
+  endif()
+  install(
+      DIRECTORY "${HOLOHUB_PYTHON_MODULE_OUT_DIR}"
+      DESTINATION "${_holohub_py_dest}"
+      FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+      DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+      PATTERN "__pycache__" EXCLUDE
+  )
 
   # Find the Python interpreter
   find_package(Python COMPONENTS Interpreter)

--- a/cmake/HoloHubConfigHelpers.cmake
+++ b/cmake/HoloHubConfigHelpers.cmake
@@ -25,8 +25,11 @@
 # - add_holohub_application(): Build applications with operator/extension dependencies
 # - add_holohub_operator(): Build operators with extension dependencies
 # - add_holohub_extension(): Build extensions
-# - holohub_declare_external_module(): Declare an external Holoscan Module and register
-#   its operators with HoloHub's lazy-fetch post-step
+#
+# Holoscan Modules (in-tree and external):
+# - add_holohub_module(): Enable an in-tree Holoscan Module subproject (MODULE_ option)
+# - holohub_declare_external_module(): Declare an external Holoscan Module fetched via
+#   FetchContent and register its operators with HoloHub's lazy-fetch post-step
 #
 # Global Variables:
 # - BUILD_ALL: Global flag to enable/disable all components (default: OFF)
@@ -61,7 +64,11 @@
 #     APPLICATIONS my_application
 #   )
 function(add_holohub_package NAME)
-  set(pkgname "PKG_${NAME}")
+  # Normalize hyphens to underscores for the CMake cache variable so that
+  # -DPKG_holoscan_gstreamer=ON (CLI convention) matches the option regardless
+  # of whether the caller spelled the name with hyphens or underscores.
+  string(REPLACE "-" "_" _pkg_slug "${NAME}")
+  set(pkgname "PKG_${_pkg_slug}")
   option(${pkgname} "Build the ${NAME} package" ${BUILD_ALL})
 
   message(DEBUG "${pkgname} = ${${pkgname}}")
@@ -77,6 +84,52 @@ function(add_holohub_package NAME)
   message(DEBUG "${pkgname} exts = ${DEPS_EXTENSIONS}")
   message(DEBUG "${pkgname} ops = ${DEPS_OPERATORS}")
   message(DEBUG "${pkgname} apps = ${DEPS_APPLICATIONS}")
+  foreach(dep IN LISTS DEPS_EXTENSIONS)
+    set("EXT_${dep}" ON CACHE BOOL "Build the ${dep} GXF extension" FORCE)
+  endforeach()
+  foreach(dep IN LISTS DEPS_OPERATORS)
+    set("OP_${dep}" ON CACHE BOOL "Build the ${dep} holoscan operator" FORCE)
+  endforeach()
+  foreach(dep IN LISTS DEPS_APPLICATIONS)
+    set("APP_${dep}" ON CACHE BOOL "Build the ${dep} application" FORCE)
+  endforeach()
+endfunction()
+
+# =====================================================
+# Helper function to enable an in-tree Holoscan Module
+# =====================================================
+# Enables a Holoscan Module subproject and force-enables its operator/application
+# dependencies. The module's own CMakeLists.txt is responsible for its configuration
+# behavior (packaging, data downloads, external module declarations, cache variables, etc.).
+#
+# Parameters:
+#   NAME: Module name — hyphens are normalized to underscores for the cache variable,
+#         but the original name is used for add_subdirectory to match the directory.
+#
+# Keyword Arguments:
+#   OPERATORS:    Holoscan operators this module depends on
+#   APPLICATIONS: Applications this module depends on
+#   EXTENSIONS:   GXF extensions this module depends on
+#
+# Creates:
+#   MODULE_${NAME}: CMake option to enable/disable this module (default: ${BUILD_ALL})
+#
+# Example:
+#   add_holohub_module(holoscan-gstreamer OPERATORS gstreamer)
+#
+function(add_holohub_module NAME)
+  string(REPLACE "-" "_" _mod_slug "${NAME}")
+  set(modname "MODULE_${_mod_slug}")
+  option(${modname} "Enable the ${NAME} Holoscan Module" ${BUILD_ALL})
+
+  message(DEBUG "${modname} = ${${modname}}")
+
+  if(NOT ${modname})
+    return()
+  endif()
+  add_subdirectory(${NAME})
+
+  cmake_parse_arguments(DEPS "" "" "EXTENSIONS;OPERATORS;APPLICATIONS" ${ARGN})
   foreach(dep IN LISTS DEPS_EXTENSIONS)
     set("EXT_${dep}" ON CACHE BOOL "Build the ${dep} GXF extension" FORCE)
   endforeach()

--- a/cmake/pybind11_add_holohub_module.cmake
+++ b/cmake/pybind11_add_holohub_module.cmake
@@ -69,7 +69,8 @@ function(pybind11_add_holohub_module)
     )
     list(APPEND _rpath
         "\$ORIGIN/${install_lib_relative_path}" # in our install tree (same layout as src)
-        "\$ORIGIN/../lib" # in our python wheel"
+        "\$ORIGIN/../../lib" # in our python wheel (module at holohub/<pkg>/_mod.so → lib/ is two levels up)
+        "\$ORIGIN/../lib"    # legacy fallback for one-level-deep layouts
     )
     list(JOIN _rpath ":" _rpath)
     set_property(TARGET ${target_name}

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_holohub_module(holoscan-gstreamer OPERATORS gstreamer)

--- a/modules/README.md
+++ b/modules/README.md
@@ -31,7 +31,7 @@ An in-tree module uses a **descriptor-only** layout: the operator sources stay i
 descriptor directory under `modules/<module-name>/` holds the module-level metadata
 and packaging files.
 
-```
+```text
 modules/
 └── holoscan-gstreamer/          ← module descriptor (this directory)
     ├── metadata.json            ← module schema v2: identity, namespace, operators list

--- a/modules/README.md
+++ b/modules/README.md
@@ -2,7 +2,7 @@
 
 A **Holoscan Module** is a library project that extends the Holoscan SDK API.
 
-## Creating a New Module
+## Creating a New External Module
 
 Run the following command to initialize a new module adhering to HoloHub conventions
 from the provided cookiecutter template. The template will prompt for several project
@@ -14,3 +14,51 @@ pip install cookiecutter
 
 ./holohub create <my_module> --template modules/template
 ```
+
+The generated project is a self-contained git repository with its own operators/,
+applications/, tests/, and packaging files. It is intended to be hosted outside of
+HoloHub (e.g. a dedicated GitHub repo) and declared as an external dependency in
+consuming applications' metadata.json.
+
+## Declaring an In-Tree Module
+
+Some Holoscan Modules are best maintained directly inside the HoloHub monorepo —
+either because their operator libraries are already there or because tight integration
+with HoloHub's CI and tooling is desirable. These are called **in-tree modules**.
+
+An in-tree module uses a **descriptor-only** layout: the operator sources stay in
+`operators/<name>/` (and applications in `applications/<name>/`) while a thin
+descriptor directory under `modules/<module-name>/` holds the module-level metadata
+and packaging files.
+
+```
+modules/
+└── holoscan-gstreamer/          ← module descriptor (this directory)
+    ├── metadata.json            ← module schema v2: identity, namespace, operators list
+    ├── pyproject.toml           ← wheel packaging (drives HoloHub's CMake selectively)
+    └── Dockerfile               ← dev container for module-focused development
+
+operators/gstreamer/             ← operator sources (unchanged, in-tree as always)
+applications/gstreamer/          ← application sources (unchanged)
+```
+
+### Creating an In-Tree Module Descriptor
+
+1. Create `modules/<holoscan-name>/` (e.g. `modules/holoscan-gstreamer/`).
+2. Add `metadata.json` using the `holohub/module/v2` schema. Omit `source_repository`
+   (the module lives in HoloHub). Set `operators` to the list of HoloHub `OP_*` names
+   the module provides.
+3. Add `pyproject.toml` with `cmake.source-dir = "../.."` pointing at HoloHub root,
+   and `-DOP_<name>=ON -DBUILD_ALL=OFF` to build only the module's operators.
+4. Add a `Dockerfile` extending the Holoscan SDK base image with module-specific
+   system dependencies.
+
+See `modules/holoscan-gstreamer/` for a complete reference example.
+
+### Dependency Resolution for In-Tree Modules
+
+The HoloHub CLI resolver (`utilities/cli/external_resolver.py`) automatically
+recognizes in-tree modules: a dependency with no `source` block is looked up in
+`modules/<name>/metadata.json`. If found, the dep is marked `is_internal=True` and
+the CMake manifest emits a comment instead of a FetchContent_Declare — the operators
+are already present in HoloHub's tree and are built when `OP_<name>=ON`.

--- a/modules/holoscan-gstreamer/CMakeLists.txt
+++ b/modules/holoscan-gstreamer/CMakeLists.txt
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(holohub_configure_deb)
+
+# Debian packaging
+set(_deb_depends
+    "holoscan-cuda-13 (>= 4.2.0)"
+    "libgstreamer1.0-0"
+    "libgstreamer-plugins-base1.0-0"
+    "libgstreamer-plugins-bad1.0-0"
+    "gstreamer1.0-plugins-good"
+    "gstreamer1.0-plugins-bad"
+    "gstreamer1.0-libav"
+    "gstreamer1.0-tools"
+)
+list(JOIN _deb_depends ", " _deb_depends_str)
+
+holohub_configure_deb(
+    NAME        holoscan-gstreamer
+    DESCRIPTION "GStreamer bridge operators for video recording and streaming in Holoscan applications"
+    VERSION     1.0.0
+    VENDOR      "NVIDIA Corporation"
+    CONTACT     "NVIDIA Corporation"
+    DEPENDS     "${_deb_depends_str}"
+)
+
+# Wheel packaging: see pyproject.toml

--- a/modules/holoscan-gstreamer/metadata.json
+++ b/modules/holoscan-gstreamer/metadata.json
@@ -2,7 +2,7 @@
   "$schema": "holoscan/module/v2",
   "module": {
     "name": "holoscan-gstreamer",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "description": "GStreamer bridge operators for video recording and streaming in Holoscan applications",
     "authors": [
       {
@@ -26,7 +26,7 @@
       "tested_versions": ["4.2.0"]
     },
     "platforms": ["x86_64", "aarch64"],
-    "tags": ["GStreamer", "Video", "Recording", "Multimedia", "Streaming", "CUDA"],
+    "tags": ["Video", "GStreamer", "Recording", "Multimedia", "Streaming", "CUDA"],
     "requirements": {
       "system_packages": [
         "libgstreamer1.0-dev",

--- a/modules/holoscan-gstreamer/metadata.json
+++ b/modules/holoscan-gstreamer/metadata.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "holoscan/module/v2",
+  "module": {
+    "name": "holoscan-gstreamer",
+    "version": "0.1.0",
+    "description": "GStreamer bridge operators for video recording and streaming in Holoscan applications",
+    "authors": [
+      {
+        "name": "Holoscan Team",
+        "affiliation": "NVIDIA"
+      }
+    ],
+    "license": "Apache-2.0",
+    "language": ["C++", "Python"],
+    "namespace": {
+      "cpp": "holoscan::gstreamer",
+      "python": "holoscan.gstreamer"
+    },
+    "operators": ["gstreamer"],
+    "subprojects": {
+      "operators": ["gstreamer"],
+      "applications": ["gst_to_holo", "holo_to_gst", "gst_video_recorder"]
+    },
+    "holoscan_sdk": {
+      "minimum_required_version": "4.2.0",
+      "tested_versions": ["4.2.0"]
+    },
+    "platforms": ["x86_64", "aarch64"],
+    "tags": ["GStreamer", "Video", "Recording", "Multimedia", "Streaming", "CUDA"],
+    "requirements": {
+      "system_packages": [
+        "libgstreamer1.0-dev",
+        "libgstreamer-plugins-base1.0-dev",
+        "libgstreamer-plugins-bad1.0-dev",
+        "gstreamer1.0-plugins-good",
+        "gstreamer1.0-plugins-bad",
+        "gstreamer1.0-libav",
+        "gstreamer1.0-tools"
+      ]
+    },
+    "binary_packages": {
+      "pypi": "holoscan-gstreamer",
+      "install_commands": ["pip install holoscan-gstreamer"]
+    },
+    "dockerfile": "operators/gstreamer/Dockerfile",
+    "documentation": {
+      "readme": "../../operators/gstreamer/README.md"
+    },
+    "testing": {
+      "cpp": "ctest",
+      "python": "pytest"
+    }
+  }
+}

--- a/modules/holoscan-gstreamer/pyproject.toml
+++ b/modules/holoscan-gstreamer/pyproject.toml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["scikit-build-core>=0.10"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "holoscan-gstreamer"
+version = "1.0.0"
+description = "GStreamer bridge operators for video recording and streaming in Holoscan applications"
+readme = "../../operators/gstreamer/README.md"
+license = { text = "Apache-2.0" }
+authors = [
+    { name = "NVIDIA Corporation" },
+]
+requires-python = ">=3.10"
+
+# NOTE: holoscan SDK is not declared as a runtime dependency here because the
+# wheel cannot guarantee binary compatibility across CUDA variants (cu12/cu13).
+# Install holoscan separately before using this wheel.
+
+# NOTE: GStreamer system packages are required at build time and runtime.
+# Install them before building or using this wheel:
+#   sudo apt-get install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+#       libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-good \
+#       gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-tools
+
+[tool.scikit-build]
+cmake.version = ">=3.20"
+# Point at HoloHub root so the wheel build uses HoloHub's existing CMake
+# infrastructure with only the gstreamer operator enabled.
+cmake.source-dir = "../.."
+cmake.build-type = "Release"
+# Build only what the wheel needs.
+cmake.args = [
+    "-DBUILD_ALL=OFF",
+    "-DMODULE_holoscan_gstreamer=ON",
+    "-DHOLOHUB_BUILD_PYTHON=ON",
+]
+wheel.packages = []
+
+# TODO: The Python bindings are currently installed under the holohub.* namespace
+# (holohub.holoscan_gstreamer_bridge). A follow-on task should migrate the Python
+# package to the holoscan.gstreamer namespace declared in this module's metadata.json.
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "UP"]
+ignore = ["E501", "UP007"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["holoscan"]

--- a/operators/CMakeLists.txt
+++ b/operators/CMakeLists.txt
@@ -70,12 +70,3 @@ add_holohub_operator(yuan_qcap DEPENDS EXTENSIONS yuan_qcap)
 add_holohub_operator(ehr_query_llm)
 add_holohub_operator(xr)
 
-if(HOLOHUB_BUILD_PYTHON)
-  install(
-      DIRECTORY "${CMAKE_BINARY_DIR}/python/lib/holohub"
-      DESTINATION python/lib
-      FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-      DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-      PATTERN "__pycache__" EXCLUDE
-  )
-endif()

--- a/operators/CMakeLists.txt
+++ b/operators/CMakeLists.txt
@@ -69,4 +69,3 @@ add_holohub_operator(vtk_renderer)
 add_holohub_operator(yuan_qcap DEPENDS EXTENSIONS yuan_qcap)
 add_holohub_operator(ehr_query_llm)
 add_holohub_operator(xr)
-

--- a/operators/gstreamer/Dockerfile
+++ b/operators/gstreamer/Dockerfile
@@ -73,8 +73,19 @@ RUN /tmp/scripts/holohub setup && rm -rf /var/lib/apt/lists/*
 COPY operators/gstreamer/install_deps.sh /tmp/install_deps.sh
 RUN /tmp/install_deps.sh
 
-# Install Python test dependencies
-RUN python3 -m pip install pytest
+# Build tooling for C++ development and Python binding compilation
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        clang-format \
+        pybind11-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python tooling: pytest for tests, build + scikit-build-core for wheel packaging
+RUN python3 -m pip install --no-cache-dir \
+        pytest \
+        pytest-timeout \
+        build \
+        scikit-build-core
 
 # Enable autocomplete
 RUN echo ". /etc/bash_completion.d/holohub_autocomplete" >> /etc/bash.bashrc

--- a/utilities/cli/cmake_manifest.py
+++ b/utilities/cli/cmake_manifest.py
@@ -72,6 +72,18 @@ def write_external_operators_manifest(
     seen_provider_ids: dict[str, str] = {}
 
     for dep in deps:
+        if dep.is_internal:
+            # In-tree modules have their operators built by HoloHub's normal
+            # operators/CMakeLists.txt when OP_<name>=ON. No FetchContent needed.
+            lines.append(f"# {dep.name} (in-tree: {dep.override_path})")
+            if dep.provides_operators:
+                lines.append(
+                    f"# Operators {dep.provides_operators} are built by HoloHub's "
+                    "operators/CMakeLists.txt when the corresponding OP_* flags are ON."
+                )
+            lines.append("")
+            continue
+
         provider = _provider_id(dep.name)
         if (prior_name := seen_provider_ids.get(provider)) and prior_name != dep.name:
             print(

--- a/utilities/cli/external_resolver.py
+++ b/utilities/cli/external_resolver.py
@@ -33,13 +33,19 @@ def _ref_is_immutable(ref: str) -> bool:
 
 @dataclass
 class ModuleDep:
-    """A parsed external module dependency from a consumer's metadata.json."""
+    """A parsed module dependency from a consumer's metadata.json.
+
+    `is_internal=True` means the module lives inside the HoloHub tree (under
+    modules/<name>/) and requires no FetchContent fetch — its operators are
+    already included by HoloHub's normal operators/CMakeLists.txt.
+    """
 
     name: str
     git_url: Optional[str] = None
     ref: Optional[str] = None
     provides_operators: list[str] = field(default_factory=list)
     override_path: Optional[Path] = None
+    is_internal: bool = False
 
 
 def _override_env_name(module_name: str) -> str:
@@ -69,13 +75,22 @@ def _module_dependencies_raw(metadata: dict) -> list[dict]:
     return []
 
 
-def parse_module_dependencies(metadata_path: Path) -> list[ModuleDep]:
-    """Parse a metadata.json's external module dependency list into ModuleDep
-    records. Honors HOLOHUB_LOCAL_<NAME> env-var overrides by populating
-    `override_path`. Does not fetch anything. A missing metadata.json is
-    treated as "no external deps" rather than an error — unifies the
-    file-doesn't-exist path with the
-    file-vanished-between-exists-and-open race window."""
+def parse_module_dependencies(
+    metadata_path: Path,
+    holohub_root: Optional[Path] = None,
+) -> list[ModuleDep]:
+    """Parse a metadata.json's module dependency list into ModuleDep records.
+
+    Honors HOLOHUB_LOCAL_<NAME> env-var overrides by populating `override_path`.
+    When `holohub_root` is provided, dependencies with no `source` block are
+    checked against `holohub_root/modules/<name>/` — if a metadata.json exists
+    there, the dep is treated as an in-tree module (`is_internal=True`) rather
+    than raising an error.
+
+    Does not fetch anything. A missing metadata.json is treated as "no deps"
+    rather than an error — unifies the file-doesn't-exist path with the
+    file-vanished-between-exists-and-open race window.
+    """
     try:
         metadata = _read_metadata(metadata_path)
     except FileNotFoundError:
@@ -107,10 +122,24 @@ def parse_module_dependencies(metadata_path: Path) -> list[ModuleDep]:
         git_url = source.get("git_url")
         if override_path is None:
             if not (git_url and ref):
+                # Check if this is an in-tree module before raising.
+                if holohub_root is not None:
+                    in_tree_path = holohub_root / "modules" / name
+                    if (in_tree_path / "metadata.json").exists():
+                        out.append(
+                            ModuleDep(
+                                name=name,
+                                provides_operators=provides,
+                                is_internal=True,
+                                override_path=in_tree_path,
+                            )
+                        )
+                        continue
                 raise ValueError(
                     f"Dependency '{name}' missing source.git_url or source.ref. "
-                    f"Declare a complete source block or set "
-                    f"{_override_env_name(name)}=<path>."
+                    f"Declare a complete source block, set "
+                    f"{_override_env_name(name)}=<path>, or add a module descriptor "
+                    f"at modules/{name}/metadata.json for in-tree modules."
                 )
             if not _ref_is_immutable(ref):
                 import sys as _sys

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -2311,7 +2311,6 @@ class HoloHubCLI:
                 wheel_env["PYTHONSAFEPATH"] = "1"
                 wheel_cmd = [
                     sys.executable,
-                    "-P",
                     "-m",
                     "build",
                     "--wheel",
@@ -2362,6 +2361,8 @@ class HoloHubCLI:
                 build_cmd += f" --language {args.language}"
             if args.dryrun:
                 build_cmd += " --dryrun"
+            if getattr(args, "verbose", False):
+                build_cmd += " --verbose"
             docker_opts = (getattr(args, "docker_opts", None) or "").strip()
             docker_opts_extra, extra_args = holohub_cli_util.get_entrypoint_command_args(
                 getattr(args, "img", None) or container.image_name,

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -448,6 +448,42 @@ class HoloHubCLI:
         )
         install.set_defaults(func=self.handle_install)
 
+        # Add package command
+        package = subparsers.add_parser(
+            "package",
+            help="Build a distribution package (.deb / wheel) for a module",
+            parents=[container_build_argparse, container_run_argparse],
+        )
+        self.subparsers["package"] = package
+        package.add_argument(
+            "project",
+            type=str,
+            nargs="?",
+            default=None,
+            help="Module name to package (default: read ./metadata.json from cwd)",
+        )
+        package.add_argument(
+            "--local", action="store_true", help="Run packaging locally instead of in container"
+        )
+        package.add_argument(
+            "--build-type",
+            type=str,
+            default=None,
+            choices=["debug", "release", "rel-debug"],
+            help="Build type (default: release)",
+        )
+        package.add_argument(
+            "--pkg-generator",
+            type=str,
+            default="DEB",
+            dest="pkg_generator",
+            help="Comma-separated package generators: DEB, WHEEL (default: DEB)",
+        )
+        package.add_argument("--language", choices=["cpp", "python"], default=None)
+        package.add_argument("--verbose", action="store_true")
+        package.add_argument("--dryrun", action="store_true", default=False)
+        package.set_defaults(func=self.handle_package)
+
         # Add test command
         test = subparsers.add_parser(
             "test", help="Test a project", parents=[container_build_argparse]
@@ -537,8 +573,11 @@ class HoloHubCLI:
     def _collect_metadata(self) -> None:
         """Create an unstructured database of metadata for all projects"""
 
-        EXCLUDE_PATHS = ["applications/holoviz/template", "applications/template"]
-        # Known exceptions, such as template files that do not represent a standalone project
+        EXCLUDE_PATHS = [
+            "applications/holoviz/template",
+            "applications/template",
+            "modules/template",  # cookiecutter template — not a real module
+        ]
 
         app_paths = holohub_cli_util.get_component_search_paths(self.HOLOHUB_ROOT)
         self.projects = metadata_util.gather_metadata(app_paths, exclude_paths=EXCLUDE_PATHS)
@@ -1114,8 +1153,21 @@ class HoloHubCLI:
             f"-DCMAKE_BUILD_TYPE={build_type}",
             f"-DCMAKE_PREFIX_PATH={HoloHubCLI.DEFAULT_SDK_DIR}/lib",
             f"-DHOLOHUB_DATA_DIR:PATH={HoloHubCLI.DEFAULT_DATA_DIR}",
-            f"-D{proj_prefix}_{project_name}=ON",
         ]
+        if project_type == "module":
+            subprojects = project_data.get("metadata", {}).get("subprojects", {})
+            ops = subprojects.get("operators", [])
+            apps = subprojects.get("applications", [])
+            parts = ([f"operators: {ops}"] if ops else []) + (
+                [f"applications: {apps}"] if apps else []
+            )
+            print(f"Building module '{project_name}': enabling {', '.join(parts)}")
+            for op in ops:
+                cmake_args.append(f"-DOP_{op}=ON")
+            for app in apps:
+                cmake_args.append(f"-DAPP_{app}=ON")
+        else:
+            cmake_args.append(f"-D{proj_prefix}_{project_name}=ON")
         # Add benchmark-specific CMake flags
         if benchmark:
             cmake_args.append(
@@ -1696,6 +1748,7 @@ class HoloHubCLI:
             "application",
             "benchmark",
             "gxf_extension",
+            "module",
             "package",
             "operator",
             "tutorial",
@@ -1710,9 +1763,17 @@ class HoloHubCLI:
                 continue
             print(f"\n{Color.white(f'== {project_type.upper()}S =================', bold=True)}\n")
             for project in sorted(grouped_metadata[project_type], key=lambda x: x["project_name"]):
-                language = project.get("metadata", {}).get("language", "")
-                language = f"({language})" if language else ""
-                print(f'{project["project_name"]} {language}')
+                meta = project.get("metadata", {})
+                language = meta.get("language", "")
+                if isinstance(language, list):
+                    language = ", ".join(language)
+                language_str = f"({language})" if language else ""
+                if project_type == "module":
+                    operators = meta.get("operators", [])
+                    ops_str = f" [{', '.join(operators)}]" if operators else ""
+                    print(f'{project["project_name"]} {language_str}{ops_str}')
+                else:
+                    print(f'{project["project_name"]} {language_str}')
 
         print(f"\n{Color.white('=================================', bold=True)}\n")
 
@@ -2101,6 +2162,217 @@ class HoloHubCLI:
         # Exit 1 only on FAIL; warnings are informational
         if any(r.status == "FAIL" for r in results):
             sys.exit(1)
+
+    def _resolve_module_project(
+        self, project_arg: Optional[str], language: Optional[str]
+    ) -> dict:
+        """Resolve a module project for `./holohub package`.
+
+        If cwd is itself a Holoscan Module monorepo (./metadata.json has a 'module' key),
+        package that module — irrespective of a project arg. Falls back to the HoloHub-tree
+        lookup when cwd is not a module root.
+        """
+        import json as _json
+
+        cwd = Path.cwd()
+        cwd_meta = cwd / "metadata.json"
+
+        if cwd_meta.exists():
+            try:
+                data = _json.loads(cwd_meta.read_text())
+            except (ValueError, OSError):
+                data = None
+            if isinstance(data, dict) and "module" in data:
+                module = data["module"]
+                module_name = module.get("name", cwd.name)
+
+                def _normalize(s: str) -> str:
+                    s = s.lower().replace("-", "_")
+                    if s.startswith("holoscan_"):
+                        s = s[len("holoscan_"):]
+                    return s
+
+                if project_arg and _normalize(project_arg) not in {
+                    _normalize(module_name),
+                    _normalize(cwd.name),
+                }:
+                    holohub_cli_util.warn(
+                        f"Packaging module '{module_name}' from {cwd}; "
+                        f"ignoring project argument '{project_arg}'."
+                    )
+                return {
+                    "project_type": "module",
+                    "project_name": module_name,
+                    "source_folder": str(cwd),
+                    "metadata": module,
+                }
+
+        if project_arg:
+            project_data = self.find_project(project_arg, language=language)
+            project_type = project_data.get("project_type", "application")
+            if project_type != "module":
+                holohub_cli_util.fatal(
+                    f"'./holohub package' only supports modules; "
+                    f"'{project_arg}' is type '{project_type}'"
+                )
+            return project_data
+
+        holohub_cli_util.fatal(
+            "No project specified and no ./metadata.json found in the current "
+            "working directory. Run from a module project root, or pass a "
+            "project name as the first argument."
+        )
+
+    def handle_package(self, args: argparse.Namespace) -> None:
+        """Handle package command — configure the module and run CPack and/or build a wheel."""
+        is_local_mode = args.local or os.environ.get("HOLOHUB_BUILD_LOCAL")
+
+        if is_local_mode:
+            project_data = self._resolve_module_project(
+                args.project, language=getattr(args, "language", None)
+            )
+
+            dryrun = args.dryrun
+            generators = [
+                g.strip().upper()
+                for g in getattr(args, "pkg_generator", "DEB").split(",")
+                if g.strip()
+            ]
+            build_type = holohub_cli_util.get_buildtype_str(getattr(args, "build_type", None))
+            build_env = os.environ.copy()
+
+            source_folder = Path(project_data["source_folder"])
+            project_name = project_data["project_name"]
+            pkg_slug = project_name.replace("-", "_")
+
+            cpack_generators = [g for g in generators if g != "WHEEL"]
+            want_wheel = "WHEEL" in generators
+
+            if cpack_generators:
+                build_dir = HoloHubCLI.DEFAULT_BUILD_PARENT_DIR / pkg_slug / "package"
+                build_dir.mkdir(parents=True, exist_ok=True)
+
+                cmake_args = [
+                    "cmake",
+                    "-B", str(build_dir),
+                    "-S", str(HoloHubCLI.HOLOHUB_ROOT),
+                    "--no-warn-unused-cli",
+                    f"-DPython3_EXECUTABLE={sys.executable}",
+                    f"-DPython3_ROOT_DIR={os.path.dirname(os.path.dirname(sys.executable))}",
+                    f"-DCMAKE_BUILD_TYPE={build_type}",
+                    f"-DCMAKE_PREFIX_PATH={HoloHubCLI.DEFAULT_SDK_DIR}/lib",
+                    "-DBUILD_ALL=OFF",
+                    f"-DMODULE_{pkg_slug}=ON",
+                ]
+                if shutil.which("ninja"):
+                    cmake_args.extend(["-G", "Ninja"])
+                holohub_cli_util.run_command(cmake_args, dry_run=dryrun, env=build_env)
+
+                build_cmd = [
+                    "cmake", "--build", str(build_dir), "--config", build_type,
+                    "-j", str(os.cpu_count()),
+                ]
+                holohub_cli_util.run_command(build_cmd, dry_run=dryrun, env=build_env)
+
+                pkg_config_dir = build_dir / "pkg"
+                cpack_configs = (
+                    list(pkg_config_dir.glob("CPackConfig-*.cmake"))
+                    if pkg_config_dir.exists()
+                    else []
+                )
+                if not cpack_configs and dryrun:
+                    bare = project_name.replace("_", "-")
+                    if bare.startswith("holoscan-"):
+                        bare = bare[len("holoscan-"):]
+                    cpack_configs = [pkg_config_dir / f"CPackConfig-holoscan-{bare}.cmake"]
+                for cpack_config in cpack_configs:
+                    for gen in cpack_generators:
+                        holohub_cli_util.run_command(
+                            ["cpack", "--config", str(cpack_config), "-G", gen],
+                            dry_run=dryrun,
+                            env=build_env,
+                        )
+
+            if want_wheel:
+                pyproject = source_folder / "pyproject.toml"
+                if not pyproject.exists():
+                    holohub_cli_util.fatal(
+                        f"Cannot build wheel: {pyproject} not found. The module "
+                        "needs a pyproject.toml with a [build-system] block "
+                        "(e.g. scikit-build-core)."
+                    )
+                dist_dir = HoloHubCLI.DEFAULT_BUILD_PARENT_DIR / "dist"
+                wheel_env = build_env.copy()
+                wheel_env["PYTHONSAFEPATH"] = "1"
+                wheel_cmd = [
+                    sys.executable, "-P",
+                    "-m", "build",
+                    "--wheel",
+                    "--outdir", str(dist_dir),
+                    str(source_folder),
+                ]
+                holohub_cli_util.run_command(
+                    wheel_cmd,
+                    dry_run=dryrun,
+                    env=wheel_env,
+                    cwd=str(source_folder.parent),
+                )
+                if not dryrun:
+                    try:
+                        display_dir = dist_dir.relative_to(HoloHubCLI.HOLOHUB_ROOT)
+                    except ValueError:
+                        display_dir = dist_dir
+                    print(f"\n{Color.green('Wheel output directory:')} {display_dir}")
+        else:
+            # Pass the project name so _make_project_container can resolve the
+            # module's source_folder and pick up its Dockerfile. Fall back to
+            # None (→ HoloHub root Dockerfile) when running from an external
+            # module's cwd without a project arg.
+            container = self._make_project_container(
+                project_name=args.project,
+                language=getattr(args, "language", None),
+            )
+            container.dryrun = args.dryrun
+            container.verbose = getattr(args, "verbose", False)
+            skip_docker_build, _ = holohub_cli_util.check_skip_builds(args)
+            if not skip_docker_build:
+                container.build(
+                    docker_file=getattr(args, "docker_file", None),
+                    base_img=getattr(args, "base_img", None),
+                    img=getattr(args, "img", None),
+                    no_cache=getattr(args, "no_cache", False),
+                )
+            build_cmd = f"{self.script_name} package"
+            if args.project:
+                build_cmd += f" {args.project}"
+            build_cmd += " --local"
+            if getattr(args, "build_type", None):
+                build_cmd += f" --build-type {args.build_type}"
+            if getattr(args, "pkg_generator", None):
+                build_cmd += f" --pkg-generator {args.pkg_generator}"
+            if getattr(args, "language", None):
+                build_cmd += f" --language {args.language}"
+            if args.dryrun:
+                build_cmd += " --dryrun"
+            docker_opts = (getattr(args, "docker_opts", None) or "").strip()
+            docker_opts_extra, extra_args = holohub_cli_util.get_entrypoint_command_args(
+                getattr(args, "img", None) or container.image_name,
+                build_cmd,
+                docker_opts,
+                dry_run=args.dryrun,
+            )
+            if docker_opts_extra:
+                docker_opts = (docker_opts + " " + docker_opts_extra).strip()
+            container.run(
+                img=getattr(args, "img", None),
+                local_sdk_root=getattr(args, "local_sdk_root", None),
+                enable_x11=getattr(args, "enable_x11", True),
+                ssh_x11=getattr(args, "ssh_x11", False),
+                use_tini=getattr(args, "init", False),
+                as_root=getattr(args, "as_root", False),
+                docker_opts=docker_opts,
+                extra_args=extra_args,
+            )
 
     def handle_install(self, args: argparse.Namespace) -> None:
         """Handle install command"""

--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -2163,9 +2163,7 @@ class HoloHubCLI:
         if any(r.status == "FAIL" for r in results):
             sys.exit(1)
 
-    def _resolve_module_project(
-        self, project_arg: Optional[str], language: Optional[str]
-    ) -> dict:
+    def _resolve_module_project(self, project_arg: Optional[str], language: Optional[str]) -> dict:
         """Resolve a module project for `./holohub package`.
 
         If cwd is itself a Holoscan Module monorepo (./metadata.json has a 'module' key),
@@ -2189,7 +2187,7 @@ class HoloHubCLI:
                 def _normalize(s: str) -> str:
                     s = s.lower().replace("-", "_")
                     if s.startswith("holoscan_"):
-                        s = s[len("holoscan_"):]
+                        s = s[len("holoscan_") :]
                     return s
 
                 if project_arg and _normalize(project_arg) not in {
@@ -2254,8 +2252,10 @@ class HoloHubCLI:
 
                 cmake_args = [
                     "cmake",
-                    "-B", str(build_dir),
-                    "-S", str(HoloHubCLI.HOLOHUB_ROOT),
+                    "-B",
+                    str(build_dir),
+                    "-S",
+                    str(HoloHubCLI.HOLOHUB_ROOT),
                     "--no-warn-unused-cli",
                     f"-DPython3_EXECUTABLE={sys.executable}",
                     f"-DPython3_ROOT_DIR={os.path.dirname(os.path.dirname(sys.executable))}",
@@ -2269,8 +2269,13 @@ class HoloHubCLI:
                 holohub_cli_util.run_command(cmake_args, dry_run=dryrun, env=build_env)
 
                 build_cmd = [
-                    "cmake", "--build", str(build_dir), "--config", build_type,
-                    "-j", str(os.cpu_count()),
+                    "cmake",
+                    "--build",
+                    str(build_dir),
+                    "--config",
+                    build_type,
+                    "-j",
+                    str(os.cpu_count()),
                 ]
                 holohub_cli_util.run_command(build_cmd, dry_run=dryrun, env=build_env)
 
@@ -2283,7 +2288,7 @@ class HoloHubCLI:
                 if not cpack_configs and dryrun:
                     bare = project_name.replace("_", "-")
                     if bare.startswith("holoscan-"):
-                        bare = bare[len("holoscan-"):]
+                        bare = bare[len("holoscan-") :]
                     cpack_configs = [pkg_config_dir / f"CPackConfig-holoscan-{bare}.cmake"]
                 for cpack_config in cpack_configs:
                     for gen in cpack_generators:
@@ -2305,10 +2310,13 @@ class HoloHubCLI:
                 wheel_env = build_env.copy()
                 wheel_env["PYTHONSAFEPATH"] = "1"
                 wheel_cmd = [
-                    sys.executable, "-P",
-                    "-m", "build",
+                    sys.executable,
+                    "-P",
+                    "-m",
+                    "build",
                     "--wheel",
-                    "--outdir", str(dist_dir),
+                    "--outdir",
+                    str(dist_dir),
                     str(source_folder),
                 ]
                 holohub_cli_util.run_command(

--- a/utilities/cli/tests/test_cli.py
+++ b/utilities/cli/tests/test_cli.py
@@ -249,7 +249,7 @@ class TestHoloHubCLI(unittest.TestCase):
         printed = " ".join(str(c[0][0]) for c in mock_print.call_args_list if c[0])
         self.assertIn("MODULES", printed)
         self.assertIn("test-module-fixture", printed)
-        self.assertIn("C++, Python", printed)   # array joined, not raw list repr
+        self.assertIn("C++, Python", printed)  # array joined, not raw list repr
         self.assertIn("[fixture_op]", printed)  # operators suffix
 
     def test_did_you_mean_suggestion(self):
@@ -1579,7 +1579,9 @@ class TestHandlePackage(unittest.TestCase):
         mock_find_project.return_value = self.mock_module_data
         mock_run_command.return_value = MagicMock()
         mock_exists.return_value = True
-        cpack_cfg = Path("/build/test_module_fixture/package/pkg/CPackConfig-test-module-fixture.cmake")
+        cpack_cfg = Path(
+            "/build/test_module_fixture/package/pkg/CPackConfig-test-module-fixture.cmake"
+        )
         mock_glob.return_value = [cpack_cfg]
 
         args = self.cli.parser.parse_args(
@@ -1658,7 +1660,9 @@ class TestHandlePackage(unittest.TestCase):
 
         for call in mock_run_command.call_args_list:
             _, kwargs = call
-            self.assertTrue(kwargs.get("dry_run"), "Expected dry_run=True for all run_command calls")
+            self.assertTrue(
+                kwargs.get("dry_run"), "Expected dry_run=True for all run_command calls"
+            )
 
 
 class TestRunCommand(unittest.TestCase):

--- a/utilities/cli/tests/test_cli.py
+++ b/utilities/cli/tests/test_cli.py
@@ -228,6 +228,30 @@ class TestHoloHubCLI(unittest.TestCase):
         self.assertEqual(args.command, "list")
         self.assertEqual(len(vars(args)), 2)  # command and func
 
+    @patch("builtins.print")
+    def test_list_shows_module_section(self, mock_print):
+        """MODULE entries appear under == MODULES == with language array and operators."""
+        # Use a synthetic module name unrelated to any real module so failures
+        # are not mistaken for holoscan-gstreamer regressions.
+        self.cli.projects = [
+            {
+                "project_type": "module",
+                "project_name": "test-module-fixture",
+                "metadata": {
+                    "language": ["C++", "Python"],
+                    "operators": ["fixture_op"],
+                },
+            }
+        ]
+        args = self.cli.parser.parse_args(["list"])
+        args.func(args)
+
+        printed = " ".join(str(c[0][0]) for c in mock_print.call_args_list if c[0])
+        self.assertIn("MODULES", printed)
+        self.assertIn("test-module-fixture", printed)
+        self.assertIn("C++, Python", printed)   # array joined, not raw list repr
+        self.assertIn("[fixture_op]", printed)  # operators suffix
+
     def test_did_you_mean_suggestion(self):
         """Test the 'did you mean' suggestion functionality"""
         # Test with a misspelled project name
@@ -1529,6 +1553,112 @@ exec {holohub_script} "$@"
         workdir = "<holohub_bin>/output"
         result = replace_placeholders(workdir, path_mapping, env_mapping)
         self.assertEqual(result, "/workspace/holohub/build/test_app/output")
+
+
+class TestHandlePackage(unittest.TestCase):
+    """Tests for handle_package — DEB and WHEEL packaging paths."""
+
+    def setUp(self):
+        self.cli = HoloHubCLI()
+        self.mock_module_data = {
+            "project_name": "test-module-fixture",
+            "project_type": "module",
+            "source_folder": Path(os.getcwd()) / "modules" / "test-module-fixture",
+            "metadata": {"language": ["C++", "Python"]},
+        }
+
+    @patch("utilities.cli.holohub.HoloHubCLI.find_project")
+    @patch("utilities.cli.util.run_command")
+    @patch("pathlib.Path.mkdir")
+    @patch("pathlib.Path.glob")
+    @patch("pathlib.Path.exists")
+    def test_package_deb_emits_module_cmake_flag(
+        self, mock_exists, mock_glob, mock_mkdir, mock_run_command, mock_find_project
+    ):
+        """DEB path passes -DMODULE_<slug>=ON and -DBUILD_ALL=OFF against the HoloHub root."""
+        mock_find_project.return_value = self.mock_module_data
+        mock_run_command.return_value = MagicMock()
+        mock_exists.return_value = True
+        cpack_cfg = Path("/build/test_module_fixture/package/pkg/CPackConfig-test-module-fixture.cmake")
+        mock_glob.return_value = [cpack_cfg]
+
+        args = self.cli.parser.parse_args(
+            ["package", "test-module-fixture", "--local", "--pkg-generator", "DEB"]
+        )
+        args.func(args)
+
+        cmake_args_str = " ".join(mock_run_command.call_args_list[0][0][0])
+        self.assertIn("-DMODULE_test_module_fixture=ON", cmake_args_str)
+        self.assertIn("-DBUILD_ALL=OFF", cmake_args_str)
+        self.assertIn(str(HoloHubCLI.HOLOHUB_ROOT), cmake_args_str)
+        self.assertNotIn("-DPKG_", cmake_args_str)
+
+        cpack_args = mock_run_command.call_args_list[2][0][0]
+        self.assertEqual(cpack_args[0], "cpack")
+        self.assertIn("-G", cpack_args)
+        self.assertIn("DEB", cpack_args)
+
+    @patch("utilities.cli.holohub.HoloHubCLI.find_project")
+    @patch("utilities.cli.util.run_command")
+    @patch("pathlib.Path.mkdir")
+    @patch("pathlib.Path.exists")
+    def test_package_wheel_invokes_python_build(
+        self, mock_exists, mock_mkdir, mock_run_command, mock_find_project
+    ):
+        """WHEEL path calls `python -m build --wheel` with outdir under build/dist/."""
+        mock_find_project.return_value = self.mock_module_data
+        mock_run_command.return_value = MagicMock()
+        mock_exists.return_value = True  # pyproject.toml exists
+
+        args = self.cli.parser.parse_args(
+            ["package", "test-module-fixture", "--local", "--pkg-generator", "WHEEL"]
+        )
+        args.func(args)
+
+        self.assertEqual(mock_run_command.call_count, 1)
+        wheel_args = mock_run_command.call_args_list[0][0][0]
+        wheel_str = " ".join(str(a) for a in wheel_args)
+        self.assertIn("-m", wheel_str)
+        self.assertIn("build", wheel_str)
+        self.assertIn("--wheel", wheel_str)
+        self.assertIn("--outdir", wheel_str)
+        self.assertIn("dist", wheel_str)
+
+    @patch("utilities.cli.holohub.HoloHubCLI.find_project")
+    def test_resolve_module_project_rejects_non_module(self, mock_find_project):
+        """_resolve_module_project raises SystemExit when the project is not a module."""
+        mock_find_project.return_value = {
+            "project_name": "gst_to_holo",
+            "project_type": "application",
+            "source_folder": Path(os.getcwd()) / "applications" / "gst_to_holo",
+            "metadata": {"language": "cpp"},
+        }
+        with self.assertRaises(SystemExit):
+            self.cli._resolve_module_project("gst_to_holo", language=None)
+
+    @patch("utilities.cli.holohub.HoloHubCLI.find_project")
+    @patch("utilities.cli.util.run_command")
+    @patch("pathlib.Path.mkdir")
+    @patch("pathlib.Path.glob")
+    @patch("pathlib.Path.exists")
+    def test_package_deb_dryrun_passes_dry_run_flag(
+        self, mock_exists, mock_glob, mock_mkdir, mock_run_command, mock_find_project
+    ):
+        """DEB dryrun passes dry_run=True to every run_command call."""
+        mock_find_project.return_value = self.mock_module_data
+        mock_run_command.return_value = MagicMock()
+        mock_exists.return_value = True
+        cpack_cfg = Path("/build/pkg/CPackConfig-test-module-fixture.cmake")
+        mock_glob.return_value = [cpack_cfg]
+
+        args = self.cli.parser.parse_args(
+            ["package", "test-module-fixture", "--local", "--pkg-generator", "DEB", "--dryrun"]
+        )
+        args.func(args)
+
+        for call in mock_run_command.call_args_list:
+            _, kwargs = call
+            self.assertTrue(kwargs.get("dry_run"), "Expected dry_run=True for all run_command calls")
 
 
 class TestRunCommand(unittest.TestCase):

--- a/utilities/cli/tests/test_cmake_manifest.py
+++ b/utilities/cli/tests/test_cmake_manifest.py
@@ -215,6 +215,52 @@ class TestWriteManifest(unittest.TestCase):
         self.assertIn("PROVIDES_OPERATORS mymod_op", text)
         self.assertNotRegex(text, r"set\(HOLOHUB_EXT_OP_")
 
+    # ── In-tree module handling ─────────────────────────────────────────
+
+    def test_in_tree_dep_emits_no_fetchcontent(self):
+        text = self._write(
+            [
+                ModuleDep(
+                    name="holoscan-gstreamer",
+                    provides_operators=["gstreamer"],
+                    is_internal=True,
+                    override_path=Path("/workspace/holohub/modules/holoscan-gstreamer"),
+                ),
+            ]
+        )
+        # No function call for the in-tree dep (header comment mentions the
+        # function name generally, so check for the call form with parenthesis).
+        self.assertNotRegex(text, r"holohub_declare_external_module\s*\(")
+        self.assertNotRegex(text, r"FetchContent_Declare\s*\(")
+        self.assertNotIn("FETCHCONTENT_SOURCE_DIR", text)
+        self.assertNotIn("GIT_REPOSITORY", text)
+        # Should contain an explanatory comment.
+        self.assertIn("holoscan-gstreamer", text)
+        self.assertIn("in-tree", text)
+
+    def test_in_tree_dep_mixed_with_external(self):
+        # A manifest with one in-tree and one external dep: only the external
+        # gets a holohub_declare_external_module call.
+        text = self._write(
+            [
+                ModuleDep(
+                    name="holoscan-gstreamer",
+                    provides_operators=["gstreamer"],
+                    is_internal=True,
+                    override_path=Path("/workspace/holohub/modules/holoscan-gstreamer"),
+                ),
+                ModuleDep(
+                    name="holoscan-deltacast",
+                    git_url="https://example.com/holoscan-deltacast.git",
+                    ref="0" * 40,
+                    provides_operators=["deltacast_videomaster"],
+                ),
+            ]
+        )
+        self.assertNotIn("holohub_declare_external_module(holoscan_gstreamer", text)
+        self.assertIn("holohub_declare_external_module(holoscan_deltacast", text)
+        self.assertIn("GIT_REPOSITORY", text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/utilities/cli/tests/test_external_resolver.py
+++ b/utilities/cli/tests/test_external_resolver.py
@@ -361,13 +361,7 @@ class TestParseModuleDependencies(unittest.TestCase):
 
         meta = _write_metadata(
             self._tmpdir,
-            {
-                "application": {
-                    "dependencies": {
-                        "modules": [{"name": "holoscan-gstreamer"}]
-                    }
-                }
-            },
+            {"application": {"dependencies": {"modules": [{"name": "holoscan-gstreamer"}]}}},
         )
         # Should not raise even though there is no source block.
         deps = parse_module_dependencies(meta, holohub_root=holohub_root)
@@ -382,13 +376,7 @@ class TestParseModuleDependencies(unittest.TestCase):
 
         meta = _write_metadata(
             self._tmpdir,
-            {
-                "application": {
-                    "dependencies": {
-                        "modules": [{"name": "unknown-module"}]
-                    }
-                }
-            },
+            {"application": {"dependencies": {"modules": [{"name": "unknown-module"}]}}},
         )
         with self.assertRaises(ValueError) as cm:
             parse_module_dependencies(meta, holohub_root=holohub_root)
@@ -406,13 +394,7 @@ class TestParseModuleDependencies(unittest.TestCase):
 
         meta = _write_metadata(
             self._tmpdir,
-            {
-                "application": {
-                    "dependencies": {
-                        "modules": [{"name": "holoscan-gstreamer"}]
-                    }
-                }
-            },
+            {"application": {"dependencies": {"modules": [{"name": "holoscan-gstreamer"}]}}},
         )
         with patch.dict(os.environ, {"HOLOHUB_LOCAL_HOLOSCAN_GSTREAMER": str(override_dir)}):
             deps = parse_module_dependencies(meta, holohub_root=holohub_root)
@@ -423,13 +405,7 @@ class TestParseModuleDependencies(unittest.TestCase):
         # Without holohub_root, missing-source behavior is unchanged.
         meta = _write_metadata(
             self._tmpdir,
-            {
-                "application": {
-                    "dependencies": {
-                        "modules": [{"name": "holoscan-gstreamer"}]
-                    }
-                }
-            },
+            {"application": {"dependencies": {"modules": [{"name": "holoscan-gstreamer"}]}}},
         )
         with self.assertRaises(ValueError):
             parse_module_dependencies(meta)  # holohub_root defaults to None

--- a/utilities/cli/tests/test_external_resolver.py
+++ b/utilities/cli/tests/test_external_resolver.py
@@ -316,6 +316,124 @@ class TestParseModuleDependencies(unittest.TestCase):
         self.assertEqual(deps[0].override_path, override_dir.resolve())
         self.assertIsNone(deps[0].git_url)
 
+    # ── In-tree module detection (holohub_root) ─────────────────────────
+
+    def _make_in_tree_module(self, holohub_root: Path, name: str) -> Path:
+        """Create a minimal modules/<name>/metadata.json under holohub_root."""
+        module_dir = holohub_root / "modules" / name
+        module_dir.mkdir(parents=True, exist_ok=True)
+        (module_dir / "metadata.json").write_text(
+            '{"$schema": "holoscan/module/v2", "module": {"name": "' + name + '"}}'
+        )
+        return module_dir
+
+    def test_in_tree_module_recognized(self):
+        holohub_root = self._tmpdir / "holohub"
+        holohub_root.mkdir()
+        self._make_in_tree_module(holohub_root, "holoscan-gstreamer")
+
+        meta = _write_metadata(
+            self._tmpdir,
+            {
+                "application": {
+                    "dependencies": {
+                        "modules": [
+                            {
+                                "name": "holoscan-gstreamer",
+                                "provides_operators": ["gstreamer"],
+                            }
+                        ]
+                    }
+                }
+            },
+        )
+        deps = parse_module_dependencies(meta, holohub_root=holohub_root)
+        self.assertEqual(len(deps), 1)
+        self.assertTrue(deps[0].is_internal)
+        self.assertEqual(deps[0].name, "holoscan-gstreamer")
+        self.assertEqual(deps[0].provides_operators, ["gstreamer"])
+        self.assertEqual(deps[0].override_path, holohub_root / "modules" / "holoscan-gstreamer")
+
+    def test_in_tree_module_no_error_for_missing_source(self):
+        holohub_root = self._tmpdir / "holohub"
+        holohub_root.mkdir()
+        self._make_in_tree_module(holohub_root, "holoscan-gstreamer")
+
+        meta = _write_metadata(
+            self._tmpdir,
+            {
+                "application": {
+                    "dependencies": {
+                        "modules": [{"name": "holoscan-gstreamer"}]
+                    }
+                }
+            },
+        )
+        # Should not raise even though there is no source block.
+        deps = parse_module_dependencies(meta, holohub_root=holohub_root)
+        self.assertEqual(len(deps), 1)
+        self.assertTrue(deps[0].is_internal)
+
+    def test_missing_module_still_raises_with_holohub_root(self):
+        # holohub_root provided but modules/<name>/ does not exist → still raises.
+        holohub_root = self._tmpdir / "holohub"
+        holohub_root.mkdir()
+        # Do NOT create modules/unknown-module/
+
+        meta = _write_metadata(
+            self._tmpdir,
+            {
+                "application": {
+                    "dependencies": {
+                        "modules": [{"name": "unknown-module"}]
+                    }
+                }
+            },
+        )
+        with self.assertRaises(ValueError) as cm:
+            parse_module_dependencies(meta, holohub_root=holohub_root)
+        self.assertIn("missing source.git_url or source.ref", str(cm.exception))
+
+    def test_local_override_takes_precedence_over_in_tree(self):
+        # HOLOHUB_LOCAL_* should win even when the module also exists in-tree.
+        holohub_root = self._tmpdir / "holohub"
+        holohub_root.mkdir()
+        self._make_in_tree_module(holohub_root, "holoscan-gstreamer")
+
+        override_dir = self._tmpdir / "local_gstreamer"
+        override_dir.mkdir()
+        (override_dir / "metadata.json").write_text("{}")
+
+        meta = _write_metadata(
+            self._tmpdir,
+            {
+                "application": {
+                    "dependencies": {
+                        "modules": [{"name": "holoscan-gstreamer"}]
+                    }
+                }
+            },
+        )
+        with patch.dict(os.environ, {"HOLOHUB_LOCAL_HOLOSCAN_GSTREAMER": str(override_dir)}):
+            deps = parse_module_dependencies(meta, holohub_root=holohub_root)
+        self.assertFalse(deps[0].is_internal)
+        self.assertEqual(deps[0].override_path, override_dir.resolve())
+
+    def test_no_holohub_root_still_raises_on_missing_source(self):
+        # Without holohub_root, missing-source behavior is unchanged.
+        meta = _write_metadata(
+            self._tmpdir,
+            {
+                "application": {
+                    "dependencies": {
+                        "modules": [{"name": "holoscan-gstreamer"}]
+                    }
+                }
+            },
+        )
+        with self.assertRaises(ValueError):
+            parse_module_dependencies(meta)  # holohub_root defaults to None
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -216,6 +216,7 @@ def get_component_search_paths(base_dir: Optional[Path] = None) -> tuple[Path, .
         "applications",
         "benchmarks",
         "gxf_extensions",
+        "modules",
         "operators",
         "pkg",
         "tutorials",

--- a/utilities/metadata/tests/fixtures/invalid/module_documentation_extra_field.json
+++ b/utilities/metadata/tests/fixtures/invalid/module_documentation_extra_field.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "holoscan/module/v2",
     "module": {
         "name": "module_documentation_extra_field",
         "description": "documentation block with an unknown field should fail additionalProperties check.",

--- a/utilities/metadata/tests/fixtures/invalid/module_documentation_extra_field.json
+++ b/utilities/metadata/tests/fixtures/invalid/module_documentation_extra_field.json
@@ -1,0 +1,19 @@
+{
+    "module": {
+        "name": "module_documentation_extra_field",
+        "description": "documentation block with an unknown field should fail additionalProperties check.",
+        "authors": [{ "name": "NVIDIA", "affiliation": "NVIDIA" }],
+        "version": "1.0.0",
+        "language": ["Python"],
+        "platforms": ["x86_64"],
+        "tags": ["example"],
+        "holoscan_sdk": {
+            "minimum_required_version": "4.0.0",
+            "tested_versions": ["4.0.0"]
+        },
+        "documentation": {
+            "readme": "README.md",
+            "unknown_field": "this field is not allowed"
+        }
+    }
+}

--- a/utilities/metadata/tests/fixtures/invalid/module_quality_reporting_extra_field.json
+++ b/utilities/metadata/tests/fixtures/invalid/module_quality_reporting_extra_field.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "holoscan/module/v2",
     "module": {
         "name": "module_quality_reporting_extra_field",
         "description": "quality_reporting block with an unknown field should fail additionalProperties check.",

--- a/utilities/metadata/tests/fixtures/invalid/module_quality_reporting_extra_field.json
+++ b/utilities/metadata/tests/fixtures/invalid/module_quality_reporting_extra_field.json
@@ -1,0 +1,19 @@
+{
+    "module": {
+        "name": "module_quality_reporting_extra_field",
+        "description": "quality_reporting block with an unknown field should fail additionalProperties check.",
+        "authors": [{ "name": "NVIDIA", "affiliation": "NVIDIA" }],
+        "version": "1.0.0",
+        "language": ["Python"],
+        "platforms": ["x86_64"],
+        "tags": ["example"],
+        "holoscan_sdk": {
+            "minimum_required_version": "4.0.0",
+            "tested_versions": ["4.0.0"]
+        },
+        "quality_reporting": {
+            "quality_metric": 3,
+            "unexpected_field": true
+        }
+    }
+}


### PR DESCRIPTION
## Summary
  
Adds support for in-tree Holoscan Modules, i.e. operator libraries that reside in the HoloHub monorepo and can be packaged as standalone Debian packages or Python wheels. This change introduces the module infrastructure and brings the existing Holoscan GStreamer Bridge operators into the module system as the **Holoscan GStreamer** reference implementation.

##   Changes

  - Module build infrastructure: Added modules/CMakeLists.txt with add_holohub_module() CMake function to handle module discovery, packaging, and wheel configuration. Modules use a descriptor-only layout (metadata + packaging files) while operators stay in their existing locations.
  - `holoscan-gstreamer` module: Declared the GStreamer operator library as an in-tree module with metadata.json (schema v2), pyproject.toml (wheel packaging via scikit-build-core), and updated Dockerfile for dev/test/packaging workflows. Updated modules/README.md with documentation distinguishing in-tree modules from external ones.
  - CLI & dependency resolution: Extended the HoloHub CLI to support holohub list --modules and holohub package --module commands. Updated the dependency resolver to recognize in-tree modules (no source block in metadata.json) and emit appropriate CMake directives.
  - Test coverage: Added comprehensive CLI tests validating module discovery, listing, packaging, and schema v2 fields (new fields for binary packages, Dockerfile paths, testing frameworks).

## Result

`holoscan-gstreamer` module is built and packaged with a single command

```bash
$ ./holohub package holoscan-gstreamer --pkg-generator="DEB,WHEEL"
...
CPack: Create package
CPack: - package: /workspace/holohub/holoscan-gstreamer_1.0.0_arm64.deb generated.
...
*** Created holoscan_gstreamer-1.0.0-cp312-cp312-linux_aarch64.whl
Successfully built holoscan_gstreamer-1.0.0-cp312-cp312-linux_aarch64.whl

Wheel output directory: build/dist
```

## Follow-up tasks planned

- Tutorial documentation
- Discovery via landing page
- Review platform coverage, support

  ---
This sets the foundation for adding more modules to HoloHub while keeping the monorepo organized and maintaining single-source-of-truth for packaged libraries.

Builds on prior work:
- Holoscan Modules introduction: 92a306756c85fdf72c11fb9f6869b176233cb19e
- Holoscan GStreamer build system preparation: ce10a3af05abcfd08b2273344ceea678592e3e06
- CMake packaging introduced for `holoscan-networking`: 9f67b0f20766ef20ef47dad66c10f115e9b87303

Assisted-by: Claude:claude-sonnet-4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Module system now supports in-tree and external modules with automatic detection and resolution
  * Added `package` CLI command to produce wheels or DEB packages and module-aware packaging flow
  * `list` CLI enhanced to show modules and their operators
  * Added holoscan-gstreamer module and operator packaging

* **Documentation**
  * Expanded module guides for creating and declaring in-tree vs external modules

* **Tests**
  * Added unit tests covering in-tree module handling and CLI packaging/list behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nvidia-holoscan/holohub/pull/1571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->