### PR TITLE
Fix Check Docker and broken documentation links

### DIFF
--- a/.github/workflows/check_docker.yml
+++ b/.github/workflows/check_docker.yml
@@ -1,107 +1,30 @@
 name: Check Docker
 
 on:
+  pull_request:
+    branches: [main, holoscan-sdk-lws2]
   push:
     branches: [main, holoscan-sdk-lws2]
 
 permissions:
   contents: read
 
-env:
-  CPU_CI_COMMANDS: |
-    sed -i 's/check_nvidia_ctk()/pass  # nvidia-ctk not available/g' utilities/cli/container.py
-    sed -i 's/return \["--runtime", "nvidia"\]/return []/g' utilities/cli/container.py
-
 jobs:
   check-docker-build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        ubuntu_version: [22.04, 24.04]
+        include:
+          - runner: ubuntu-22.04
+            ubuntu_version: 22.04
+          - runner: ubuntu-24.04
+            ubuntu_version: 24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
       - name: Run Docker build
         run: |
-          set -o pipefail
           export ubuntu_version=${{ matrix.ubuntu_version }}
 
-          ./holohub build-container --base-img ubuntu:${ubuntu_version} 2>&1 | tee /tmp/build.log
-          grep -qE "writing image.* done" /tmp/build.log || { echo "Build failed - no success pattern"; cat /tmp/build.log; exit 1; }
-
-          if ! command -v nvidia-ctk >/dev/null 2>&1; then
-            eval "$CPU_CI_COMMANDS"
-          fi
-
-          ./holohub run-container --base-img ubuntu:${ubuntu_version} --no-docker-build | grep -q "docker run" || { echo "run-container failed"; exit 1; }
-          ./holohub run-container --docker-opts "--memory 4g" --no-docker-build | grep -q "memory 4g" || { echo "docker-opts test failed"; exit 1; }
-          ./holohub run-container --no-docker-build --add-volume "/tmp" | grep -q "/tmp" || { echo "add-volume test failed"; exit 1; }
-          ./holohub run-container --no-docker-build -- echo hello > /tmp/trailing-args.log 2>&1
-          grep -q "hello" /tmp/trailing-args.log || { echo "trailing args test failed"; cat /tmp/trailing-args.log; exit 1; }
-
-          # test linting in docker
-          ./holohub run-container --base-img ubuntu:${ubuntu_version} --no-docker-build -- "./holohub lint --install-dependencies; ./holohub lint --fix; ./holohub lint"
-
-  test-entrypoint:
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - dockerfile_config: 'CMD ["/bin/sh"]'
-            description: "cmd-bin-sh"
-          - dockerfile_config: 'CMD ["sh"]'
-            description: "cmd-sh"
-          - dockerfile_config: |
-              RUN echo '#!/bin/sh' > /usr/local/bin/test-entrypoint.sh && \
-                  echo 'exec "$@"' >> /usr/local/bin/test-entrypoint.sh && \
-                  chmod +x /usr/local/bin/test-entrypoint.sh
-              ENTRYPOINT ["/usr/local/bin/test-entrypoint.sh"]
-            description: "entrypoint-test"
-          - dockerfile_config: |
-              RUN echo '#!/bin/sh' > /docker-entrypoint.sh && \
-                  echo 'exec "$@"' >> /docker-entrypoint.sh && \
-                  chmod +x /docker-entrypoint.sh
-              ENTRYPOINT ["/docker-entrypoint.sh"]
-              CMD ["echo", "test case"]
-            description: "entrypoint-and-cmd"
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Create test Dockerfile
-        run: |
-          cat > /tmp/test-dockerfile << 'EOF'
-          FROM ubuntu:24.04
-
-          # Install basic shell utilities required by ./holohub
-          RUN apt-get update && apt-get install -y \
-              bash \
-              && rm -rf /var/lib/apt/lists/*
-
-          ${{ matrix.dockerfile_config }}
-          EOF
-
-      - name: Test run-container with different dockerfile configurations
-        run: |
-          if ! command -v nvidia-ctk >/dev/null 2>&1; then
-            eval "$CPU_CI_COMMANDS"
-          fi
-
-          DOCKERFILE="/tmp/test-dockerfile"
-          echo "Testing with ${{ matrix.description }}"
-          cat /tmp/test-dockerfile
-
-          ./holohub run-container --docker-file "$DOCKERFILE" --img test_image --dryrun -- echo test
-
-          # Test trailing args with different entrypoint configurations
-          ./holohub run-container --docker-file "$DOCKERFILE" --img test_image -- echo test > /tmp/test.log 2>&1
-          grep -q "echo test" /tmp/test.log || { echo "Failed for ${{ matrix.description }}"; cat /tmp/test.log; exit 1; }
-
-          # Test custom entrypoint override
-          ./holohub run-container --docker-file "$DOCKERFILE" --img test_image --docker-opts="--entrypoint=/bin/sh" -- echo override > /tmp/override.log 2>&1
-          grep -q "echo override" /tmp/override.log || { echo "Entrypoint override failed for ${{ matrix.description }}"; cat /tmp/override.log; exit 1; }
-
-          docker inspect test_image --format='ENTRYPOINT: {{.Config.Entrypoint}} | CMD: {{.Config.Cmd}}'
-          docker rmi test_image || echo "Image cleanup completed"
+          ./holohub build-container --base-img ubuntu:${ubuntu_version}

--- a/applications/orthorectification_with_optix/README.md
+++ b/applications/orthorectification_with_optix/README.md
@@ -12,7 +12,7 @@ Steps for running the application:
 
 a) Download and Prep the ODM Dataset
 
-1. Download the [Lafayette Square Dataset](https://www.opendronemap.org/odm/datasets/) and place into ~/Data.
+1. Download the [Lafayette Square Dataset](https://opendronemap.org/odm/datasets/) and place into ~/Data.
 
 2. Process the dataset with ODM via docker command:
 

--- a/applications/ultrasound_postprocessing/README.md
+++ b/applications/ultrasound_postprocessing/README.md
@@ -70,7 +70,7 @@ python3 -m streamlit run applications/ultrasound_postprocessing/ultra_post/app/s
 python3 -m ultra_post.app.holoscan_app [--uff path/to/myfile.uff] [--fps 10]
 ```
 
-The sample dataset used in this project is available at <https://www.ustb.no/ustb-datasets/>.
+The sample dataset used in this project is available at <https://unioslo.github.io/USTB/datasets.html>.
 
 ## Key Concepts
 
@@ -155,6 +155,6 @@ This project is licensed under the Apache-2.0 License. See the HoloHub [LICENSE]
 
 ## Reference Data
 
-This project uses UFF sample data hosted by the [Ultrasound Toolbox](https://www.ustb.no/).
+This project uses UFF sample data hosted by the [Ultrasound Toolbox](https://unioslo.github.io/USTB/datasets.html).
 
 > H. Liebgott, A. Rodriguez-Molares, F. Cervenansky, J. A. Jensen and O. Bernard, "Plane-Wave Imaging Challenge in Medical Ultrasound," 2016 IEEE International Ultrasonics Symposium (IUS), Tours, France, 2016, pp. 1-4, doi: 10.1109/ULTSYM.2016.7728908.

--- a/tutorials/debugging/holoscan_container_vscode/README.md
+++ b/tutorials/debugging/holoscan_container_vscode/README.md
@@ -79,11 +79,11 @@ Select `(gdb) examples/hello_world/cpp` from the list of available launch config
 Hit **F5** on the keyboard or click the green arrow to start debugging. VS Code shall hit the breakpoint and stop as the screenshot shows below:
 ![VS Code Breakpoint](./static/vscode-breakpoint.png)
 
-> 💡 *Tip*: **What happens when you hit F5?** VS Code looks up the launch profile for `(gdb) examples/hello_world/cpp` in the [.vscode/launch.json](/.vscode/launch.json) file and starts the debugger with the appropriate configurations and arguments.
+> 💡 *Tip*: **What happens when you hit F5?** VS Code looks up the launch profile for `(gdb) examples/hello_world/cpp` in the `/workspace/.vscode/launch.json` file and starts the debugger with the appropriate configurations and arguments.
 
 ### Debugging a Python Application
 
-There are a few options when debugging a Python application. In the [.vscode/launch.json](/.vscode/launch.json) file, you may find the following options to debug the Hello World application:
+There are a few options when debugging a Python application. In the `/workspace/.vscode/launch.json` file, you may find the following options to debug the Hello World application:
 
 - **Python: Debug Current File**: with this option selected, open [hello_world.py](https://github.com/nvidia-holoscan/holoscan-sdk/blob/main/examples/hello_world/python/hello_world.py) file and hit F5. It shall stop at any breakpoints selected.
 - **Python C++ Debug**: similar to the previous option, this launch profile allows you to debug both the Python and C++ code.


### PR DESCRIPTION
## Summary
- remove the stale public Check Docker sed patch that targeted the old in-tree CLI file removed by PR #1583
- run Check Docker as a premerge `pull_request` check and on `push`
- keep public Check Docker focused on real `build-container` coverage for paired runner/base combinations:
  - `ubuntu-22.04` runner with `ubuntu:22.04`
  - `ubuntu-24.04` runner with `ubuntu:24.04`
- rely on `build-container` exit status instead of grepping BuildKit output
- remove public non-dry-run `run-container` and ENTRYPOINT/CMD checks for now; hosted GitHub CPU runners do not have NVIDIA GPUs, and `holoscan-cli run-container` currently requires `nvidia-ctk` before launching. Runtime coverage remains in `holohub-internal/ci/scripts/cli-entrypoint-tests.sh`, and entrypoint argument logic is covered in `holoscan-cli/tests/unit/test_docker_utils.py`.
- fix README links that were failing URL validation for VS Code dev-container paths, OpenDroneMap datasets, and USTB datasets

## Testing
- `python3 -c "import pathlib, yaml; p=pathlib.Path('.github/workflows/check_docker.yml'); data=yaml.safe_load(p.read_text()); print(data['name']); print(data[True].keys()); print([step['name'] for step in data['jobs']['check-docker-build']['steps']])"`
- `git diff --check`
- `./holohub run-container --dryrun --verbose -- "./holohub lint --install-dependencies; ./holohub lint"`
- `./holohub run-container -- "./holohub lint --install-dependencies; ./holohub lint"`

AI-assisted: Created with Codex/GPT at the user's request.
