### PR TITLE
Skip Claude Code Review on fork and Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip PRs from forks and Dependabot: their runs get no OIDC token or
+    # secrets, so the action cannot authenticate and the job would fail.
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
### Problem

The `claude-review` job added in #1637 fails on every PR opened from a fork — first seen on #1639 ([failing run](https://github.com/nvidia-holoscan/holohub/actions/runs/28798720053/job/85395991707)):

```
Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
Could not fetch an OIDC token. Did you remember to add id-token: write to your workflow permissions?
```

### Root cause

On `pull_request` runs triggered from forked repositories, GitHub silently drops `id-token: write` (the failing run's granted permissions show only `contents/issues/pull-requests: read`) and withholds repository secrets. `anthropics/claude-code-action` needs the OIDC token to obtain its GitHub App token, so authentication fails — and `ANTHROPIC_API_KEY` would be unavailable regardless. Dependabot-triggered runs have the same restrictions.

### Fix

Gate the `claude-review` job to same-repo, non-Dependabot PRs. Fork PRs now show the check as **skipped** instead of a red failure. This is the approach recommended for public repos; the alternative (`pull_request_target`) would expose secrets to untrusted PR code.

`@claude` mentions keep working on fork PRs — `claude.yml` triggers on comment/issue events, which run in the base repository context where OIDC and secrets are available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pull request review workflow so it skips runs from forks and Dependabot, avoiding failed checks when required secrets aren’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->