### PR TITLE
Dockerfile: install pip via get-pip.py to fix Ubuntu 24.04 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,16 @@ ARG PYTHON_VERSION=python3
 ARG HOLOSCAN_CLI_INSTALL_SPEC=holoscan-cli
 
 # 1. Ensure python3 + pip exist.
+#
+# Do NOT apt-install ${PYTHON_VERSION}-pip on Ubuntu 24.04+: that pip is
+# debian-managed and missing the RECORD file, so when ``holoscan-cli``
+# transitively requests ``pip>25.1.0`` the upgrade aborts with
+# ``Cannot uninstall pip 24.0, RECORD file not found``. Install pip via
+# get-pip.py instead — it lands under /usr/local and is freely upgradeable.
 RUN if ! command -v python3 >/dev/null 2>&1; then \
         apt-get update \
         && apt-get install --no-install-recommends -y \
-            ${PYTHON_VERSION} ${PYTHON_VERSION}-pip curl ca-certificates \
+            ${PYTHON_VERSION} curl ca-certificates \
         && rm -rf /var/lib/apt/lists/*; \
     fi
 ENV PIP_BREAK_SYSTEM_PACKAGES=1

--- a/operators/gstreamer/Dockerfile
+++ b/operators/gstreamer/Dockerfile
@@ -30,10 +30,14 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG PYTHON_VERSION=python3
 ARG HOLOSCAN_CLI_INSTALL_SPEC=holoscan-cli
 
+# Do NOT apt-install ${PYTHON_VERSION}-pip on Ubuntu 24.04+: that pip is
+# debian-managed and missing the RECORD file, so a transitive
+# `pip>25.1.0` upgrade from holoscan-cli aborts with `Cannot uninstall
+# pip 24.0, RECORD file not found`. Install pip via get-pip.py instead.
 RUN if ! command -v python3 >/dev/null 2>&1; then \
         apt-get update \
         && apt-get install --no-install-recommends -y \
-            ${PYTHON_VERSION} ${PYTHON_VERSION}-pip curl ca-certificates \
+            ${PYTHON_VERSION} curl ca-certificates \
         && rm -rf /var/lib/apt/lists/*; \
     fi
 ENV PIP_BREAK_SYSTEM_PACKAGES=1


### PR DESCRIPTION
## Context

Follow-up to #1577. Reported by HoloHub-internal Blossom nightly #479 stage `cuda12base-2404`.

## Problem

When building against an Ubuntu 24.04-based image (e.g. `nvcr.io/nvidia/cuda:12.9.1-base-ubuntu24.04`), the Dockerfile's `pip install --upgrade holoscan-cli` step fails:

```
Attempting uninstall: pip
Found existing installation: pip 24.0
ERROR: Cannot uninstall pip 24.0, RECORD file not found.
Hint: The package was installed by debian.
```

`holoscan-cli` declares `pip>25.1.0` as a transitive dep. Pip 24.0 (the version shipped by `apt install python3-pip` on Ubuntu 24.04) is debian-managed and lacks the RECORD file pip needs to perform an in-place uninstall, so the entire docker build aborts.

22.04 doesn't hit this because its `apt`-installed `python3-pip` is older and falls into the "Not uninstalling pip outside environment" silent path, after which pip 26.x installs alongside.

## Fix

Drop `${PYTHON_VERSION}-pip` from the apt install. The existing `get-pip.py` fallback runs when no pip is present and lands pip under `/usr/local` — that pip is not debian-managed and can be upgraded freely.

Same fix applied to `operators/gstreamer/Dockerfile`.

## Test plan

- [ ] HoloHub-internal Blossom: `cuda12base-2404`, `cuda13base-2404`, `ubuntu2404` stages build successfully against PR branch.
- [ ] Pre-existing stages (`sdk-cuda12`, `sdk-cuda13`, `dind-default`, `cuda12base-2204`, `ubuntu2204`) continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)