### PR TITLE
App: Fix System Configuration tutorial links in daqiri_raw_ethernet_b…

### DIFF
--- a/applications/daqiri_raw_ethernet_bench/README.md
+++ b/applications/daqiri_raw_ethernet_bench/README.md
@@ -1,7 +1,7 @@
 # DAQIRI Raw Ethernet Benchmark
 
 > [!TIP]
-> Review the [High Performance Networking tutorial](/tutorials/high_performance_networking/README.md) for guided
+> Review the [System Configuration tutorial](https://nvidia.github.io/daqiri/tutorials/system_configuration/) for guided
 > instructions to configure your system and test DAQIRI.
 
 This sample application measures raw DAQIRI DPDK transmit and receive throughput using the single
@@ -10,7 +10,7 @@ configured interface and receives them on another configured interface.
 
 The performance of this application depends heavily on a properly-configured system and tuning parameters
 that are acceptable for the workload. To configure the system, see the
-[High Performance Networking documentation](/tutorials/high_performance_networking/README.md).
+[System Configuration tutorial](https://nvidia.github.io/daqiri/tutorials/system_configuration/).
 
 ## Configuration
 


### PR DESCRIPTION
…ench README

Update both links from the old HoloHub High Performance Networking tutorial path to the DAQIRI System Configuration tutorial at https://nvidia.github.io/daqiri/tutorials/system_configuration/, and relabel the link text accordingly.
@jjomier 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated system setup guidance in the README with revised tutorial references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->