### PR TITLE
test: make CuPy/Holoscan optional in test fixtures

### DIFF
--- a/applications/ultrasound_postprocessing/tests/test_display.py
+++ b/applications/ultrasound_postprocessing/tests/test_display.py
@@ -17,21 +17,22 @@ from __future__ import annotations
 
 import unittest
 
+import pytest
+
 try:
     import cupy as cp  # type: ignore
-except ImportError:  # pragma: no cover - optional dependency
-    cp = None  # type: ignore
 
-from ultra_post.core.display import (
-    DisplayCompressionSettings,
-    compress_color,
-    compress_grayscale,
-    ensure_rgba,
-    tensor_to_display,
-)
+    from ultra_post.core.display import (
+        DisplayCompressionSettings,
+        compress_color,
+        compress_grayscale,
+        ensure_rgba,
+        tensor_to_display,
+    )
+except Exception as exc:  # pragma: no cover - optional GPU dependency
+    pytest.skip(f"CuPy is unavailable: {exc}", allow_module_level=True)
 
 
-@unittest.skipIf(cp is None, "CuPy is required for display tests.")
 class DisplayTests(unittest.TestCase):
     def test_ensure_rgba_shapes(self) -> None:
         gray = cp.ones((2, 3), dtype=cp.float32)

--- a/applications/ultrasound_postprocessing/tests/test_display.py
+++ b/applications/ultrasound_postprocessing/tests/test_display.py
@@ -21,7 +21,6 @@ import pytest
 
 try:
     import cupy as cp  # type: ignore
