### PR TITLE
Update CMakeLists.txt and generate_resnet_model.py

### DIFF
--- a/applications/object_detection_torch/CMakeLists.txt
+++ b/applications/object_detection_torch/CMakeLists.txt
@@ -54,7 +54,8 @@ if(HOLOHUB_DOWNLOAD_DATASETS)
 
   # Download the model
   add_custom_target(download_model
-    COMMAND python3 "${CMAKE_CURRENT_SOURCE_DIR}/generate_resnet_model.py"  "${HOLOHUB_DATA_DIR}/object_detection_torch/frcnn_resnet50_t.pt"
+    COMMAND python3 -W ignore "${CMAKE_CURRENT_SOURCE_DIR}/generate_resnet_model.py"
+            "${HOLOHUB_DATA_DIR}/object_detection_torch/frcnn_resnet50_t.pt"
     BYPRODUCTS "${HOLOHUB_DATA_DIR}/object_detection_torch/frcnn_resnet50_t.pt"
   )
   add_dependencies(object_detection_torch download_model)
@@ -100,6 +101,7 @@ if(BUILD_TESTING)
            WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
   set_tests_properties(object_detection_torch_test PROPERTIES
+                TIMEOUT 1500
                 PASS_REGULAR_EXPRESSION "Reach end of file or playback count reaches to the limit. Stop ticking.;"
                 FAIL_REGULAR_EXPRESSION "[^a-z]Error;ERROR;Failed")
 

--- a/applications/object_detection_torch/generate_resnet_model.py
+++ b/applications/object_detection_torch/generate_resnet_model.py
@@ -13,16 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import warnings
 
-try:
-    from requests.exceptions import RequestsDependencyWarning
+# Must be set before requests is imported (e.g. by torchvision model download).
+warnings.filterwarnings("ignore", message=".*doesn't match a supported version.*")
 
-    warnings.filterwarnings("ignore", category=RequestsDependencyWarning)
-except ImportError:
-    pass
+import os
+import sys
 
 import torch
 from torchvision.models import ResNet50_Weights, detection


### PR DESCRIPTION
- Modified the download_model command in CMakeLists.txt to suppress warnings during model generation.
- Increased the timeout for object_detection_torch_test to 1500 seconds.
- Adjusted warning filters in generate_resnet_model.py to ignore specific version warnings from requests.