### PR TITLE
Dockerfile: restore self-contained CLI bootstrap for non-SDK bases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,54 @@
 ARG GPU_TYPE
 ARG BASE_SDK_VERSION
 ARG BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v${BASE_SDK_VERSION}-${GPU_TYPE}
-FROM ${BASE_IMAGE} AS holohub-cli
+
+############################################################
+# Prerequisites: normalize the base image into one that can run
+# the consolidated HoloHub CLI.
+#
+# BASE_IMAGE can be an SDK image (ships python + holoscan), a CUDA
+# base image (ships nothing Python-related), or a plain Ubuntu image.
+# Each conditional below is a no-op when the base already provides
+# the requirement, so SDK builds stay cheap.
+############################################################
+FROM ${BASE_IMAGE} AS holohub-cli-prerequisites
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG PYTHON_VERSION=python3
+ARG HOLOSCAN_CLI_INSTALL_SPEC=holoscan-cli
+
+# 1. Ensure python3 + pip exist.
+RUN if ! command -v python3 >/dev/null 2>&1; then \
+        apt-get update \
+        && apt-get install --no-install-recommends -y \
+            ${PYTHON_VERSION} ${PYTHON_VERSION}-pip curl ca-certificates \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+RUN if ! python3 -m pip --version >/dev/null 2>&1; then \
+        curl -sS https://bootstrap.pypa.io/get-pip.py | ${PYTHON_VERSION}; \
+    fi
+
+# 2. Ensure the consolidated `holoscan` CLI exists. Skip the pip install
+#    when the base already ships it (SDK images) to avoid network access.
+RUN if ! command -v holoscan >/dev/null 2>&1; then \
+        python3 -m pip install --upgrade "${HOLOSCAN_CLI_INSTALL_SPEC}"; \
+    fi
+
+############################################################
+# HoloHub CLI: stage the in-tree wrapper and smoke-test.
+############################################################
+FROM holohub-cli-prerequisites AS holohub-cli
+
 ARG CMAKE_BUILD_TYPE=Release
 
+# 3. Stage /tmp/scripts/holohub so the in-tree wrapper is callable inside
+#    the container regardless of base.
+RUN mkdir -p /tmp/scripts
+COPY holohub /tmp/scripts/
+RUN chmod +x /tmp/scripts/holohub
+
+# 4. Smoke-test: both the CLI and the wrapper are present and usable.
 RUN holoscan version \
     && test -x /tmp/scripts/holohub
 

--- a/operators/gstreamer/Dockerfile
+++ b/operators/gstreamer/Dockerfile
@@ -18,10 +18,43 @@
 ARG GPU_TYPE
 ARG BASE_SDK_VERSION
 ARG BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v${BASE_SDK_VERSION}-${GPU_TYPE}
-FROM ${BASE_IMAGE} AS holohub-cli
+
+############################################################
+# Prerequisites: normalize the base image into one that can run
+# the consolidated HoloHub CLI. See the root Dockerfile for the
+# rationale; this stage is the same contract.
+############################################################
+FROM ${BASE_IMAGE} AS holohub-cli-prerequisites
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG PYTHON_VERSION=python3
+ARG HOLOSCAN_CLI_INSTALL_SPEC=holoscan-cli
+
+RUN if ! command -v python3 >/dev/null 2>&1; then \
+        apt-get update \
+        && apt-get install --no-install-recommends -y \
+            ${PYTHON_VERSION} ${PYTHON_VERSION}-pip curl ca-certificates \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+RUN if ! python3 -m pip --version >/dev/null 2>&1; then \
+        curl -sS https://bootstrap.pypa.io/get-pip.py | ${PYTHON_VERSION}; \
+    fi
+
+RUN if ! command -v holoscan >/dev/null 2>&1; then \
+        python3 -m pip install --upgrade "${HOLOSCAN_CLI_INSTALL_SPEC}"; \
+    fi
+
+############################################################
+# HoloHub CLI: stage the in-tree wrapper and smoke-test.
+############################################################
+FROM holohub-cli-prerequisites AS holohub-cli
+
 ARG CMAKE_BUILD_TYPE=Release
