### PR TITLE
object_detection_torch: suppress known PyTorch SM warnings

### DIFF
--- a/applications/object_detection_torch/generate_resnet_model.py
+++ b/applications/object_detection_torch/generate_resnet_model.py
@@ -20,6 +20,7 @@ from typing import List
 
 import torch
 
+
 # Suppress PyTorch's UserWarning: Failed to load image Python extension: 'libnvjpeg.so.12: cannot open shared object file: No such file or directory'
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", UserWarning)
@@ -48,7 +49,10 @@ det_model = detection.fasterrcnn_resnet50_fpn(
 # https://forums.developer.nvidia.com/t/dgx-dashboard-playbook-pytorch-in-sample-code-not-supporting-cuda-12-1/350762
 with warnings.catch_warnings():
     warnings.filterwarnings(
-        "ignore", category=UserWarning, module="torch.cuda", message=r"\n.*Found GPU0 NVIDIA GB10.*"
+        "ignore",
+        category=UserWarning,
+        module=r"torch\.cuda",
+        message=r"\n.*Found GPU0 NVIDIA GB10.*",
     )
     det_model = det_model.to(DEVICE)
 

--- a/applications/object_detection_torch/generate_resnet_model.py
+++ b/applications/object_detection_torch/generate_resnet_model.py
@@ -21,6 +21,21 @@ from typing import List
 import torch
 
 
+def ignore_known_torch_cuda_capability_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        category=UserWarning,
+        module=r"torch\.cuda",
+        message=r"\n.*Found GPU0 NVIDIA GB10.*",
+    )
+    warnings.filterwarnings(
+        "ignore",
+        category=UserWarning,
+        module=r"torch\.cuda",
+        message=r"\n.*Found GPU0 DRIVE-P2021.*capability.*10\.0\.",
+    )
+
+
 # Suppress PyTorch's UserWarning: Failed to load image Python extension: 'libnvjpeg.so.12: cannot open shared object file: No such file or directory'
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", UserWarning)
@@ -33,7 +48,11 @@ model_file = "frcnn_resnet50_t.pt"
 if len(sys.argv) > 1:
     model_file = sys.argv[1]
 
-DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+# Suppress known PyTorch CUDA compatibility warnings for platforms where model
+# generation can continue successfully despite PyTorch not listing the GPU SM.
+with warnings.catch_warnings():
+    ignore_known_torch_cuda_capability_warnings()
+    DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 det_model = detection.fasterrcnn_resnet50_fpn(
     weights=FasterRCNN_ResNet50_FPN_Weights.DEFAULT,
@@ -41,19 +60,16 @@ det_model = detection.fasterrcnn_resnet50_fpn(
     weights_backbone=ResNet50_Weights.DEFAULT,
 )
 
-# Suppress PyTorch 2.9 known UserWarning for GB10 / sm_120 (capability 12.x) only.
+# Suppress PyTorch 2.9 known UserWarning for GB10 / sm_120 (capability 12.x).
 # \\n    Found GPU0 NVIDIA GB10 which is of cuda capability 12.1.
 # \\n    Minimum and Maximum cuda capability supported by this version of PyTorch is
 # \\n    (8.0) - (12.0)\\n
 # https://github.com/pytorch/pytorch/issues/172629
 # https://forums.developer.nvidia.com/t/dgx-dashboard-playbook-pytorch-in-sample-code-not-supporting-cuda-12-1/350762
+# Also suppress the same non-fatal compatibility warning for DRIVE-P2021.
+# \\n    Found GPU0 DRIVE-P2021 which is of compute capability (CC) 10.0.
 with warnings.catch_warnings():
-    warnings.filterwarnings(
-        "ignore",
-        category=UserWarning,
-        module=r"torch\.cuda",
-        message=r"\n.*Found GPU0 NVIDIA GB10.*",
-    )
+    ignore_known_torch_cuda_capability_warnings()
     det_model = det_model.to(DEVICE)
 
 


### PR DESCRIPTION
## Background

`object_detection_torch` model generation can report a PyTorch CUDA
UserWarning when running on DRIVE-P2021 platforms whose compute capability is
newer than the installed PyTorch build advertises:

```text
Found GPU0 DRIVE-P2021 which is of compute capability (CC) 10.0.
```

This is the same warning family handled for DGX Spark GB10 in
https://github.com/nvidia-holoscan/holohub/pull/1473. Model generation can
continue for this device-specific PyTorch capability warning.

## Workaround

Generalize the existing warning filter into a helper, include the known
DRIVE-P2021 warning pattern, and apply the filter while selecting the CUDA
device as well as while moving the model.

The suppression remains limited to known PyTorch CUDA capability messages for
GB10 and DRIVE-P2021. Other `UserWarning` output remains visible.

## Result

Validated locally:

- `python3 -m py_compile applications/object_detection_torch/generate_resnet_model.py`
- `git diff --check origin/main..HEAD`
- `uvx pre-commit run --all-files`

Target-platform runtime validation was not run in this environment.

## References

- https://github.com/nvidia-holoscan/holohub/pull/1473


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy, non-fatal CUDA compatibility warnings during object detection model startup.
  * Improved suppression consistency for known CUDA capability messages across supported GPU hardware, keeping device setup and model initialization logs cleaner and less distracting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->