### PR TITLE
Op: Use "native" CUDA architecture default to build fft operator

### DIFF
--- a/operators/fft/CMakeLists.txt
+++ b/operators/fft/CMakeLists.txt
@@ -4,7 +4,6 @@
 cmake_minimum_required(VERSION 3.20)
 project(fft CXX)
 
-set(CMAKE_CUDA_ARCHITECTURES "70;80;90")
 enable_language(CUDA)
 
 find_package(holoscan 4.0.0 REQUIRED CONFIG


### PR DESCRIPTION
Issue: The FFT operator explicitly set target GPU architectures for CUDA compilation. The minimum architecture "70" is not supported in latest CUDA Toolkit versions and results in build-time NVCC failure.

Changes:
- Remove explicit CUDA arch list and rely on HoloHub standard "CMAKE_CUDA_ARCHITECTURES=native" setting in top-level CMakeLists.txt to build for development machine hardware
- Explicitly pass CMake arg to set the list to a different value:

```bash
./holohub build fft
--configure-args="-DCMAKE_CUDA_ARCHITECTURES='70;80;90'"
```

Verified locally on x86.

Closes #1650

cc @JohnMoon-Voyager

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CUDA build setup to avoid hard-coding specific GPU architectures, allowing builds to adapt more flexibly to different CUDA-capable systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->