-
     from ultra_post.core.display import (
         DisplayCompressionSettings,
         compress_color,

--- a/applications/ultrasound_postprocessing/tests/test_pipeline_core.py
+++ b/applications/ultrasound_postprocessing/tests/test_pipeline_core.py
@@ -17,22 +17,23 @@ from __future__ import annotations
 
 import unittest
 
+import pytest
+
 try:
     import cupy as cp  # type: ignore
-except ImportError:  # pragma: no cover - optional GPU dependency
-    cp = None  # type: ignore
 
-from ultra_post.core.pipeline import (
-    Pipeline,
-    create_node,
-    pipeline_from_yaml,
-    pipeline_to_yaml,
-    run_pipeline,
-)
-from ultra_post.filters.registry import FILTERS
+    from ultra_post.core.pipeline import (
+        Pipeline,
+        create_node,
+        pipeline_from_yaml,
+        pipeline_to_yaml,
+        run_pipeline,
+    )
+    from ultra_post.filters.registry import FILTERS
+except Exception as exc:  # pragma: no cover - optional GPU dependency
+    pytest.skip(f"CuPy is unavailable: {exc}", allow_module_level=True)
 
 
-@unittest.skipIf(cp is None, "CuPy is required for pipeline tests.")
 class PipelineCoreTests(unittest.TestCase):
     def setUp(self) -> None:
         self.filters = FILTERS

--- a/applications/ultrasound_postprocessing/tests/test_pipeline_core.py
+++ b/applications/ultrasound_postprocessing/tests/test_pipeline_core.py
@@ -21,7 +21,6 @@ import pytest
 
 try:
     import cupy as cp  # type: ignore
-
     from ultra_post.core.pipeline import (
         Pipeline,
         create_node,

--- a/applications/ultrasound_postprocessing/tests/test_wrap_op.py
+++ b/applications/ultrasound_postprocessing/tests/test_wrap_op.py
@@ -21,7 +21,6 @@ import pytest
 
 try:
     import cupy as cp  # type: ignore
-
     from ultra_post.app.holoscan_operators import FuncOp
     from ultra_post.filters.registry import FILTERS
 except Exception as exc:  # pragma: no cover - optional GPU/Holoscan dependency

--- a/applications/ultrasound_postprocessing/tests/test_wrap_op.py
+++ b/applications/ultrasound_postprocessing/tests/test_wrap_op.py
@@ -15,21 +15,19 @@
 
 from __future__ import annotations
 
-import importlib.util
 import unittest
+
+import pytest
 
 try:
     import cupy as cp  # type: ignore
-except ImportError:  # pragma: no cover
-    cp = None  # type: ignore
 
-from ultra_post.app.holoscan_operators import FuncOp
-from ultra_post.filters.registry import FILTERS
-
-_HOLOSCAN_AVAILABLE = importlib.util.find_spec("holoscan") is not None
+    from ultra_post.app.holoscan_operators import FuncOp
+    from ultra_post.filters.registry import FILTERS
+except Exception as exc:  # pragma: no cover - optional GPU/Holoscan dependency
+    pytest.skip(f"CuPy or Holoscan is unavailable: {exc}", allow_module_level=True)
 
 
-@unittest.skipIf(cp is None or not _HOLOSCAN_AVAILABLE, "CuPy/Holoscan required for FuncOp test.")
 class FuncOpTests(unittest.TestCase):
     def test_func_op_gamma(self) -> None:
         from holoscan.core import Application, Operator

--- a/conftest.py
+++ b/conftest.py
@@ -15,20 +15,18 @@
 
 import os
 
-import cupy as cp
 import numpy as np
 import pytest
-from holoscan.core import Application, Fragment
 
 
 @pytest.fixture
 def app():
-    return Application()
+    return pytest.importorskip("holoscan.core").Application()
 
 
 @pytest.fixture
 def fragment():
-    return Fragment()
+    return pytest.importorskip("holoscan.core").Fragment()
 
 
 @pytest.fixture
@@ -44,9 +42,14 @@ def config_file():
 
 @pytest.fixture
 def mock_image():
-    def _factory(shape, dtype=cp.uint8, backend="cupy", seed=None):
+    def _factory(shape, dtype="uint8", backend="cupy", seed=None):
         if backend == "cupy":
-            xp = cp
+            try:
+                # CuPy can be installed yet unimportable (no GPU/driver, ABI
+                # mismatch), so skip on any import failure, not just ImportError.
+                import cupy as xp
+            except Exception as exc:
+                pytest.skip(f"CuPy is unavailable in this test environment: {exc}")
         elif backend == "numpy":
             xp = np
         else:
@@ -56,7 +59,7 @@ def mock_image():
         if dtype.kind in "ui":
             img = rng.integers(0, 256, size=shape, dtype=dtype, endpoint=False)
         elif dtype.kind == "f":
-            img = rng.uniform(0.0, 1.0, size=shape, dtype=dtype)
+            img = rng.uniform(0.0, 1.0, size=shape).astype(dtype)
         else:
             raise ValueError(f"{dtype=} unsupported")
         return img

--- a/operators/video_streaming/video_streaming_client/python/tests/conftest.py
+++ b/operators/video_streaming/video_streaming_client/python/tests/conftest.py
@@ -21,10 +21,8 @@ Pytest fixtures for StreamingClientOp Python binding tests.
 import os
 import sys
 
-import cupy as cp
 import numpy as np
 import pytest
-from holoscan.core import Application, Fragment
 
 
 @pytest.fixture(scope="session")
@@ -105,22 +103,27 @@ def default_operator(operator_factory):
 @pytest.fixture
 def app():
     """Provide a Holoscan Application instance."""
-    return Application()
+    return pytest.importorskip("holoscan.core").Application()
 
 
 @pytest.fixture
 def fragment():
     """Provide a Holoscan Fragment instance."""
-    return Fragment()
+    return pytest.importorskip("holoscan.core").Fragment()
 
 
 @pytest.fixture
 def mock_image():
     """Factory fixture for creating mock image tensors."""
 
-    def _factory(shape, dtype=cp.uint8, backend="cupy", seed=None):
+    def _factory(shape, dtype="uint8", backend="cupy", seed=None):
         if backend == "cupy":
-            xp = cp
+            try:
+                # CuPy can be installed yet unimportable (no GPU/driver, ABI
+                # mismatch), so skip on any import failure, not just ImportError.
+                import cupy as xp
+            except Exception as exc:
+                pytest.skip(f"CuPy is unavailable in this test environment: {exc}")
         elif backend == "numpy":
             xp = np
         else:

--- a/operators/video_streaming/video_streaming_server/python/tests/conftest.py
+++ b/operators/video_streaming/video_streaming_server/python/tests/conftest.py
@@ -21,10 +21,8 @@ Pytest fixtures for StreamingServer operators Python binding tests.
 import os
 import sys
 
-import cupy as cp
 import numpy as np
 import pytest
-from holoscan.core import Application, Fragment
 
 
 @pytest.fixture(scope="session")
@@ -135,22 +133,27 @@ def downstream_operator_factory(streaming_server_classes, fragment):
 @pytest.fixture
 def app():
     """Provide a Holoscan Application instance."""
-    return Application()
+    return pytest.importorskip("holoscan.core").Application()
 
 
 @pytest.fixture
 def fragment():
     """Provide a Holoscan Fragment instance."""
-    return Fragment()
+    return pytest.importorskip("holoscan.core").Fragment()
 
 
 @pytest.fixture
 def mock_image():
     """Factory fixture for creating mock image tensors."""
 
-    def _factory(shape, dtype=cp.uint8, backend="cupy", seed=None):
+    def _factory(shape, dtype="uint8", backend="cupy", seed=None):
         if backend == "cupy":
-            xp = cp
+            try:
+                # CuPy can be installed yet unimportable (no GPU/driver, ABI
+                # mismatch), so skip on any import failure, not just ImportError.
+                import cupy as xp
+            except Exception as exc:
+                pytest.skip(f"CuPy is unavailable in this test environment: {exc}")
         elif backend == "numpy":
             xp = np
         else:


### PR DESCRIPTION
## Summary

Several test `conftest.py` files imported `cupy` and `holoscan.core` at
module-import time, so collecting tests failed whenever those optional
dependencies were missing or unimportable (for example, CuPy installed
without a working GPU/driver, or a NumPy ABI mismatch). Because the
repo-root `conftest.py` is loaded for the entire session, this aborted
collection of **every** test in the repo — even tests unrelated to CuPy.

This change defers/guards those imports so that only tests which actually
request a CuPy- or Holoscan-backed fixture skip when the dependency is
unavailable:

- **`conftest.py` (root)** and the **`video_streaming_{server,client}`
  conftests** (near-identical copies of the root fixtures):
  - `app` / `fragment` import `holoscan.core` lazily via
    `pytest.importorskip`.
  - `mock_image` imports `cupy` only for the `cupy` backend and skips on
    any import failure (not just `ImportError`); its default `dtype` is
    now the `"uint8"` string instead of `cupy.uint8`, so the fixture no
    longer references CuPy at definition time.
  - The root `mock_image` float branch uses
    `rng.uniform(...).astype(dtype)`, which works on both the NumPy and
    CuPy `Generator` APIs (NumPy's `Generator.uniform` does not accept a
    `dtype` argument).
- **Ultrasound tests** (`test_display`, `test_pipeline_core`,
  `test_wrap_op`): they already guarded their own `cupy` import, but
  still failed at collection because the `ultra_post.*` modules they
  import pull in CuPy. They now skip at module level when CuPy (or
  Holoscan, for `FuncOp`) is unavailable, before importing those
  GPU-only modules.

## Testing

- `ruff check` / `ruff format --check` on all changed files.
- `python -m compileall -q conftest.py`; `python -c "import conftest"`
  succeeds with CuPy unimportable.
- `pytest` with CuPy unavailable:
  - NumPy-backed `mock_image` (uint8 + float32) passes; CuPy-backed
    `mock_image` skips cleanly.
  - `video_streaming` server/client tests: collect and skip (89 skipped)
    instead of erroring at collection.
  - ultrasound `test_display`/`test_pipeline_core`/`test_wrap_op`: 3
    modules skip at collection instead of erroring.

## Out of scope

A few GPU-operator/app test modules (`pixelator`, `sam2`, `vila_live`)
still fail collection without CuPy because they transitively import CuPy
through the operator/application code under test. Those are a separate,
larger cleanup and are not addressed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test suites now lazily check optional GPU and core dependencies and skip affected modules when unavailable, improving reliability across environments.
  * Image test fixtures use string-based dtype defaults, defer GPU backend import until needed, and ensure generated floating-point data is cast to the requested dtype.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->