### PR TITLE
Module template: stage Python package under python/lib/

### DIFF
--- a/modules/template/{{cookiecutter.module_repo_name}}/.github/workflows/ci.yml
+++ b/modules/template/{{cookiecutter.module_repo_name}}/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Python tests (pytest)
         run: |
           {{ cookiecutter.module_slug | upper }}_BUILD_DIR=build \
-          PYTHONPATH=build/python${PYTHONPATH:+:$PYTHONPATH} \
+          PYTHONPATH=build/python/lib${PYTHONPATH:+:$PYTHONPATH} \
           python -m pytest tests/python/ -v --tb=short
 
       - uses: actions/upload-artifact@v4

--- a/modules/template/{{cookiecutter.module_repo_name}}/CMakeLists.txt
+++ b/modules/template/{{cookiecutter.module_repo_name}}/CMakeLists.txt
@@ -63,10 +63,15 @@ endif()
 # Python package root in the build tree.
 # PYTHONPATH=${{'{'}}{{ cookiecutter.module_slug | upper }}_PYTHON_ROOT} lets Python find
 # holoscan.{{ cookiecutter.module_slug }} alongside the installed Holoscan SDK package.
+#
+# The package lands under python/lib/ (not just python/) to match the layout
+# the Holoscan CLI expects in default `./holohub run` mode — it resolves the
+# module from <build>/python/lib, so `import holoscan.{{ cookiecutter.module_slug }}` fails if the
+# package is staged one directory higher.
 # ---------------------------------------------------------------------------
 
 set({{ cookiecutter.module_slug | upper }}_PYTHON_ROOT
-    ${CMAKE_BINARY_DIR}/python)
+    ${CMAKE_BINARY_DIR}/python/lib)
 set({{ cookiecutter.module_slug | upper }}_PYTHON_PKG_DIR
     ${{'{'}}{{ cookiecutter.module_slug | upper }}_PYTHON_ROOT}/holoscan/{{ cookiecutter.module_slug }})
 

--- a/modules/template/{{cookiecutter.module_repo_name}}/DEVELOPER.md
+++ b/modules/template/{{cookiecutter.module_repo_name}}/DEVELOPER.md
@@ -74,14 +74,14 @@ Run Python tests:
 
 ```bash
 {{ cookiecutter.module_slug | upper }}_BUILD_DIR=build \
-PYTHONPATH=build/python${PYTHONPATH:+:$PYTHONPATH} \
+PYTHONPATH=build/python/lib${PYTHONPATH:+:$PYTHONPATH} \
 pytest tests/python/ -v
 ```
 
 `PYTHONPATH` is **prepended via `${PYTHONPATH:+:$PYTHONPATH}`** so that an existing entry on the variable is kept while an unset/empty variable doesn't yield a trailing colon. Two failure modes the shorter forms invite:
 
-- **`PYTHONPATH=build/python`** (replace): drops any ambient holoscan SDK install on `PYTHONPATH`. The module-level `importorskip("holoscan")` then fires, pytest exits with code 5, and CTest marks the run as Skipped.
-- **`PYTHONPATH=build/python:$PYTHONPATH`** (naive prepend): on a fresh shell or CI runner where `$PYTHONPATH` is unset, this expands to `PYTHONPATH=build/python:` — Python treats the trailing empty entry as the current directory, silently shadowing installed packages with whatever happens to live in the test CWD.
+- **`PYTHONPATH=build/python/lib`** (replace): drops any ambient holoscan SDK install on `PYTHONPATH`. The module-level `importorskip("holoscan")` then fires, pytest exits with code 5, and CTest marks the run as Skipped.
+- **`PYTHONPATH=build/python/lib:$PYTHONPATH`** (naive prepend): on a fresh shell or CI runner where `$PYTHONPATH` is unset, this expands to `PYTHONPATH=build/python/lib:` — Python treats the trailing empty entry as the current directory, silently shadowing installed packages with whatever happens to live in the test CWD.
 
 ---
 

