### PR TITLE
Module template: Install complete CMake export interface

### DIFF
--- a/modules/template/hooks/post_gen_project.py
+++ b/modules/template/hooks/post_gen_project.py
@@ -89,7 +89,11 @@ if _holohub_root is None:
 
 # Copy CMake helpers from the HoloHub clone so the module builds standalone:
 #   - HoloHubConfigHelpers.cmake: add_holohub_application/operator/package gating
-#   - holohub_configure_deb.cmake: deb packaging helper used by the root CMakeLists
+#   - holohub_configure_deb.cmake: deb packaging helper used by the root
+#     CMakeLists. Brings a companion asset:
+#       - Config.cmake.in: package-config template the helper feeds to
+#         configure_package_config_file() when EXPORT_NAME is set, so
+#         downstream find_package(<module>) resolves the exported targets
 #   - pybind11_add_holohub_module.cmake: fetches pybind11 at the HSDK-pinned
 #     version + ABI-aligned target. Brings two companion assets:
 #       - pybind11/__init__.py: per-operator __init__ template configured by
@@ -102,6 +106,7 @@ if _holohub_root:
     for _rel in (
         ("cmake", "HoloHubConfigHelpers.cmake"),
         ("cmake", "modules", "holohub_configure_deb.cmake"),
+        ("cmake", "modules", "Config.cmake.in"),
         ("cmake", "pybind11_add_holohub_module.cmake"),
     ):
         _src = _holohub_root.joinpath(*_rel)

--- a/modules/template/{{cookiecutter.module_repo_name}}/operators/{{cookiecutter.operator_slug}}/CMakeLists.txt
+++ b/modules/template/{{cookiecutter.module_repo_name}}/operators/{{cookiecutter.operator_slug}}/CMakeLists.txt
@@ -12,6 +12,14 @@ target_link_libraries({{ cookiecutter.operator_slug }} PRIVATE holoscan::core)
 
 install(FILES {{ cookiecutter.operator_slug }}.hpp DESTINATION include/{{ cookiecutter.operator_slug }})
 
+# Add the operator to an export set. The package layer installs the set and
+# generates the CMake config — see holohub_configure_deb(... EXPORT_NAME ...) in
+# pkg/{{ cookiecutter.module_repo_name }}/CMakeLists.txt — so downstream projects
+# can find_package({{ cookiecutter.module_repo_name }}) and link
+# holoscan::{{ cookiecutter.operator_slug }}.
+install(TARGETS {{ cookiecutter.operator_slug }}
+    EXPORT holoscan_{{ cookiecutter.module_slug }}_targets)
+
 add_subdirectory(python)
 {% else %}# Pure Python operator — copy source into the Python package tree.
 configure_file(

--- a/modules/template/{{cookiecutter.module_repo_name}}/pkg/{{cookiecutter.module_repo_name}}/CMakeLists.txt
+++ b/modules/template/{{cookiecutter.module_repo_name}}/pkg/{{cookiecutter.module_repo_name}}/CMakeLists.txt
@@ -12,4 +12,5 @@ holohub_configure_deb(
     VENDOR      "{% if cookiecutter.affiliation %}{{ cookiecutter.affiliation }}{% else %}NVIDIA{% endif %}"
     CONTACT     "{{ cookiecutter.contact_email }}"
     DEPENDS     "holoscan (>= {{ cookiecutter.holoscan_version }})"
+    EXPORT_NAME "holoscan_{{ cookiecutter.module_slug }}_targets"
 )

--- a/modules/template/{{cookiecutter.module_repo_name}}/pkg/{{cookiecutter.module_repo_name}}/CMakeLists.txt
+++ b/modules/template/{{cookiecutter.module_repo_name}}/pkg/{{cookiecutter.module_repo_name}}/CMakeLists.txt
@@ -12,5 +12,5 @@ holohub_configure_deb(
     VENDOR      "{% if cookiecutter.affiliation %}{{ cookiecutter.affiliation }}{% else %}NVIDIA{% endif %}"
     CONTACT     "{{ cookiecutter.contact_email }}"
     DEPENDS     "holoscan (>= {{ cookiecutter.holoscan_version }})"
-    EXPORT_NAME "holoscan_{{ cookiecutter.module_slug }}_targets"
-)
+{% if cookiecutter.language == 'cpp' %}    EXPORT_NAME "holoscan_{{ cookiecutter.module_slug }}_targets"
+{% endif %})


