### PR TITLE
Modules: Add discovery for Holoscan Deltacast external module

### DIFF
--- a/doc/website/scripts/clone_module.py
+++ b/doc/website/scripts/clone_module.py
@@ -19,6 +19,7 @@ into CMake FetchContent records without performing any network operations. This 
 the actual git checkout so the website generator can read remote README and metadata files.
 """
 
+import re
 import shutil
 import subprocess
 import tempfile
@@ -29,6 +30,9 @@ if _GIT is None:
     raise RuntimeError("git executable not found in PATH")
 
 
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+
+
 def clone_external_module(url: str, ref: str) -> tuple[Path, tempfile.TemporaryDirectory]:
     """Shallow-clone url@ref into a temp dir.
 
@@ -36,15 +40,36 @@ def clone_external_module(url: str, ref: str) -> tuple[Path, tempfile.TemporaryD
     Raises subprocess.CalledProcessError on failure — caller is responsible for
     catching and skipping the module gracefully.
 
-    NOTE: --branch only accepts branch names and annotated tags; full commit SHAs
-    cause a fatal error. Pin refs to branch names or tags in module-sites.json.
+    Accepts branch names, annotated tags, or full 40-character commit SHAs.
+    Commit SHAs are fetched via init+fetch+checkout rather than --branch, which
+    only accepts named refs.
     """
     tmp = tempfile.TemporaryDirectory(prefix="holohub_module_")
-    subprocess.run(
-        [_GIT, "clone", "--depth=1", "--branch", ref, url, tmp.name],
-        check=True,
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
-    return Path(tmp.name), tmp
+    clone_path = Path(tmp.name)
+
+    if _SHA_RE.match(ref):
+        # git clone --branch rejects bare SHAs; use init + fetch instead.
+        subprocess.run([_GIT, "init", str(clone_path)], check=True, capture_output=True, text=True)
+        subprocess.run(
+            [_GIT, "-C", str(clone_path), "fetch", "--depth=1", url, ref],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        subprocess.run(
+            [_GIT, "-C", str(clone_path), "checkout", "FETCH_HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    else:
+        subprocess.run(
+            [_GIT, "clone", "--depth=1", "--branch", ref, url, str(clone_path)],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+    return clone_path, tmp

--- a/modules/module-sites.json
+++ b/modules/module-sites.json
@@ -4,6 +4,13 @@
     {
       "name": "holoscan-gstreamer",
       "nvidia_quality_score": 3
+    },
+    {
+      "name": "holoscan-deltacast",
+      "url": "https://github.com/deltacasttv/holoscan-modules",
+      "ref": "36deda4f925dfb7aaa69df70459246f154f4dcdd",
+      "source_url": "https://github.com/deltacasttv/holoscan-modules",
+      "nvidia_quality_score": 2
     }
   ]
 }


### PR DESCRIPTION
## Background

Holoscan Modules are projects that extend the Holoscan SDK with domain- or hardware-specific components and adhere to Holoscan ecosystem conventions. We've recently added support in HoloHub for creating, discovering, and developing with Holsocan Modules.
- 92a306756c85fdf72c11fb9f6869b176233cb19e
- 89c5802ebcc2436c5de9c1dbfd182fb620062d07

## Overview

Add the Holoscan Deltacast third party module for ecosystem discovery in HoloHub tooling and the Holoscan Ecosystem website.


The holoscan-deltacast module lives at https://github.com/deltacasttv/holoscan-modules and needs to be surfaced by HoloHub's website and tooling.

Register the module in modules/module-sites.json with url/ref/source_url for external-repo tooling discovery and nvidia_quality_score: 2 ("Developing")

<img width="1579" height="711" alt="image" src="https://github.com/user-attachments/assets/98ad7c35-2826-486d-889c-346d8a90b2c3" />

<img width="1581" height="860" alt="image" src="https://github.com/user-attachments/assets/3b428840-5bd6-43c5-a76b-c476957adcaf" />

## Results

Test with: `cd doc/website && mkdocs serve`

co-authored-by: Claude:claude-sonnet-4.6

cc: @laurent-radoux  @Isard7777 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for cloning modules using commit SHAs in addition to branch references.
  * Added holoscan-deltacast module to the available modules list.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nvidia-holoscan/holohub/pull/1585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->