### PR TITLE
Module, CLI: Update template for holoscan-cli migration

### DIFF
--- a/modules/template/{{cookiecutter.module_repo_name}}/Dockerfile
+++ b/modules/template/{{cookiecutter.module_repo_name}}/Dockerfile
@@ -21,6 +21,12 @@ FROM ${BASE_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Install holoscan-cli developer tools
+ARG HOLOSCAN_CLI_INSTALL_ARGS="--pre --extra-index-url https://pypi.nvidia.com holoscan-cli>4.2.0"
+RUN if ! python3 -m holoscan_cli --help 2>/dev/null | grep -qw build; then \
+        python3 -m pip install ${HOLOSCAN_CLI_INSTALL_ARGS} \
+    ; fi
+
 # TODO: add module-specific runtime / build dependencies below.
 {% if cookiecutter.language == "cpp" %}RUN apt-get update \
     && apt-get install --no-install-recommends -y \

--- a/modules/template/{{cookiecutter.module_repo_name}}/holohub
+++ b/modules/template/{{cookiecutter.module_repo_name}}/holohub
@@ -45,13 +45,13 @@ export HOLOSCAN_CLI_HOSTNAME_PREFIX="${HOLOSCAN_CLI_HOSTNAME_PREFIX:-{{ cookiecu
 # ==============================================================================
 
 export HOLOSCAN_CLI_DEFAULT_DOCKERFILE="${HOLOSCAN_CLI_DEFAULT_DOCKERFILE:-${SCRIPT_DIR}/Dockerfile}"
-# Recursive walk from SCRIPT_DIR — picks up the top-level metadata.json
+# Recursive walk from working directory — picks up the top-level metadata.json
 # (project_type=module) along with operators/<x>/metadata.json and
 # applications/<y>/metadata.json. The narrower default
 # `applications,operators` skipped the module's own descriptor, so
 # `./holohub list` showed no MODULES section and `./holohub package
 # <name>` couldn't find the module by name. (holohub#1582)
-export HOLOSCAN_CLI_SEARCH_PATH="${HOLOSCAN_CLI_SEARCH_PATH:-${SCRIPT_DIR}}"
+export HOLOSCAN_CLI_SEARCH_PATH="${HOLOSCAN_CLI_SEARCH_PATH:-./}"
 export HOLOSCAN_CLI_BUILD_PARENT_DIR="${HOLOSCAN_CLI_BUILD_PARENT_DIR:-${SCRIPT_DIR}/build}"
 export HOLOSCAN_CLI_DATA_DIR="${HOLOSCAN_CLI_DATA_DIR:-${SCRIPT_DIR}/data}"
 


### PR DESCRIPTION
Fixup for in-progress CLI migration: https://github.com/nvidia-holoscan/holohub/pull/1583

Update the Holoscan Module template project scaffolding to address
    minor issues from holoscan-cli migration.
    
**Issue 1**: "holoscan" command is not available in a new module container
    environment immediately after setup
**Fix**: Install holoscan-cli wheel in Dockerfile setup
    
**Issue 2**: "holoscan list" command fails to detect any projects in new
    module container, though passes in host environment
    Root cause: HOLOSCAN_CLI_SEARCH_PATH setting in "holohub" entrypoint
    script is set to absolute host path and then mounted into the container
**Fix**: Set HOLOSCAN_CLI_SEARCH_PATH to relative path for validity across
    both host path and corresponding container entrypoint

## Results

Verified with list, build, run, package commands from a new module. (expand below for logs)

<details>

```bash
$ ./holohub create mymodule --template ./modules/template
...
Successfully created new project: mynewmodule 
...

$ cd ../holoscan-mymodule
```

</details>

<details>
```bash
$ ./holohub list

== APPLICATIONS =================

mynewmodule_pipeline (C++, Python)

== MODULES =================

holoscan-mynewmodule (C++, Python) [mynewmodule_op]

== PACKAGES =================

holoscan-mynewmodule 

== OPERATORS =================

mynewmodule_op (C++, Python)

=================================
```
</details>

<details>
```bash
$ ./holohub run-container -- ./holohub list
No project provided, proceeding with default container
2026-06-11 19:50:13 $ docker buildx version
2026-06-11 19:50:14 $ docker build --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda13 --build-arg GPU_TYPE=dgpu --build-arg COMPUTE_CAPACITY=8.6 --build-arg CUDA_MAJOR=13 --network=host --build-arg BASE_SDK_VERSION=4.3.0 -f /home/tbirdsong/repos/claude-sandbox/holoscan-mynewmodule/Dockerfile -t mynewmodule:latest -t mynewmodule:ngc-v4.3.0-cuda13 /home/tbirdsong/repos/claude-sandbox/holoscan-mynewmodule
[+] Building 7.1s (10/10) FINISHED                                                                                                                              docker:default
 => [internal] load build definition from Dockerfile                                                                                                                      0.0s
 => => transferring dockerfile: 1.57kB                                                                                                                                    0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:1                                                                                                 0.2s
 => CACHED docker-image://docker.io/docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89                                           0.0s
 => => resolve docker.io/docker/dockerfile:1@sha256:87999aa3d42bdc6bea60565083ee17e86d1f3339802f543c0d03998580f9cb89                                                      0.0s
 => [internal] load metadata for nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda13                                                                                     0.5s
 => [internal] load .dockerignore                                                                                                                                         0.0s
 => => transferring context: 2B                                                                                                                                           0.0s
 => [1/4] FROM nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda13@sha256:59ef7712c6d027b595f23f7d3ed69189ac27a605ceed38ae9b4af3aaa16c32f1                               0.1s
 => => resolve nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda13@sha256:59ef7712c6d027b595f23f7d3ed69189ac27a605ceed38ae9b4af3aaa16c32f1                               0.1s
 => CACHED [2/4] RUN if ! python3 -m holoscan_cli --help 2>/dev/null | grep -qw build; then         python3 -m pip install --pre --extra-index-url https://pypi.nvidia.c  0.0s
 => CACHED [3/4] RUN apt-get update     && apt-get install --no-install-recommends -y         libgtest-dev         clang-format         pybind11-dev     && rm -rf /var/  0.0s
 => CACHED [4/4] RUN pip install --no-cache-dir pytest-timeout build scikit-build-core                                                                                    0.0s
 => exporting to image                                                                                                                                                    5.3s
 => => exporting layers                                                                                                                                                   0.0s
 => => preparing layers for inline cache                                                                                                                                  4.5s
 => => exporting manifest sha256:88cc35810a3cee3de817eb93bb8befcf52fb403cac13d5e7c8f295008fe863fd                                                                         0.0s
 => => exporting config sha256:c67d5133f1ceb887c56b8d5fafccd4dfaea1494d25ae313535c8720331287797                                                                           0.0s
 => => exporting attestation manifest sha256:7bf14a383771e6f808191bbf8a39afae4f423007a7c69e73e61c4d9de79a58a1                                                             0.1s
 => => exporting manifest list sha256:9c80571d45493648bea3d2871ec2858a5d980648a373864ec6e1ecb8f7a2e356                                                                    0.1s
 => => naming to docker.io/library/mynewmodule:latest                                                                                                                     0.0s
 => => unpacking to docker.io/library/mynewmodule:latest                                                                                                                  0.1s
 => => naming to docker.io/library/mynewmodule:ngc-v4.3.0-cuda13                                                                                                          0.0s
 => => unpacking to docker.io/library/mynewmodule:ngc-v4.3.0-cuda13                                                                                                       0.1s
2026-06-11 19:50:21 $ docker inspect "--format={{json .Config.Entrypoint}}" mynewmodule:ngc-v4.3.0-cuda13
INFO: No DISPLAY or WAYLAND_DISPLAY set; skipping display forwarding.
2026-06-11 19:50:21 $ docker inspect --format "{{range .Config.Env}}{{println .}}{{end}}" mynewmodule:latest
2026-06-11 19:50:21 $ docker run --net host --interactive --tty --cidfile /tmp/holohub-container-1670005.cid -u 1776653678:748400513 -v /etc/group:/etc/group:ro -v /etc/passwd:/etc/passwd:ro -v /home/tbirdsong/repos/claude-sandbox/holoscan-mynewmodule:/workspace/mynewmodule -w /workspace/mynewmodule --runtime nvidia --cap-add CAP_SYS_PTRACE --ipc=host -v /dev:/dev --device-cgroup-rule "c 81:* rmw" --device-cgroup-rule "c 189:* rmw" -e NVIDIA_DRIVER_CAPABILITIES=graphics,video,compute,utility,display -e NVIDIA_VISIBLE_DEVICES=all -e HOME=/workspace/mynewmodule -e CUPY_CACHE_DIR=/workspace/mynewmodule/.cupy/kernel_cache -e HOLOSCAN_CLI_BUILD_LOCAL=1 -e HOLOSCAN_CLI_SEARCH_PATH=./ --rm --ipc=host --cap-add=CAP_SYS_PTRACE --ulimit=memlock=-1 --ulimit=stack=67108864 --device /dev/snd/controlC0 --device /dev/snd/controlC1 --device /dev/snd/pcmC0D9p --device /dev/snd/pcmC0D8p --device /dev/snd/pcmC0D7p --device /dev/snd/pcmC0D3p --device /dev/snd/pcmC0D2c --device /dev/snd/pcmC0D0c --device /dev/snd/pcmC0D0p --device /dev/snd/pcmC1D9p --device /dev/snd/pcmC1D8p --device /dev/snd/pcmC1D7p --device /dev/snd/pcmC1D3p --device /dev/snd/timer --device /dev/snd/seq --device /dev/infiniband/rdma_cm --device /dev/nvidia-modeset -v /usr/share/nvidia/nvoptix.bin:/usr/share/nvidia/nvoptix.bin:ro --group-add 44 --group-add 993 --group-add 984 --group-add 29 -e PYTHONPATH=/opt/nvidia/holoscan/python/lib:/opt/nvidia/hololink/python:/workspace/mynewmodule/benchmarks/holoscan_flow_benchmarking --entrypoint=/bin/bash mynewmodule:latest -c "./holohub list"

== APPLICATIONS =================

mynewmodule_pipeline (C++, Python)

== MODULES =================

mynewmodule (C++, Python) [mynewmodule_op]

== PACKAGES =================

holoscan-mynewmodule 

== OPERATORS =================

mynewmodule_op (C++, Python)

=================================
```
</details>

<details>
```bash
$ ./holohub run mymodule_pipeline
...
-- Build files have been written to: /workspace/mynewmodule/build/mynewmodule_pipeline
2026-06-11 19:51:18 $ cmake --build /workspace/mynewmodule/build/mynewmodule_pipeline --config Release -j 32
[8/8] Linking CXX shared module python/holoscan/mynewmodule/mynewmodule_op/_mynewmodule_op.cpython-312-x86_64-linux-gnu.so
lto-wrapper: warning: using serial compilation of 6 LTRANS jobs
lto-wrapper: note: see the ‘-flto’ option documentation for more information
2026-06-11 19:51:30 $ cd /workspace/mynewmodule/build/mynewmodule_pipeline/applications/mynewmodule_pipeline
2026-06-11 19:51:30 $ /workspace/mynewmodule/build/mynewmodule_pipeline/applications/mynewmodule_pipeline/mynewmodule_pipeline
[info] [fragment.cpp:1147] Loading extensions from configs...
[info] [gxf_executor.cpp:566] Creating context
[warning] [gxf_executor.cpp:2415] Operator graph is empty. Skipping execution.
[info] [gxf_executor.cpp:2787] Activating Graph...
[info] [entity_pool.cpp:134] EntityPool::GetShared: created new shared pool for context 0x566b182be340 with capacity 256
[info] [gxf_executor.cpp:2928] Running Graph...
[warning] [program.cpp:546] No GXF scheduler specified.
[info] [gxf_executor.cpp:2930] Waiting for completion...
[info] [gxf_executor.cpp:2937] Deactivating Graph...
[info] [gxf_executor.cpp:2946] Graph execution finished.
[info] [gxf_executor.cpp:601] Destroying context
```
</details>

<details>
```bash
./holohub package mymodule_pipeline
...
CPack: - package: /workspace/mynewmodule/holoscan-mynewmodule_0.1.0_amd64.deb generated.
```
</details>