+
+RUN mkdir -p /tmp/scripts
+COPY holohub /tmp/scripts/
+RUN chmod +x /tmp/scripts/holohub
 
 # --------------------------------------------------------------------------
 #


### PR DESCRIPTION
## Context

Follow-up to #1552 addressing a build-time regression that only surfaces on non-SDK base images. Reported via the HoloHub-internal Blossom nightly (build #478, stage `ubuntu2204`) after the bare-base CI matrix was restored.

## Problem

The prototype Dockerfile's first stage starts with:

```dockerfile
FROM ${BASE_IMAGE} AS holohub-cli
...
RUN holoscan version \
    && test -x /tmp/scripts/holohub
```

That assumes `BASE_IMAGE` already ships **both** the consolidated `holoscan` CLI on `PATH` and `/tmp/scripts/holohub`. Those assumptions hold for `nvcr.io/nvidia/clara-holoscan/holoscan:v…` images and fail on `ubuntu:22.04`, `ubuntu:24.04`, `nvcr.io/nvidia/cuda:12.9.1-base-*`, `nvcr.io/nvidia/cuda:13.0.0-base-*`, etc. — every non-SDK base fails at this line with `/bin/sh: 1: holoscan: not found` (exit 127).

The pre-consolidation Dockerfile (`main`) was self-contained on any base: a `holohub-cli-prerequisites` stage installed `python3`/`pip` if missing, then the in-tree CLI was COPY-ed and run. PR #1552 deleted both — only the assertion remained.

## Fix (Option A from the
`cli-consolidation-dockerfile-bare-base-regression.md` design note)

Re-introduce a `holohub-cli-prerequisites` stage that normalizes any base into a CLI-ready image:

1. apt-install `python3` + `pip` **only when missing** (no-op on SDK images).
2. pip-install `holoscan-cli` **only when no `holoscan` is on PATH** (no-op on SDK images that bundle the CLI; avoids build-time network access there).
3. COPY the in-tree `./holohub` wrapper so `/tmp/scripts/holohub` exists on every base.
4. Keep the existing `RUN holoscan version && test -x /tmp/scripts/holohub` as the post-install smoke gate.

A new `HOLOSCAN_CLI_INSTALL_SPEC` build-arg mirrors the host-side env var so CI can pin a TestPyPI build, a `git+https://...@branch` spec, or a local wheel:

```
docker build --build-arg HOLOSCAN_CLI_INSTALL_SPEC=holoscan-cli==4.3.0a26390596878 ...
```

## What this does NOT address (explicit non-goals)

The same "assume `holoscan_cli` is already available" pattern shows up in three other surfaces flagged in #1552 review:

- `holohub:44`/`holohub:45` — wrapper only checks `import holoscan_cli`; doesn't validate post-consolidation `PROJECT_COMMANDS` dispatch.
- `holohub:49` — `command -v holoscan` may resolve to a different `holoscan` than `import holoscan_cli`.
- `benchmarks/holoscan_flow_benchmarking/benchmark.py:37` — `ImportError` outside the container.

Those are out of scope here. They should land as one shared `ensure_post_consolidation_holoscan_cli()` helper reused across wrapper, Dockerfile post-install check, and `benchmark.py`. Filing a separate follow-up.

## Test plan

- [ ] HoloHub-internal Blossom matrix passes on all bare-base stages: `ubuntu2204`, `ubuntu2404`, `cuda12base-2204`, `cuda12base-2404`, `cuda13base-2204`, `cuda13base-2404`.
- [ ] Pre-existing GitHub CI (`check-cli-py`, `check-cli-ctest`) and the `sdk-cuda12` / `sdk-cuda13` / `dind-default` Blossom stages continue to pass.
- [ ] `docker run --network=none <image> holoscan version` succeeds (no first-run pip install in the container).
- [ ] `docker run --network=none <image> /tmp/scripts/holohub --help` reaches CLI help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)