### PR TITLE
CLI: Update packaging command to allow skipping docker build

### DIFF
--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -487,6 +487,9 @@ class HoloHubCLI:
         )
         package.add_argument("--language", choices=["cpp", "python"], default=None)
         package.add_argument("--verbose", action="store_true")
+        package.add_argument(
+            "--no-docker-build", action="store_true", help="Skip building the container"
+        )
         package.add_argument("--dryrun", action="store_true", default=False)
         package.set_defaults(func=self.handle_package)
 


### PR DESCRIPTION
Issue: "./holohub package" did not expose an argument to allow skipping the container build prior to package tooling execution. This could result in unnecessary docker rebuild.

Align to other container-first commands with:
```bash
./holohub package <my-package> --no-docker-build
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-docker-build` option to the `package` command. This flag enables faster packaging by skipping the container image build step and reusing an existing build context, which is useful when iterating on packaging without needing to rebuild the entire container environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->