### PR TITLE
CMake: Minor fixes for common CMake helper utilities

### DIFF
--- a/cmake/modules/holohub_configure_deb.cmake
+++ b/cmake/modules/holohub_configure_deb.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmake/modules/holohub_configure_deb.cmake
+++ b/cmake/modules/holohub_configure_deb.cmake
@@ -47,8 +47,8 @@ function(holohub_configure_deb)
   set(CPACK_DEBIAN_PACKAGE_DEPENDS "${ARG_DEPENDS}")
   set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "${ARG_RECOMMENDS}")
   set(CPACK_DEBIAN_PACKAGE_SUGGESTS "${ARG_SUGGESTS}")
-  set(CPACK_PACKAGE_SECTION "${ARG_SECTION}")
-  set(CPACK_PACKAGE_PRIORITY "${ARG_PRIORITY}")
+  set(CPACK_DEBIAN_PACKAGE_SECTION "${ARG_SECTION}")
+  set(CPACK_DEBIAN_PACKAGE_PRIORITY "${ARG_PRIORITY}")
 
   if(ARG_EXPORT_NAME)
     set(config_install_dir "lib/cmake/${ARG_NAME}")
@@ -86,7 +86,10 @@ function(holohub_configure_deb)
     # only packages installed components, in a single package
     set(CPACK_DEB_COMPONENT_INSTALL 1)
     set(CPACK_ARCHIVE_COMPONENT_INSTALL 1)
-    set(CPACK_COMPONENTS_ALL "${ARG_COMPONENTS};${export_component}") # TODO: check if components are valid?
+    set(CPACK_COMPONENTS_ALL "${ARG_COMPONENTS}")
+    if(export_component)
+      list(APPEND CPACK_COMPONENTS_ALL "${export_component}")
+    endif()
     set(CPACK_COMPONENTS_GROUPING ALL_COMPONENTS_IN_ONE)
   else()
     # package all installed targets

--- a/cmake/pybind11/__init__.py
+++ b/cmake/pybind11/__init__.py
@@ -24,7 +24,7 @@ try:
 except ImportError as e:
     pybind11_hsdk_err = 'unknown base type "holoscan::'
 
-    if not pybind11_hsdk_err in str(e):
+    if pybind11_hsdk_err not in str(e):
         # Unknown import error, raise it
         raise e
 

--- a/cmake/pybind11_add_holohub_module.cmake
+++ b/cmake/pybind11_add_holohub_module.cmake
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Find pybind11
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
 
 # We fetch pybind11 since we need the same version as the Holoscan SDK
 # and it's not necessarily available on all the platforms

--- a/cmake/pydoc/macros.hpp
+++ b/cmake/pydoc/macros.hpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmake/pydoc/macros.hpp
+++ b/cmake/pydoc/macros.hpp
@@ -18,8 +18,6 @@
 #ifndef PYHOLOSCAN_MACRO_HPP
 #define PYHOLOSCAN_MACRO_HPP
 
-#include <fmt/format.h>
-
 #include <string>
 
 constexpr const char* remove_leading_spaces(const char* str) {


### PR DESCRIPTION
## Background

`cmake/` helper files are used throughout HoloHub projects. Several helper files are also copied into new Holoscan Module projects when initialized from the template at `modules/template`.

## Issue

Identified several minor issues when linting a newly initialized module from template. These issues are generally non-blocking but good to fix.

## Updates

  - holohub_configure_deb.cmake: use CPACK_DEBIAN_PACKAGE_SECTION/PRIORITY (the generic CPACK_PACKAGE_* names are silently ignored by the DEB generator), and stop appending an empty export component to CPACK_COMPONENTS_ALL when no EXPORT_NAME is given.
  - pybind11_add_holohub_module.cmake: require the Python3 Development.Module component instead of the full Development component, which fails to find the embed library in minimal/manylinux build images.
  - pybind11/__init__.py: use `x not in s` instead of `not x in s`.
  - pydoc/macros.hpp: drop the unused <fmt/format.h> include.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Debian package metadata so generated packages use the correct section and priority values.
  * Fixed component package generation to avoid including an empty optional component entry.
* **Chores**
  * Updated Python build discovery to require the module development component for smoother builds.
  * Made small documentation/build header and error-handling cleanups with no expected user-facing behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->