### PR TITLE
fix: unpin onnxscript in depth_anything_v2 Dockerfile

### DIFF
--- a/applications/depth_anything_v2/Dockerfile
+++ b/applications/depth_anything_v2/Dockerfile
@@ -45,7 +45,13 @@ RUN git clone --depth 1 https://github.com/DepthAnything/Depth-Anything-V2.git \
     && mv depth-anything-tensorrt/depth_anything_v2/dpt.py Depth-Anything-V2/depth_anything_v2 \
     && mv depth-anything-tensorrt/depth_anything_v2/export_v2.py Depth-Anything-V2
 
-RUN pip install onnx==1.19.1 onnx-graphsurgeon==0.5.8 onnxscript==0.5.6 \
+# Note: onnxscript is intentionally left unpinned. The upstream Depth-Anything-V2
+# repository does not pin the torch version, so the torch version shipped in the
+# base image can change over time. onnxscript loads a torch-version-specific
+# submodule (e.g. onnxscript._framework_apis.torch_2_11) during ONNX export, so a
+# pinned onnxscript can break when the base image torch version is bumped. Leaving
+# it unpinned lets pip resolve a version compatible with the installed torch.
+RUN pip install onnx==1.19.1 onnx-graphsurgeon==0.5.8 onnxscript \
     && pip install -r Depth-Anything-V2/requirements.txt
 
 # Change to the repository directory


### PR DESCRIPTION
Fixes #1620.

### Problem

`./holohub run depth_anything_v2` fails during the ONNX export build step with:

```
ModuleNotFoundError: No module named 'onnxscript._framework_apis.torch_2_11'
```

The base image now ships PyTorch 2.11, but the pinned `onnxscript==0.5.6` has no `torch_2_11` submodule. Upstream Depth-Anything-V2 does not pin torch, so the base image torch version can drift and a fixed onnxscript pin keeps breaking.

### Fix

Unpin `onnxscript` so pip resolves a version compatible with the installed torch, and add a comment explaining why it must stay unpinned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the model export environment to use a more flexible dependency version, improving compatibility during export.
  * Added guidance in the setup notes to clarify the compatibility requirement for the export workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->