### PR TITLE
fix: declare CMake languages explicitly in the create template

### DIFF
--- a/applications/template/{{cookiecutter.project_slug}}/CMakeLists.txt
+++ b/applications/template/{{cookiecutter.project_slug}}/CMakeLists.txt
@@ -15,12 +15,12 @@
 
 cmake_minimum_required(VERSION 3.20)
 
-project({{ cookiecutter.project_slug }})
+{% if cookiecutter.language == "cpp" %}
+project({{ cookiecutter.project_slug }} LANGUAGES CXX)
 
 find_package(holoscan {{ cookiecutter.holoscan_version }} REQUIRED CONFIG
              PATHS "/opt/nvidia/holoscan" "/workspace/holoscan-sdk/install")
 
-{% if cookiecutter.language == "cpp" %}
 add_executable({{ cookiecutter.project_slug }}
     src/main.cpp
 )
@@ -29,10 +29,15 @@ target_link_libraries({{ cookiecutter.project_slug }}
     PRIVATE
     holoscan::core
 )
+{% else %}
+# Python application: nothing to compile. The Holoscan SDK is imported at
+# runtime (`import holoscan`), so configuring this project needs no C/C++
+# toolchain and no Holoscan SDK development package.
+project({{ cookiecutter.project_slug }} LANGUAGES NONE)
+{% endif %}
 
 if(BUILD_TESTING)
-  add_test({{ cookiecutter.project_slug }}-test
+  add_test(NAME {{ cookiecutter.project_slug }}-test
     COMMAND echo "Add test coverage for {{ cookiecutter.project_slug }} here"
   )
 endif()
-{% endif %}


### PR DESCRIPTION
## Summary

The application template's `CMakeLists.txt` called a bare `project()` — which implicitly enables **C and CXX** — and ran `find_package(holoscan)` unconditionally. As a result, a `language=python` project generated by `./holohub create` failed to configure on hosts without a C/C++ toolchain (e.g. bare CUDA base images):

```
CMake Error at applications/myproj/CMakeLists.txt:18 (project):
  No CMAKE_C_COMPILER could be found.
  No CMAKE_CXX_COMPILER could be found.
```

This change makes the template follow the conventions already used in the tree (the root `CMakeLists.txt` probes for a compiler before enabling CXX; `holochat` declares `project(... NONE)`):

- **cpp** projects declare `LANGUAGES CXX` (no C compiler required) and keep `find_package(holoscan)`.
- **python** projects declare `LANGUAGES NONE` and skip `find_package` — the SDK is imported at runtime, so configuring needs no toolchain and no SDK development package.
- The placeholder test uses the modern `add_test(NAME ... COMMAND ...)` signature (the keyword-less form parses as CMake's legacy signature and registers a test whose executable is the literal word `COMMAND`), and is now registered for python projects too.

## Related

Complements nvidia-holoscan/holoscan-cli#175, which adds `build-essential` to `holoscan setup` so **cpp** projects build on bare CUDA bases — with this change, **python** projects need no compiler at all. Addresses the CMake-language discussion raised by @tbirdso in that PR's review thread.

## Test plan

- [x] Rendered python project configures with no usable compilers (`-DCMAKE_C_COMPILER=/nonexistent -DCMAKE_CXX_COMPILER=/nonexistent`)
- [x] Pre-change template rendered the same way reproduces the CI failure above
- [x] Rendered cpp project compiles and links against an installed Holoscan SDK (4.3.0, `/opt/nvidia/holoscan`) with CXX as the only enabled language
- [x] `utilities/cli/tests/test_create_module.py` passes (2 passed, run with `--noconftest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project templates now generate language-appropriate build configuration for C++ and Python projects.
  * C++ projects get the expected build setup, while Python projects use a lighter configuration that skips C++-specific steps.
* **Bug Fixes**
  * Test scaffolding now appears consistently across both project types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->