### PR DESCRIPTION
## Overview

Fixes module template so that new projects generate a viable C++ development package.

### Previous behavior

Creating a new Holoscan Module from template and then running default "./holohub package" commands would generate an incomplete C++ development package missing libraries and CMake import rules

### Updated

"./holohub package" installs binary operator libraries and CMake development files (*-config.cmake, *-targets.cmake) into the Debian package for distribution and reuse.

### Result

```
$ ./holohub create mymod --template ./modules/template
...
$ cd path/to/holoscan-mymod
$ ./holohub package holoscan-mymod
...
CPack: - package: /workspace/mymod/holoscan-mymod_0.1.0_amd64.deb generated.

$ dpkg-deb -c ./holoscan-mymod_0.1.0_amd64.deb 
drwxr-xr-x root/root         0 2026-06-25 09:16 ./opt/
drwxr-xr-x root/root         0 2026-06-25 09:16 ./opt/nvidia/
drwxr-xr-x root/root         0 2026-06-25 09:16 ./opt/nvidia/holoscan/
drwxr-xr-x root/root         0 2026-06-25 09:16 ./opt/nvidia/holoscan/bin/
-rwxr-xr-x root/root       877 2026-06-25 09:15 ./opt/nvidia/holoscan/bin/mymod_pipeline
drwxr-xr-x root/root         0 2026-06-25 09:16 ./opt/nvidia/holoscan/holoscan/
drwxr-xr-x root/root         0 2026-06-25 09:16 ./opt/nvidia/holoscan/holoscan/mymod/
-rw-r--r-- root/root       585 2026-06-25 09:16 ./opt/nvidia/holoscan/holoscan/mymod/__init__.py
drwxr-xr-x root/root         0 2026-06-25 09:16 ./opt/nvidia/holoscan/holoscan/mymod/mymod_op/
-rw-r--r-- root/root      2496 2026-06-25 09:16 ./opt/nvidia/holoscan/holoscan/mymod/mymod_op/__init__.py
-rw-r--r-- root/root    572920 2026-06-25 09:16 ./opt/nvidia/holoscan/holoscan/mymod/mymod_op/_mymod_op.cpython-312-x86_64-linux-gnu.so
drwxr-xr-x root/root         0 2026-06-25 09:16 ./opt/nvidia/holoscan/include/
drwxr-xr-x root/root         0 2026-06-25 09:16 ./opt/nvidia/holoscan/include/mymod_op/
-rw-r--r-- root/root       678 2026-06-25 09:15 ./opt/nvidia/holoscan/include/mymod_op/mymod_op.hpp
drwxr-xr-x root/root         0 2026-06-25 09:16 ./opt/nvidia/holoscan/lib/
drwxr-xr-x root/root         0 2026-06-25 09:16 ./opt/nvidia/holoscan/lib/cmake/
drwxr-xr-x root/root         0 2026-06-25 09:16 ./opt/nvidia/holoscan/lib/cmake/holoscan-mymod/
-rw-r--r-- root/root       526 2026-06-25 09:16 ./opt/nvidia/holoscan/lib/cmake/holoscan-mymod/holoscan-mymodConfig.cmake
-rw-r--r-- root/root      1861 2026-06-25 09:16 ./opt/nvidia/holoscan/lib/cmake/holoscan-mymod/holoscan-mymodConfigVersion.cmake
-rw-r--r-- root/root       867 2026-06-25 09:16 ./opt/nvidia/holoscan/lib/cmake/holoscan-mymod/holoscan_mymod_targets-release.cmake
-rw-r--r-- root/root      4203 2026-06-25 09:16 ./opt/nvidia/holoscan/lib/cmake/holoscan-mymod/holoscan_mymod_targets.cmake
-rw-r--r-- root/root    314884 2026-06-25 09:16 ./opt/nvidia/holoscan/lib/libmymod_op.a
```

### Follow-up tasks

Improve CI/CD coverage to generate and exercise Debian C++ development interface from a new module.

Assisted-by: Claude:claude-opus-4.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved generated project packaging so operator targets are installed with an export set for downstream `find_package(...)` discovery.
  * Updated CMake packaging behavior for C++ projects to set the appropriate export name, ensuring generated package config exports the operator correctly.

* **Documentation**
  * Expanded template guidance on copying and generating HoloHub CMake helper files, including `Config.cmake.in` and how package configuration is created for exported packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->