### PR TITLE
Modules: document hyphen vs underscore naming conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -357,6 +357,9 @@ For an operator named "Adaptive Thresholding":
 | README Title | Title Case + "Operator" | "Adaptive Thresholding Operator" |
 | Unit Test | "test_" + directory name | `test_adaptive_thresholding.py` |
 
+For **Holoscan Modules** (standalone library packages), a different three-tier naming
+system applies — see [Module Naming Conventions](./modules/README.md#naming-conventions).
+
 ### Build System Integration
 
 All contributions that include code need to be integrated with HoloHub's build system using CMake. Edit the appropriate `CMakeLists.txt` to add your contribution:

--- a/modules/README.md
+++ b/modules/README.md
@@ -62,3 +62,46 @@ recognizes in-tree modules: a dependency with no `source` block is looked up in
 `modules/<name>/metadata.json`. If found, the dep is marked `is_internal=True` and
 the CMake manifest emits a comment instead of a FetchContent_Declare — the operators
 are already present in HoloHub's tree and are built when `OP_<name>=ON`.
+
+## Naming Conventions
+
+The template derives four related names from a single human-readable input. Review
+this before running the command to avoid confusion during the prompts.
+
+### The three-tier system
+
+| Name | Format | Used for |
+| --- | --- | --- |
+| `project_name` | Free text, title case | Display name, README title |
+| `module_slug` | `snake_case` (underscores) | Python import path, C++ namespace, file/dir names inside the module, CMake variable prefixes |
+| `module_repo_name` | `holoscan-<slug>` (hyphens) | Repository directory name, PyPI package name, Debian package name |
+| `operator_slug` | `snake_case` + `_op` | Operator source file name; class name is TitleCase (`MySensorOp`) |
+
+### Example: "My Sensor"
+
+```text
+project_name     → "My Sensor"
+module_slug      → my_sensor           (underscores: used in Python/C++ code)
+module_repo_name → holoscan-my-sensor  (hyphens: used in package/repo names)
+operator_slug    → my_sensor_op        (class: MySensorOp)
+```
+
+### Why two formats?
+
+Python identifiers and C++ namespaces cannot contain hyphens, so `module_slug` uses
+underscores. Package registries (PyPI, apt) and repository directory names follow the
+opposite convention. The template enforces both so that
+`from holoscan.my_sensor import MySensorOp` and `pip install holoscan-my-sensor` both
+work without manual adjustment.
+
+### Transformation rules
+
+```text
+module_slug      = project_name.lower().replace(' ', '_').replace('-', '_')
+module_repo_name = "holoscan-" + module_slug.replace('_', '-')
+operator_slug    = module_slug + "_op"
+```
+
+The template computes `module_slug`, `module_repo_name`, and `operator_slug`
+automatically from `project_name`. You can accept the defaults or override any of them
+at the prompts.

--- a/modules/template/cookiecutter.json
+++ b/modules/template/cookiecutter.json
@@ -12,9 +12,9 @@
     "_license": "Apache-2.0",
     "contact_email": "your.email@example.com",
     "__prompts__": {
-        "project_name": "Module name (e.g. 'My Sensor')",
-        "module_slug": "Module slug — snake_case identifier used for Python import and C++ namespace (e.g. 'my_sensor')",
-        "module_repo_name": "Repository folder name — kebab-case, prefixed 'holoscan-' (e.g. 'holoscan-my-sensor')",
+        "project_name": "Human-readable module name (e.g. 'My Sensor'). See modules/README.md for the full naming system.",
+        "module_slug": "snake_case identifier — auto-derived from project_name. Used for Python import path and C++ namespace (e.g. 'my_sensor').",
+        "module_repo_name": "kebab-case repo/package name — auto-derived, prefixed 'holoscan-' (e.g. 'holoscan-my-sensor'). Used for PyPI and Debian packages.",
         "operator_slug": "Initial operator name in snake_case (e.g. 'my_sensor_op'). CamelCase class name is derived.",
         "full_name": "Author name",
         "affiliation": "Author organization",


### PR DESCRIPTION
The three-tier naming system (project_name / module_slug / module_repo_name) was only explained in brief cookiecutter prompts and a post-creation DEVELOPER.md.

- Add Naming Conventions section to modules/README.md with table, example, rationale, and transformation rules
- Clarify cookiecutter.json prompts to note auto-derived values and link to README
- Add pointer in CONTRIBUTING.md Naming Conventions section

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced naming conventions guidance for Holoscan modules with detailed mappings and transformation rules.
  * Clarified different naming formats and their applications across project setup and templates.
  * Updated template prompts with improved guidance on deriving project and module naming values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nvidia-holoscan/holohub/pull/1572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->