### PR TITLE
Website: Add common sub-index for Holoscan Modules tutorials

### DIFF
--- a/.github/workflows/.lycheeignore
+++ b/.github/workflows/.lycheeignore
@@ -21,6 +21,10 @@ file://.*/static/chat.css
 file://.*/static/favicon.ico
 file://.*/static/nvidia-logo.png
 
+# Links to MkDocs dynamically-generated pages (exist at build time via generate_pages.py, not on filesystem)
+file://.*holoscan-modules/create-a-module
+file://.*holoscan-modules/use-a-module
+
 # HTTP/2 protocol errors (server compatibility issues)
 https://www.analog.com/.*
 https://www.logitech.com/.*

--- a/doc/website/docs/tutorials/holoscan-modules/index.md
+++ b/doc/website/docs/tutorials/holoscan-modules/index.md
@@ -1,0 +1,12 @@
+---
+title: Holoscan Modules Tutorials
+---
+
+A collection of tutorials for working with Holoscan Modules — reusable, versioned
+SDK extensions that bundle operators, assets, and metadata for distribution.
+Browse available modules in the [Modules tab](../../modules/).
+
+- [Create a Holoscan Module](create-a-module/) - Walk through project setup from a
+  blank directory to a published community module.
+- [Use a Holoscan Module](use-a-module/) - Walk through declaring a module dependency,
+  installing or building the module, and importing its operators in your own code.

--- a/tutorials/holoscan-modules/README.md
+++ b/tutorials/holoscan-modules/README.md
@@ -1,0 +1,50 @@
+# Holoscan Modules Tutorials
+
+## Purpose
+
+Learn to create, package, and consume Holoscan Modules — reusable, versioned SDK extensions
+that bundle operators, assets, and metadata for distribution and discovery across projects.
+
+## Usage
+
+Select a tutorial from the list below to get started:
+
+- **[Create a Holoscan Module](./create-a-module)** — Learn to set up a new module from scratch,
+  implement operators, build, test, package, and publish it to your team or community.
+- **[Use a Holoscan Module](./use-a-module)** — Learn to declare a module dependency, install
+  or build it, and import its operators in your own application or framework project.
+
+Browse published modules in the [Modules tab](https://nvidia-holoscan.github.io/holohub/modules/).
+
+## Requirements
+
+- Holoscan SDK 0.4.2 or later
+- C++ compiler with C++17 support or Python 3.8+
+- CMake 3.20 or later (for C++ modules)
+
+## Examples
+
+### Running a Tutorial
+
+Navigate to the tutorial directory and follow the instructions in its README:
+
+```bash
+cd create-a-module
+# Follow the walkthrough in README.md
+```
+
+Each tutorial includes step-by-step guidance and runnable examples.
+
+## Architecture
+
+The holoscan-modules tutorials are structured as standalone walkthroughs:
+
+- **create-a-module/** — End-to-end guide for module scaffolding, implementation, and publication
+- **use-a-module/** — Guide for consuming modules from HoloHub, external CMake projects, and pip packages
+
+Each tutorial includes:
+
+- Conceptual overview and rationale
+- Step-by-step walkthrough with code examples
+- Troubleshooting and reference sections
+- Links to relevant Holoscan SDK documentation and the Modules directory


### PR DESCRIPTION
## Depends on

Depends on https://github.com/nvidia-holoscan/holohub/pull/1581

## Goal

Provide an intentional landing page experience for users seeking to discover Holoscan Modules guidance at https://nvidia-holoscan.github.io/holohub/tutorials/holoscan-modules/

## Previous behavior

404 or Implicit redirect to "Create a Module" tutorial

<img width="1206" height="259" alt="image" src="https://github.com/user-attachments/assets/845ea5e2-bbb6-45e6-a3f2-b6f89818c3e0" />
    
## Updated behavior

Brief high-level discussion and link to tutorials and Modules discovery

<img width="1377" height="544" alt="image" src="https://github.com/user-attachments/assets/c4ca10c1-0ce4-4844-a667-5869d01c4ee2" />

## Additional Notes

Manually verified via local build. Added generated pages as exceptions in URL checker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Holoscan Modules tutorials documentation index
  * New comprehensive guide introducing Holoscan Modules as reusable SDK extensions
  * Tutorial guides added: "Create a Holoscan Module" and "Use a Holoscan Module"
  * Includes architecture overview and requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->