### PR TITLE
Module: Clean up duplicate URL entries

### DIFF
--- a/modules/module-sites.json
+++ b/modules/module-sites.json
@@ -9,7 +9,6 @@
       "name": "holoscan-deltacast",
       "url": "https://github.com/deltacasttv/holoscan-modules",
       "ref": "36deda4f925dfb7aaa69df70459246f154f4dcdd",
-      "source_url": "https://github.com/deltacasttv/holoscan-modules",
       "provides_operators": ["deltacast_videomaster"],
       "nvidia_quality_score": 2
     }


### PR DESCRIPTION
## Issue

"holoscan-deltacast" module has two URL entries in module-sites.json. "url" is the source of truth for module source resolution at build time via CLI tooling, whereas "source_url" is an optional override for website presentation only.

## Update

Align to a single "url" field for "holoscan-deltacast" presentation. "source_url" is populated at "url" by default.

## Results

- Built website locally, verified no observable change
- Locally verified no regression in external module source URL fetch with `./holohub build endoscopy_tool_tracking deltacast`

Co-authored-by: Claude:claude-sonnet-4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated upstream module dependency configuration to pin a specific commit version instead of using a mutable source reference. This ensures consistent and reproducible builds across all installations by locking the exact dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->