### PR TITLE
CLI: Fix GPU_TYPE detection for Jetson AGX Orin on JetPack 7.x

### DIFF
--- a/utilities/cli/tests/test_container.py
+++ b/utilities/cli/tests/test_container.py
@@ -27,7 +27,12 @@ from unittest.mock import patch
 sys.path.append(str(Path(os.getcwd()) / "utilities"))
 
 from utilities.cli.container import HoloHubContainer, _ContainerTerminationSignal
-from utilities.cli.util import get_cli_arg_value, get_cuda_tag, get_default_cuda_version
+from utilities.cli.util import (
+    get_cli_arg_value,
+    get_cuda_tag,
+    get_default_cuda_version,
+    get_host_gpu,
+)
 
 
 class TestHoloHubContainer(unittest.TestCase):
@@ -463,6 +468,36 @@ class TestHoloHubContainer(unittest.TestCase):
         """No default org when API key is missing."""
         options = self.container.get_ngc_options()
         self.assertListEqual([], options)
+
+    @patch("utilities.cli.util.get_default_cuda_version")
+    @patch("utilities.cli.util.get_gpu_name")
+    def test_get_host_gpu_orin_driver_disambiguation(self, mock_gpu_name, mock_cuda_version):
+        """Orin (nvgpu) maps to igpu on JP6.x (CUDA 12) and dgpu on JP7.x (CUDA 13)."""
+        mock_gpu_name.return_value = "Orin (nvgpu)"
+
+        # JP6.x: driver < 580, CUDA 12 -> igpu
+        mock_cuda_version.return_value = "12"
+        self.assertEqual(get_host_gpu(), "igpu")
+
+        # JP7.x: driver >= 580, CUDA 13 -> dgpu (SBSA-compatible stack)
+        mock_cuda_version.return_value = "13"
+        self.assertEqual(get_host_gpu(), "dgpu")
+
+        # nvidia-smi unavailable for driver query: get_default_cuda_version defaults to "13" -> dgpu
+        mock_cuda_version.return_value = "13"
+        self.assertEqual(get_host_gpu(), "dgpu")
+
+    @patch("utilities.cli.util.get_gpu_name")
+    def test_get_host_gpu_non_orin(self, mock_gpu_name):
+        """Non-Orin GPU names always map to dgpu regardless of driver."""
+        mock_gpu_name.return_value = "NVIDIA RTX 4090"
+        self.assertEqual(get_host_gpu(), "dgpu")
+
+    @patch("utilities.cli.util.get_gpu_name")
+    def test_get_host_gpu_no_gpu(self, mock_gpu_name):
+        """No GPU detected defaults to dgpu."""
+        mock_gpu_name.return_value = None
+        self.assertEqual(get_host_gpu(), "dgpu")
 
     @patch("utilities.cli.util.run_info_command")
     @patch("utilities.cli.util.shutil.which")

--- a/utilities/cli/tests/test_container.py
+++ b/utilities/cli/tests/test_container.py
@@ -483,8 +483,8 @@ class TestHoloHubContainer(unittest.TestCase):
         mock_cuda_version.return_value = "13"
         self.assertEqual(get_host_gpu(), "dgpu")
 
-        # nvidia-smi unavailable for driver query: get_default_cuda_version defaults to "13" -> dgpu
-        mock_cuda_version.return_value = "13"
+        # Unexpected/unknown CUDA version defaults to dgpu (treated as non-igpu)
+        mock_cuda_version.return_value = None
         self.assertEqual(get_host_gpu(), "dgpu")
 
     @patch("utilities.cli.util.get_gpu_name")

--- a/utilities/cli/util.py
+++ b/utilities/cli/util.py
@@ -468,9 +468,12 @@ def get_host_gpu() -> str:
         )
         return "dgpu"
 
-    # Check for iGPU (Orin integrated GPU)
+    # Orin (nvgpu) appears on both JP6.x (integrated GPU stack, driver ~540)
+    # and JP7.x (SBSA-compatible dGPU stack, driver >= 580). Use CUDA/driver
+    # version to distinguish: JP6.x / IGX OS 1.x ship CUDA 12 (driver < 580);
+    # JP7.x / IGX OS 2.x ship CUDA 13 (driver >= 580).
     if "Orin (nvgpu)" in gpu_name:
