### PR TITLE
Website: Fix Holoscan Module tutorials rendering on HoloHub landing page

### DIFF
--- a/doc/website/scripts/generate_pages.py
+++ b/doc/website/scripts/generate_pages.py
@@ -958,7 +958,10 @@ def parse_metadata_path(
     with metadata_path.open("r") as metadata_file:
         metadata = json.load(metadata_file)
 
-    project_type = list(metadata.keys())[0]
+    project_type = next((k for k in metadata.keys() if k != "$schema"), None)
+    if not project_type:
+        logger.error(f"Skipping {metadata_rel_path}: no valid project type found (only $schema)")
+        return
     metadata = metadata[project_type]
 
     # Check valid component type


### PR DESCRIPTION
## Overview

- Fix nvidia-holoscan.github.io Holoscan Modules tutorials so that `$schema` field is safely ignored. Previous: 404, updated: rendering properly.

## Previous

<img width="1466" height="917" alt="image" src="https://github.com/user-attachments/assets/a6d3d3a6-9b81-4085-a5c7-a4a6680065bf" />

## Updated

<img width="1466" height="917" alt="image" src="https://github.com/user-attachments/assets/b66bc24b-3d4f-4fa5-a8b6-06209bdffa86" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata file processing to correctly identify project types and handle missing required metadata fields with appropriate error logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nvidia-holoscan/holohub/pull/1581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->