### PR TITLE
CLI: Fix "--cuda" flag observation in "package" subcommand

### DIFF
--- a/utilities/cli/holohub.py
+++ b/utilities/cli/holohub.py
@@ -2368,7 +2368,13 @@ class HoloHubCLI:
                     base_img=getattr(args, "base_img", None),
                     img=getattr(args, "img", None),
                     no_cache=getattr(args, "no_cache", False),
+                    build_args=getattr(args, "build_args", None),
+                    cuda_version=getattr(args, "cuda", None),
+                    extra_scripts=getattr(args, "extra_scripts", []),
                 )
+            else:
+                if hasattr(args, "cuda") and args.cuda is not None:
+                    container.cuda_version = args.cuda
             build_cmd = f"{self.script_name} package"
             if args.project:
                 build_cmd += f" {args.project}"

--- a/utilities/cli/tests/test_cli.py
+++ b/utilities/cli/tests/test_cli.py
@@ -1648,6 +1648,47 @@ class TestHandlePackage(unittest.TestCase):
                 kwargs.get("dry_run"), "Expected dry_run=True for all run_command calls"
             )
 
+    @patch("utilities.cli.util.check_nvidia_ctk")
+    @patch("utilities.cli.holohub.HoloHubCLI.find_project")
+    @patch("utilities.cli.holohub.HoloHubCLI._make_project_container")
+    @patch("utilities.cli.util.check_skip_builds")
+    def test_package_container_passes_cuda_version(
+        self,
+        mock_check_skip_builds,
+        mock_make_container,
+        mock_find_project,
+        mock_check_nvidia_ctk,
+    ):
+        """Container package path forwards --cuda to container.build like run-container."""
+        mock_check_nvidia_ctk.return_value = None
+        mock_find_project.return_value = self.mock_module_data
+        mock_container = MagicMock()
+        mock_make_container.return_value = mock_container
+
+        mock_check_skip_builds.return_value = (True, False)
+        args = self.cli.parser.parse_args(
+            ["package", "test-module-fixture", "--cuda", "13", "--no-docker-build"]
+        )
+        args.func(args)
+        mock_container.build.assert_not_called()
+        self.assertEqual(mock_container.cuda_version, "13")
+
+        mock_container.reset_mock()
+        mock_check_skip_builds.return_value = (False, False)
+        args = self.cli.parser.parse_args(
+            ["package", "test-module-fixture", "--cuda", "13"]
+        )
+        args.func(args)
+        mock_container.build.assert_called_once_with(
+            docker_file=None,
+            base_img=None,
+            img=None,
+            no_cache=False,
+            build_args=None,
+            cuda_version="13",
+            extra_scripts=None,
+        )
+
 
 class TestRunCommand(unittest.TestCase):
     """Test the run_command function with explicit shell parameter"""

--- a/utilities/cli/tests/test_cli.py
+++ b/utilities/cli/tests/test_cli.py
@@ -1675,9 +1675,7 @@ class TestHandlePackage(unittest.TestCase):
 
         mock_container.reset_mock()
         mock_check_skip_builds.return_value = (False, False)
-        args = self.cli.parser.parse_args(
-            ["package", "test-module-fixture", "--cuda", "13"]
-        )
+        args = self.cli.parser.parse_args(["package", "test-module-fixture", "--cuda", "13"])
         args.func(args)
         mock_container.build.assert_called_once_with(
             docker_file=None,


### PR DESCRIPTION
## Issue

"--cuda" flag was ignored when running "./holohub package". CUDA flags were set in the docker container build based on the host platform and ignored the CLI override.

## Update

Fixed such that "--cuda" is observed at parity with other subcommands.

## Verified

Built "holoscan-gstreamer" with CUDA 13 support while running on CUDA 12 host platform (R535).

See result on IGX Orin platform (R535, CUDA 12 support):
```bash
$ ./holohub package holoscan-gstreamer --cuda 13 --dryrun
...
2026-06-02 18:22:45 [dryrun] $ docker build \
    --build-arg BUILDKIT_INLINE_CACHE=1 \
    --build-arg BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda13 \
    --build-arg GPU_TYPE=dgpu \
    --build-arg BASE_SDK_VERSION=4.3.0 \
    --build-arg COMPUTE_CAPACITY=8.6 \
    --build-arg CUDA_MAJOR=13 \
 ...
```

Assisted-by: Claude:claude-sonnet-4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container build argument handling in the package command so CLI build arguments and CUDA version are correctly forwarded to container builds, avoiding mismatches during packaging and when container builds are skipped.

* **Tests**
  * Added unit test coverage to verify the package command forwards CUDA/version and build-argument behavior for container-based packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->