--- a/modules/template/{{cookiecutter.module_repo_name}}/README.md
+++ b/modules/template/{{cookiecutter.module_repo_name}}/README.md
@@ -117,13 +117,13 @@ ctest --test-dir build --output-on-failure -L unit
 
 ```bash
 # Python (pytest)
-PYTHONPATH=build/python${PYTHONPATH:+:$PYTHONPATH} {{ cookiecutter.module_slug | upper }}_BUILD_DIR=build pytest tests/python/ -v
+PYTHONPATH=build/python/lib${PYTHONPATH:+:$PYTHONPATH} {{ cookiecutter.module_slug | upper }}_BUILD_DIR=build pytest tests/python/ -v
 ```
 
 `PYTHONPATH` is **prepended** (with `${PYTHONPATH:+:$PYTHONPATH}`) so that an
-ambient holoscan SDK install stays visible. A bare `PYTHONPATH=build/python`
+ambient holoscan SDK install stays visible. A bare `PYTHONPATH=build/python/lib`
 would replace the variable and hide the SDK from pytest. A bare
-`PYTHONPATH=build/python:$PYTHONPATH` looks safe but, when `$PYTHONPATH` is
+`PYTHONPATH=build/python/lib:$PYTHONPATH` looks safe but, when `$PYTHONPATH` is
 unset (typical on a fresh shell or CI runner), it expands to a trailing colon
 that Python reads as an empty path entry — equivalent to `.`, which silently
 adds the test CWD to `sys.path` and lets a local file shadow installed

--- a/modules/template/{{cookiecutter.module_repo_name}}/tests/python/conftest.py
+++ b/modules/template/{{cookiecutter.module_repo_name}}/tests/python/conftest.py
@@ -18,7 +18,7 @@ build_dir = os.environ.get(
 try:
     import holoscan  # noqa: E402
 
-    build_holoscan_path = os.path.join(build_dir, "python", "holoscan")
+    build_holoscan_path = os.path.join(build_dir, "python", "lib", "holoscan")
     if build_holoscan_path not in holoscan.__path__:
         holoscan.__path__.insert(0, build_holoscan_path)
 except ImportError:


### PR DESCRIPTION
## Overview

Align Holoscan module template default Python build directory subpath to the Holoscan CLI expected `python/lib` path

## Details

In default `./holohub run` mode the Holoscan CLI resolves the module's Python package from <build>/python/lib, but the template staged it one directory higher at <build>/python, so `import holoscan.<module>` failed.

Set <MODULE>_PYTHON_ROOT to ${CMAKE_BINARY_DIR}/python/lib so the package (and the per-operator pybind subpackages keyed off it) land where the CLI expects. Update the consumers that hard-code the path — conftest.py, the CI pytest step, and the README/DEVELOPER/app-stub examples; the CTest harness already derives the path from the CMake variable and needs no change.

## Results

### Previous

```bash
$ ./holohub create ... --template modules/template
$ cd <../holoscan-my-module>
$ ./holohub run module_pipeline
...
Traceback (most recent call last):
  File "/workspace/mymodule/applications/mymodule/mymodule_pipeline.py", line 15, in <module>
    from holoscan.mymodule import MymoduleOp
ModuleNotFoundError: No module named 'holoscan.mymodule'
```

```bash
$ ./holohub create ... --template modules/template
$ cd <../holoscan-mymodule>
$ ./holohub run mymodule_pipeline
...
>>> python3 /workspace/mymodule/applications/mymodule_pipeline/mymodule_pipeline.py
[info] [fragment.cpp:1147] Loading extensions from configs...
[info] [gxf_executor.cpp:566] Creating context
[warning] [gxf_executor.cpp:2415] Operator graph is empty. Skipping execution.
[info] [gxf_executor.cpp:2787] Activating Graph...
[info] [entity_pool.cpp:134] EntityPool::GetShared: created new shared pool for context 0x19e7e9c0 with capacity 256
[info] [gxf_executor.cpp:2928] Running Graph...
[warning] [program.cpp:546] No GXF scheduler specified.
[info] [gxf_executor.cpp:2930] Waiting for completion...
[info] [gxf_executor.cpp:2937] Deactivating Graph...
[info] [gxf_executor.cpp:2946] Graph execution finished.
[info] [gxf_executor.cpp:601] Destroying context
```

## Follow-Up Tasks

Module template app default run command in `metadata.json` covers C++ app only, will split into C++ and Python app entrypoints in a follow-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Python test and build settings so the package is found from the correct build output path.
  * Improved test execution reliability when `PYTHONPATH` is unset or already set, reducing skipped or misconfigured test runs.

* **Documentation**
  * Refreshed setup and testing instructions to match the new build path.
  * Clarified expected behavior for environment path handling during local development and CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->