-        return "igpu"
+        return "igpu" if get_default_cuda_version() == "12" else "dgpu"
     return "dgpu"
 
 
@@ -520,9 +523,9 @@ def get_cuda_tag(cuda_version: Optional[Union[str, int]] = None, sdk_version: st
     - SDK < 3.6.1: Old format (dgpu/igpu)
     - SDK == 3.6.1: only cuda13-dgpu available
     - SDK >= 3.7.0: Full CUDA support
-      - cuda13: CUDA 13 (x86_64, Jetson Thor)
+      - cuda13: CUDA 13 (x86_64, Jetson AGX Orin w/ JP7.x, Jetson AGX Thor w/ JP7.x)
       - cuda12-dgpu: CUDA 12 dGPU (x86_64, IGX Orin dGPU, Clara AGX dGPU, GH200)
-      - cuda12-igpu: CUDA 12 iGPU (Jetson Orin, IGX Orin iGPU, Clara AGX iGPU)
+      - cuda12-igpu: CUDA 12 iGPU (Jetson AGX Orin w/ JP6.x, IGX Orin iGPU w/ IGX OS 1.x, Clara AGX iGPU)
 
     Args:
         cuda_version: CUDA major version (e.g., 12, 13). If None, uses platform default.


### PR DESCRIPTION
## Issue

JP7.2 transitions Jetson AGX Orin to SBSA compatibility (dGPU compute stack) but nvidia-smi still reports the GPU name as "Orin (nvgpu)", causing get_host_gpu() to incorrectly return "igpu".

## Updates

Fix by adding a driver version check when the Orin nvgpu name is detected: driver < 580 (CUDA 12) maps to the JP6.x / IGX OS 1.x integrated GPU stack (igpu), while driver >= 580 (CUDA 13) maps to the JP7.x / IGX OS 2.x SBSA-compatible stack (dgpu).

Adds unit tests covering the JP6/JP7 disambiguation and updates the get_cuda_tag() docstring to reflect the JP7.x platform mapping.

### Caveats

- Strictly assumes the user is using default drivers with their Jetpack installation: R540 for Jetpack 6.x, R580 or R595 for Jetpack 7.x
- Edge case: may fail if user attempts to install a custom driver, such as R580 on Jetpack 6.x. This is generally not supported and is OK to ignore for HoloHub CLI.

## Results

Verified on Jetson AGX Orin with Jetpack 7.2 (R595):
```bash
$ ./holohub build-container --dryrun
No project provided, proceeding with default container
2026-06-06 14:26:25 [dryrun] $ docker build \
    --build-arg BUILDKIT_INLINE_CACHE=1 \
    --build-arg BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda13 \
    --build-arg GPU_TYPE=dgpu \               # <---- fixed: previously "igpu" which is not reflective of Jetpack 7.2 stack
    --build-arg BASE_SDK_VERSION=4.3.0 \
    --build-arg COMPUTE_CAPACITY=8.7 \
    --build-arg CUDA_MAJOR=13 \
    ...
```

On IGX Orin iGPU w/ IGX OS 1.1 (R540):
```bash
$ ./holohub build-container --dryrun
No project provided, proceeding with default container
2026-06-06 14:31:06 [dryrun] $ docker build \
    --build-arg BUILDKIT_INLINE_CACHE=1 \
    --build-arg BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda12-igpu \
    --build-arg GPU_TYPE=igpu \            # <---- preserves "igpu" as expected
    --build-arg BASE_SDK_VERSION=4.3.0 \
    --build-arg COMPUTE_CAPACITY=8.7 \
    --build-arg CUDA_MAJOR=12 \
    ...
```

Assisted-by: Claude:claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU type detection on Orin devices: integrated vs discrete GPU classification now depends on detected CUDA version.

* **Documentation**
  * Clarified platform compatibility and CUDA-tag mapping for relevant Jetson and IGX OS combinations.

* **Tests**
  * Added unit tests covering Orin and non-Orin GPU scenarios and the no-GPU default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->