### PR TITLE
docs: refresh HoloHub CLI documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,13 @@ Projects live under `applications/`, `benchmarks/`, `operators/`, `gxf_extension
 ## Boundaries
 
 - **Always** run `./holohub run-container -- "./holohub lint --install-dependencies; ./holohub lint"` before committing
-- **Always** use `--dryrun --verbose` to inspect a CLI command before running it for real
+- **Always** preview mutating CLI commands before running them for real:
+  - Use `--dryrun --verbose` with `build`, `run`, `build-container`,
+    `run-container`, `install`, `test`, and `package`
+  - Use `--dryrun` with `create`, `lint`, `setup`, and `clear-cache`; these
+    commands do not accept `--verbose`
+  - `list`, `modes`, `env-info`, `env-check`, `status`, and `version` are
+    read-only diagnostics and accept neither preview flag
 - **Ask first** before changing `metadata.json` schemas, shared Dockerfiles, or CMake registration macros (`add_holohub_application`, `add_holohub_operator`, etc.)
 - **Never** delete `build/`, `data/`, or `install/` directories without asking
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,13 +9,7 @@ Projects live under `applications/`, `benchmarks/`, `operators/`, `gxf_extension
 ## Boundaries
 
 - **Always** run `./holohub run-container -- "./holohub lint --install-dependencies; ./holohub lint"` before committing
-- **Always** preview mutating CLI commands before running them for real:
-  - Use `--dryrun --verbose` with `build`, `run`, `build-container`,
-    `run-container`, `install`, `test`, and `package`
-  - Use `--dryrun` with `create`, `lint`, `setup`, and `clear-cache`; these
-    commands do not accept `--verbose`
-  - `list`, `modes`, `env-info`, `env-check`, `status`, and `version` are
-    read-only diagnostics and accept neither preview flag
+- **Always** preview mutating CLI commands with `--dryrun` before running them for real; add `--verbose` where supported. Read-only diagnostics (`list`, `modes`, `env-info`, `env-check`, `status`, `version`) need no preview. See the [CLI Reference](utilities/cli/cli_reference.md#preview-support) for per-command support.
 - **Ask first** before changing `metadata.json` schemas, shared Dockerfiles, or CMake registration macros (`add_holohub_application`, `add_holohub_operator`, etc.)
 - **Never** delete `build/`, `data/`, or `install/` directories without asking
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -520,7 +520,8 @@ You can also run lint directly. If `pre-commit` is not already available in the
 environment, `./holohub lint` installs it automatically before running checks:
 
 ```bash
-./holohub run-container -- ./holohub lint
+./holohub run-container -- \
+  "./holohub lint --install-dependencies; ./holohub lint"
 ```
 
 The container reuses `.local/` and `.cache/pre-commit/` from the mounted
@@ -653,8 +654,8 @@ For examples, see existing test files like:
 
 - VSCode Dev Container support available in Holoscan SDK
 - `holohub` CLI tool with debugging options:
-  - `--as_root`: Launch as root for expanded debugging permissions
-  - `--local_sdk_root`: Mount local SDK for debug symbol access
+  - `--as-root`: Run the application phase, or a development container, as root
+  - `--local-sdk-root`: Mount a local SDK build for debug symbol access
 
 **Debugging Tools:**
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,12 @@ To build and run in a containerized environment you will need:
 - the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) (v1.12.2 or later)
 - [Docker](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository), including the buildx plugin (`docker-buildx-plugin`)
 - `git` version control
-- (optional) [Python 3.10+](https://www.python.org/downloads/) with `venv` support on the host machine to run the `./holohub` infrastructure script; its first run installs the [holoscan-cli](https://github.com/nvidia-holoscan/holoscan-cli) package into a user-owned environment (see [utilities/cli/README.md](utilities/cli/README.md))
+- [Python 3.10+](https://www.python.org/downloads/) on the host. Unless you
+  select an existing compatible environment, `venv` support is also required;
+  the first `./holohub` invocation installs
+  [holoscan-cli](https://github.com/nvidia-holoscan/holoscan-cli) into a
+  user-owned managed environment (see
+  [utilities/cli/README.md](utilities/cli/README.md))
 
 You will also need to set up your NVIDIA NGC credentials at [ngc.nvidia.com](https://catalog.ngc.nvidia.com/).
 
@@ -95,7 +100,7 @@ If you want to use a specific based image for the application, you can use the `
 ./holohub run --base-img <base_image> <application_name>
 ```
 
-> **NOTE:** The build_and_run command is not supported for all applications and operators, especially applications that requires manual configurations or applications that requires additional datasets. Please refer to the README of each application or operator for more information.
+> **NOTE:** The `./holohub run` command is not sufficient for all applications and operators, especially those requiring manual configuration or additional datasets. Refer to each project's README for details.
 
 If you want a more detailed command to build and run a specific application, please follow the instructions below.
 
@@ -117,7 +122,7 @@ Check to verify that the image is created:
 $ docker images
 REPOSITORY      TAG               IMAGE ID       CREATED         SIZE
 ...
-holohub         ngc-v3.5.0-dgpu   c93e9f90a263   1 minutes ago   19.1GB
+holohub         ngc-v4.4.0-cuda13   c93e9f90a263   1 minute ago   19.1GB
 ...
 ```
 
@@ -152,11 +157,16 @@ The development container has been tested on the following platforms:
 
 (1) On AGX Orin Dev Kit the launch script will add ```--privileged``` and ```--group-add video``` to the docker run command for the reference applications to work. Please also make sure that the current user is member of the group video.
 
-(2) When building Holoscan SDK on AGX Orin Dev Kit from source please add the option  ```--build-args="--cudaarchs all"``` to the ```./holohub build-container``` command to include support for AGX Orin's iGPU.
+(2) When building Holoscan SDK from source for AGX Orin, pass
+`--cudaarchs all` to the SDK repository's `./run` build command. This is a
+Holoscan SDK option, not a `./holohub build-container` option.
 
 ## Building Operators, Applications, and Packages
 
-> *Make sure you have either launched your [development container](#container-build-recommended) or [set up your local environment](./doc/developer.md#native-build) before attempting to build Holohub components.*
+> By default, `./holohub build` and `./holohub run` create and enter the
+> appropriate development container automatically. Use
+> [native setup](./doc/developer.md#native-build) only when you intentionally
+> pass `--local`.
 
 This repository provides a convenience `holohub` script to abstract some of the CMake build process below.
 
@@ -170,7 +180,7 @@ Then run the following to build the component of your choice:
 
   ```sh
   # Build using the component name
-  ./holohub build <package|application|operator>
+  ./holohub build <project_name>
   # Ex: ./holohub build endoscopy_tool_tracking
   ```
 
@@ -201,8 +211,9 @@ endoscopy application:
     ./holohub run endoscopy_tool_tracking --language=python
   ```
 
-The run script reads the "run" command from the metadata.json file for a given application and runs from the "workdir" directory.
-Make sure you build the application (if applicable) before running it.
+The run command resolves the selected application's `metadata.json`, builds it
+unless a supported skip option is active, and executes its configured command
+from the `workdir` directory.
 
 ## Cleanup
 

--- a/applications/README.md
+++ b/applications/README.md
@@ -15,7 +15,7 @@ Please review the [CONTRIBUTING.md file](https://github.com/nvidia-holoscan/holo
 Use the HoloHub CLI tool when starting a new project to generate a project folder with files in compliance with HoloHub conventions out of the box.
 
 ```bash
-./holohub create
+./holohub create my_application
 ```
 
 ## Required Conventions

--- a/applications/ai_surgical_video/README.md
+++ b/applications/ai_surgical_video/README.md
@@ -142,10 +142,11 @@ Once your environment is set up, you can build the application using the followi
 Using the Holohub container, you can run the application without building it again:
 
 ```sh
-./holohub run ai_surgical_video --no-build
+./holohub run ai_surgical_video --no-docker-build --no-local-build
 ```
 
-However, if you want to build the application, you can just remove the `--no-build` flag:
+Remove the skip flags when the container image or application artifacts need
+to be rebuilt:
 
 ```sh
 ./holohub run ai_surgical_video

--- a/applications/ai_surgical_video/README.md
+++ b/applications/ai_surgical_video/README.md
@@ -145,8 +145,7 @@ Using the Holohub container, you can run the application without building it aga
 ./holohub run ai_surgical_video --no-docker-build --no-local-build
 ```
 
-Remove the skip flags when the container image or application artifacts need
-to be rebuilt:
+Remove the skip flags to fully rebuild the container image and application:
 
 ```sh
 ./holohub run ai_surgical_video

--- a/applications/distributed/grpc/grpc_endoscopy_tool_tracking/README.md
+++ b/applications/distributed/grpc/grpc_endoscopy_tool_tracking/README.md
@@ -149,9 +149,13 @@ replayer->output: 683
 
 ## Containerization
 
+> [!IMPORTANT]
+> These helpers require the application packager from `holoscan-cli` 4.2.0 or
+> earlier. Current `./holohub package` builds Holoscan Module artifacts instead.
+
 To containerize the application:
 
-1. Install [Holoscan CLI](https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/examples/cli_packager)
+1. Install a compatible legacy [Holoscan CLI](https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/examples/cli_packager)
 2. Build the application:
 
    ```bash

--- a/applications/ehr_query_llm/fhir/README.md
+++ b/applications/ehr_query_llm/fhir/README.md
@@ -19,7 +19,7 @@ The default set of FHIR resource types to retrieve are listed below, which can b
 
 ## Requirements
 
-- On a [Holohub supported platform](../../README.md#supported-platforms)
+- On a [HoloHub supported platform](../../../README.md#supported-platforms)
 - Python 3.10+
 - Python packages from [PyPI](https://pypi.org), including holoscan, fhir.resources, pyzmq, requests and their dependencies
 
@@ -117,7 +117,11 @@ From the menu, pick one of the choices for the resources of interest.
 
 ## Packaging the Application for Distribution and Deployment
 
-With Holoscan CLI, applications built with Holoscan SDK can be packaged into a Holoscan Application Package (HAP), which is an [Open Container Initiative](https://opencontainers.org/) compliant image. An HAP is well suited to be distributed for deployment on hosting platforms, be it Docker Compose, Kubernetes, or otherwise. Please refer to [Packaging Holoscan Applications](https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/examples/cli_packager) in the User Guide for more information.
+> [!IMPORTANT]
+> This helper requires the application packager from `holoscan-cli` 4.2.0 or
+> earlier. Current `./holohub package` builds Holoscan Module artifacts instead.
+
+With a compatible legacy Holoscan CLI, applications built with Holoscan SDK can be packaged into a Holoscan Application Package (HAP), which is an [Open Container Initiative](https://opencontainers.org/) compliant image. An HAP is well suited to be distributed for deployment on hosting platforms, be it Docker Compose, Kubernetes, or otherwise. Please refer to [Packaging Holoscan Applications](https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/examples/cli_packager) for more information.
 
 This example application provides all the necessary contents for HAP packaging. It is required to perform the packaging in a Python virtual environment, with the application's dependencies installed, before running the following script to reveal specific packaging commands.
 

--- a/applications/ehr_query_llm/fhir/README.md
+++ b/applications/ehr_query_llm/fhir/README.md
@@ -121,7 +121,7 @@ From the menu, pick one of the choices for the resources of interest.
 > This helper requires the application packager from `holoscan-cli` 4.2.0 or
 > earlier. Current `./holohub package` builds Holoscan Module artifacts instead.
 
-With a compatible legacy Holoscan CLI, applications built with Holoscan SDK can be packaged into a Holoscan Application Package (HAP), which is an [Open Container Initiative](https://opencontainers.org/) compliant image. An HAP is well suited to be distributed for deployment on hosting platforms, be it Docker Compose, Kubernetes, or otherwise. Please refer to [Packaging Holoscan Applications](https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/examples/cli_packager) for more information.
+With a compatible legacy Holoscan CLI, applications built with Holoscan SDK can be packaged into a Holoscan Application Package (HAP), which is an [Open Container Initiative](https://opencontainers.org/) compliant image. An HAP is well suited to be distributed for deployment on hosting platforms, be it Docker Compose, Kubernetes, or otherwise. Please refer to [Packaging Holoscan Applications](https://github.com/nvidia-holoscan/holoscan-sdk/tree/874dc9deb8cb92fd1f12691695abdef9d85888d4/examples/cli_packager) for more information.
 
 This example application provides all the necessary contents for HAP packaging. It is required to perform the packaging in a Python virtual environment, with the application's dependencies installed, before running the following script to reveal specific packaging commands.
 

--- a/applications/endoscopy_tool_tracking/README.md
+++ b/applications/endoscopy_tool_tracking/README.md
@@ -121,6 +121,10 @@ Arguments:
 
 ## Containerize the application
 
-To containerize the application using [Holoscan CLI](https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/examples/cli_packager), first build the application using `./holohub install endoscopy_tool_tracking`, run the `package-app.sh` script in the [cpp](./cpp/package-app.sh) or the [python](./python/package-app.sh) directory and then follow the generated output to package and run the application.
+> [!IMPORTANT]
+> These scripts require the application packager from `holoscan-cli` 4.2.0 or
+> earlier. Current `./holohub package` builds Holoscan Module artifacts instead.
 
-Refer to the [Packaging Holoscan Applications](https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/examples/cli_packager) section of the [Holoscan User Guide](https://docs.nvidia.com/holoscan/sdk-user-guide/introduction/getting-started) to learn more about installing the Holoscan CLI or packaging your application using Holoscan CLI.
+To containerize the application using the legacy [Holoscan CLI](https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/examples/cli_packager), first build the application using `./holohub install endoscopy_tool_tracking`, run the `package-app.sh` script in the [cpp](./cpp/package-app.sh) or the [python](./python/package-app.sh) directory and then follow the generated output to package and run the application.
+
+Refer to the [Packaging Holoscan Applications](https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/examples/cli_packager) section of the [Holoscan User Guide](https://docs.nvidia.com/holoscan/sdk-user-guide/introduction/getting-started) to learn more about installing the legacy Holoscan CLI or packaging your application using Holoscan CLI.

--- a/applications/iio/README.md
+++ b/applications/iio/README.md
@@ -64,7 +64,7 @@ Connect your ADALM-Pluto to your computer via USB. The device will appear as a n
 
 ```bash
 # From HoloHub root directory
-./dev_container build_and_run iio
+./holohub run iio
 ```
 
 ### 3. Run Examples
@@ -75,7 +75,7 @@ The application includes several example modes:
 
 ```bash
 # Transmits a sine wave on the configured frequency
-./run launch iio python
+./holohub run iio --language python
 ```
 
 #### Read Device Attributes
@@ -92,8 +92,8 @@ The C++ FFT example (`cpp/pluto_fft_example`) demonstrates real-time FFT visuali
 
 ```bash
 # Build and run the FFT example
-./run build iio cpp
-./run launch iio cpp
+./holohub build iio --language cpp
+./holohub run iio --language cpp
 ```
 
 This example captures IQ samples from the Pluto SDR and displays a real-time FFT spectrum:

--- a/applications/imaging_ai_segmentator/README.md
+++ b/applications/imaging_ai_segmentator/README.md
@@ -148,7 +148,11 @@ The application generates two types of outputs:
 
 ## Packaging the Application for Distribution
 
-With Holoscan CLI, an applications built with Holoscan SDK can be packaged into a Holoscan Application Package (HAP), which is essentially a Open Container Initiative compliant container image. An HAP is well suited to be distributed for deployment on hosting platforms, be a Docker Compose, Kubernetes, or else. Please refer to Packaging Holoscan Applications in the User Guide for more information.
+> [!IMPORTANT]
+> This helper requires the application packager from `holoscan-cli` 4.2.0 or
+> earlier. Current `./holohub package` builds Holoscan Module artifacts instead.
+
+With a compatible legacy Holoscan CLI, an applications built with Holoscan SDK can be packaged into a Holoscan Application Package (HAP), which is essentially a Open Container Initiative compliant container image. An HAP is well suited to be distributed for deployment on hosting platforms, be a Docker Compose, Kubernetes, or else. Please refer to Packaging Holoscan Applications in the User Guide for more information.
 
 This example application includes all the necessary files for HAP packaging. First, you should install the application:
 

--- a/applications/imaging_ai_segmentator/README.md
+++ b/applications/imaging_ai_segmentator/README.md
@@ -152,7 +152,7 @@ The application generates two types of outputs:
 > This helper requires the application packager from `holoscan-cli` 4.2.0 or
 > earlier. Current `./holohub package` builds Holoscan Module artifacts instead.
 
-With a compatible legacy Holoscan CLI, an applications built with Holoscan SDK can be packaged into a Holoscan Application Package (HAP), which is essentially a Open Container Initiative compliant container image. An HAP is well suited to be distributed for deployment on hosting platforms, be a Docker Compose, Kubernetes, or else. Please refer to Packaging Holoscan Applications in the User Guide for more information.
+With a compatible legacy Holoscan CLI, an application built with Holoscan SDK can be packaged into a Holoscan Application Package (HAP), which is essentially a Open Container Initiative compliant container image. An HAP is well suited to be distributed for deployment on hosting platforms, be a Docker Compose, Kubernetes, or else. Please refer to Packaging Holoscan Applications in the User Guide for more information.
 
 This example application includes all the necessary files for HAP packaging. First, you should install the application:
 

--- a/applications/imx274_gpu_resident/README.md
+++ b/applications/imx274_gpu_resident/README.md
@@ -215,7 +215,7 @@ Artifacts are produced under `./build/<operator_name>/` (e.g. `./build/csi_to_ba
 ##### Build Options
 
 - **Debug build**: `./holohub build <operator_name> --build-type debug`
-- **Extra CMake options**: `./holohub build <operator_name> --configure-args '-DCMAKE_VERBOSE_MAKEFILE=ON'`
+- **Extra CMake options**: `./holohub build <operator_name> --configure-args='-DCMAKE_VERBOSE_MAKEFILE=ON'`
 
 Run `./holohub build --help` for more options.
 

--- a/applications/object_detection_torch/README.md
+++ b/applications/object_detection_torch/README.md
@@ -5,7 +5,10 @@ The inference is executed using `torch` backend in `holoinfer` module in Holosca
 
 `object_detection_torch.yaml` is the configuration file. Input video file is converted into GXF tensors and the name and location of the GXF tensors are updated in the `basename` and the `directory` field in `replayer`.
 
-This application need `Libtorch` for inferencing. Ensure that the Holoscan SDK is build with `build_libtorch` flag as true. If not, then rebuild the SDK with following: `./holohub build --build_libtorch true` before running this application.
+This application requires LibTorch for inference. Use the application-specific
+container through `./holohub`; its Dockerfile verifies PyTorch from the selected
+base image, configures its LibTorch runtime for the C++ application, and
+installs a matching `torchvision` version.
 
 ## Data
 
@@ -82,9 +85,13 @@ export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/hpcx/ompi/lib"
 
 ## Containerize the application
 
-To containerize the application using [Holoscan CLI](https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/examples/cli_packager), first build the application using `./holohub install object_detection_torch`, run the `package-app.sh` script and then follow the generated output to package and run the application.
+> [!IMPORTANT]
+> This helper requires the application packager from `holoscan-cli` 4.2.0 or
+> earlier. Current `./holohub package` builds Holoscan Module artifacts instead.
 
-Refer to the [Packaging Holoscan Applications](https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/examples/cli_packager) section of the [Holoscan User Guide](https://docs.nvidia.com/holoscan/sdk-user-guide/introduction/getting-started) to learn more about installing the Holoscan CLI or packaging your application using Holoscan CLI.
+To containerize the application using the legacy [Holoscan CLI](https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/examples/cli_packager), first build the application using `./holohub install object_detection_torch`, run the `package-app.sh` script and then follow the generated output to package and run the application.
+
+Refer to the [Packaging Holoscan Applications](https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/examples/cli_packager) section of the [Holoscan User Guide](https://docs.nvidia.com/holoscan/sdk-user-guide/introduction/getting-started) to learn more about installing the legacy Holoscan CLI or packaging your application using Holoscan CLI.
 
 ## Known Issues
 

--- a/applications/pipeline_visualization/README.md
+++ b/applications/pipeline_visualization/README.md
@@ -70,7 +70,8 @@ Options:
 Example with custom settings:
 
 ```bash
-./holohub run pipeline_visualization --nats_url nats://0.0.0.0:4222 --subject_prefix my_demo --publish_rate 5.0
+./holohub run pipeline_visualization \
+  --run-args="--nats_url nats://0.0.0.0:4222 --subject_prefix my_demo --publish_rate 5.0"
 ```
 
 ### Step 4: Visualize the Data

--- a/applications/pva_video_filter/README.md
+++ b/applications/pva_video_filter/README.md
@@ -34,7 +34,7 @@ Build the application inside docker
 ```bash
 $ ./holohub build-container pva_video_filter --base-img nvcr.io/nvidia/clara-holoscan/holoscan:v2.1.0-dgpu
 # Check which version of CUPVA is installed on your platform at /opt/nvidia
-$ ./holohub run-container pva_video_filter --no-docker-build --docker_opts "-v /opt/nvidia/cupva-<version>:/opt/nvidia/cupva-<version> --device /dev/nvhost-ctrl-pva0:/dev/nvhost-ctrl-pva0 --device /dev/nvmap:/dev/nvmap --device /dev/dri/renderD129:/dev/dri/renderD129"
+$ ./holohub run-container pva_video_filter --no-docker-build --docker-opts "-v /opt/nvidia/cupva-<version>:/opt/nvidia/cupva-<version> --device /dev/nvhost-ctrl-pva0:/dev/nvhost-ctrl-pva0 --device /dev/nvmap:/dev/nvmap --device /dev/dri/renderD129:/dev/dri/renderD129"
 ```
 
 Inside docker, add to your environment variable the following directories:
@@ -65,7 +65,7 @@ sudo pva_allow
 Run the same docker container you used to build your application
 
 ```bash
-$ ./holohub run-container pva_video_filter --no-docker-build --docker_opts "-v /opt/nvidia/cupva-<version>:/opt/nvidia/cupva-<version> --device /dev/nvhost-ctrl-pva0:/dev/nvhost-ctrl-pva0 --device /dev/nvmap:/dev/nvmap --device /dev/dri/renderD129:/dev/dri/renderD129"
+$ ./holohub run-container pva_video_filter --no-docker-build --docker-opts "-v /opt/nvidia/cupva-<version>:/opt/nvidia/cupva-<version> --device /dev/nvhost-ctrl-pva0:/dev/nvhost-ctrl-pva0 --device /dev/nvmap:/dev/nvmap --device /dev/dri/renderD129:/dev/dri/renderD129"
 
 # inside docker
 # don't forget the line below to export the environment variables

--- a/applications/stereo_vision/README.md
+++ b/applications/stereo_vision/README.md
@@ -48,11 +48,11 @@ you build the devcontainer with a compatible `base_img` as shown in the **Build 
 Run the following command to build and run application using the recorded video:
 
 ```sh
-./holohub run stereo_vision --base_img nvcr.io/nvidia/clara-holoscan/holoscan:v2.4.0-dgpu
+./holohub run stereo_vision --base-img nvcr.io/nvidia/clara-holoscan/holoscan:v2.4.0-dgpu
 ```
 
 To run the application using a v4l2 compatible stereo camera, run:
 
 ```sh
-./holohub run stereo_vision --base_img nvcr.io/nvidia/clara-holoscan/holoscan:v2.4.0-dgpu --run-args="--source v4l2"
+./holohub run stereo_vision --base-img nvcr.io/nvidia/clara-holoscan/holoscan:v2.4.0-dgpu --run-args="--source v4l2"
 ```

--- a/applications/template/{{cookiecutter.project_slug}}/README.md
+++ b/applications/template/{{cookiecutter.project_slug}}/README.md
@@ -55,10 +55,9 @@ For custom Docker builds:
 
 ```bash
 # Build with custom base image
-./holohub build-container {{ cookiecutter.project_slug }} --base-image nvcr.io/nvidia/clara-holoscan/holoscan:v{{ cookiecutter.holoscan_version }}-dgpu
+./holohub build-container {{ cookiecutter.project_slug }} --base-img nvcr.io/nvidia/clara-holoscan/holoscan:v{{ cookiecutter.holoscan_version }}-dgpu
 
-# Run with specific GPU type
-./holohub run-container {{ cookiecutter.project_slug }} --gpu-type dgpu
+# GPU type is detected automatically.
 ```
 
 ## Development

--- a/applications/tracks2endo4d/README.md
+++ b/applications/tracks2endo4d/README.md
@@ -85,7 +85,7 @@ The build produces the following TensorRT engine files:
 Once the Docker image is built and TensorRT engines have been generated, subsequent runs reuse them. To skip the TensorRT conversion on subsequent runs:
 
 ```sh
-./holohub run tracks2endo4d --configure-args "-DCONVERT_ENGINE=OFF"
+./holohub run tracks2endo4d --configure-args="-DCONVERT_ENGINE=OFF"
 ```
 
 ## Advanced Usage
@@ -109,7 +109,7 @@ Once your environment is set up, you can build the workflow using the following 
 To force TensorRT engine re-conversion (e.g., after switching GPUs):
 
 ```sh
-./holohub build tracks2endo4d --configure-args "-DCONVERT_ENGINE=ON"
+./holohub build tracks2endo4d --configure-args="-DCONVERT_ENGINE=ON"
 ```
 
 ### Running the Application
@@ -122,10 +122,10 @@ Run the application using the Holohub container (builds if needed):
 ./holohub run tracks2endo4d
 ```
 
-To skip the build step:
+To reuse both an existing container image and existing application artifacts:
 
 ```sh
-./holohub run tracks2endo4d --no-build
+./holohub run tracks2endo4d --no-docker-build --no-local-build
 ```
 
 #### From Inside the Container
@@ -154,7 +154,7 @@ This application supports the following CMake options that can be passed via `--
 Example usage:
 
 ```sh
-./holohub build tracks2endo4d --configure-args "-DCONVERT_ENGINE=OFF"
+./holohub build tracks2endo4d --configure-args="-DCONVERT_ENGINE=OFF"
 ```
 
 ### Command Line Arguments

--- a/applications/volume_rendering_xr/README.md
+++ b/applications/volume_rendering_xr/README.md
@@ -105,8 +105,8 @@ To build the release container:
 
 ```bash
 # Generate HoloHub `volume_rendering_xr` installation in the "holohub/install" folder
-./holohub build volume_rendering_xr --configure-args="-DCMAKE_INSTALL_PREFIX:PATH=/workspace/holohub/install"
-./holohub run-container volume_rendering_xr --docker-opts="--entrypoint=bash" -- -c cmake --build ./build --target install
+./holohub install volume_rendering_xr \
+  --configure-args="-DCMAKE_INSTALL_PREFIX:PATH=/workspace/holohub/install"
 
 # Copy files into a release container
 ./holohub build-container --img holohub:volume_rendering_xr_rel --docker-file ./applications/volume_rendering_xr/scripts/Dockerfile.rel --base-img nvcr.io/nvidia/cuda:12.4.1-runtime-ubuntu22.04
@@ -256,7 +256,7 @@ export ML_START_OPTIONS="debug"
 1. Follow [Advanced Setup Instructions](#advanced-setup) and add the `-u root` option to launch the container with root permissions.
 
 ```sh
-./holohub run --img holohub:volume_rendering_xr --docker-opts"-u root"
+./holohub run volume_rendering_xr --img holohub:volume_rendering_xr --as-root
 ```
 
 1. Clear the build cache and any home cache folders in the HoloHub workspace.

--- a/applications/volume_rendering_xr/README.md
+++ b/applications/volume_rendering_xr/README.md
@@ -253,7 +253,7 @@ code appears, try any of the following:
 export ML_START_OPTIONS="debug"
 ```
 
-1. Follow [Advanced Setup Instructions](#advanced-setup) and add the `-u root` option to launch the container with root permissions.
+1. Follow [Advanced Setup Instructions](#advanced-setup) and add the `--as-root` option to run the application phase as root.
 
 ```sh
 ./holohub run volume_rendering_xr --img holohub:volume_rendering_xr --as-root

--- a/benchmarks/holoscan_flow_benchmarking/README.md
+++ b/benchmarks/holoscan_flow_benchmarking/README.md
@@ -41,11 +41,11 @@ For detailed information, refer to:
 All dependencies are automatically managed by the Holohub Docker container. You can simply run:
 
 ```bash
-./holohub run-container --extra-script benchmarking [<application_name>]
+./holohub run-container <application_name> --extra-scripts benchmarking
 ```
 
 > [!NOTE]
-> This command sets up the benchmarking environment on top of the default Holohub container image, unless you specify an application with a custom Dockerfile. In that case, the benchmarking environment attempts to extend the application's Dockerfile. However, this process hasn't been fully tested for every possible custom Dockerfile, and success depends on how the Dockerfile is authored. Some Dockerfiles may already include the required benchmarking support and may work even without the `--extra-script benchmarking` option; in other cases, there may be conflicts or additional manual steps needed. Always refer to the relevant application's README for any application-specific benchmarking instructions or compatibility considerations.
+> This command sets up the benchmarking environment on top of the default Holohub container image, unless you specify an application with a custom Dockerfile. In that case, the benchmarking environment attempts to extend the application's Dockerfile. However, this process hasn't been fully tested for every possible custom Dockerfile, and success depends on how the Dockerfile is authored. Some Dockerfiles may already include the required benchmarking support and may work even without the `--extra-scripts benchmarking` option; in other cases, there may be conflicts or additional manual steps needed. Always refer to the relevant application's README for any application-specific benchmarking instructions or compatibility considerations.
 
 ### Bare-metal Installation
 

--- a/benchmarks/release_benchmarking/README.md
+++ b/benchmarks/release_benchmarking/README.md
@@ -96,7 +96,7 @@ Alternatively, collect results across platforms. On each machine:
 1. Add platform configuration information:
 
 ```bash
-./holohub run release_benchmarking --no-local-build --run-args "--print" > benchmarks/release_benchmarking/output/platform.txt
+./holohub run release_benchmarking --no-local-build --run-args="--print" > benchmarks/release_benchmarking/output/platform.txt
 ```
 
 1. Transfer output contents from each platform to a single machine:
@@ -120,7 +120,7 @@ tar xvf benchmarks-<platform-name>
 ./holohub run release_benchmarking --no-local-build --run-args "\
     --process benchmarks/release_benchmarking/2.4/x86_64 \
     --process benchmarks/release_benchmarking/2.4/IGX_iGPU \
-    --process benchmarks/release/benchmarking/2.4/IGX_dGPU"
+    --process benchmarks/release_benchmarking/2.4/IGX_dGPU"
 ```
 
 ## Presenting Data

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -223,9 +223,9 @@ For example:
   ./holohub build endoscopy_tool_tracking
 ```
 
-If a project has multiple language implementations, the CLI reports its
-selection and defaults to Python when available. Pass `--language cpp` or
-`--language python` to select an implementation explicitly.
+If a project has multiple language implementations, the CLI warns that the
+project has multiple languages and defaults to Python when available. Pass
+`--language cpp` or `--language python` to select an implementation explicitly.
 
 ### Building an application or operator manually
 

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -54,12 +54,8 @@ If you prefer you can also install the dependencies manually, typically includin
 - ffmpeg runtime
 - [ngc-cli](https://ngc.nvidia.com/setup/installers/cli)
 - wget
-- CUDA Toolkit: 12.6
-- libcudnn9-cuda-12
-- libcudnn9-dev-cuda-12
-- libnvinfer-dev
-- libnvinfer-plugin-dev
-- libnvonnxparsers-dev
+- The CUDA Toolkit, cuDNN, and TensorRT versions required by the installed
+  Holoscan SDK and selected platform
 
 Visit the [Holoscan SDK User Guide](https://docs.nvidia.com/holoscan/sdk-user-guide/setup/sdk-installation) for the latest
 details on dependency versions and custom installation.
@@ -118,21 +114,18 @@ Where:
 - `--docker-file`  is the path to the container's Dockerfile;
 - `--img` defines the fully qualified image name.
 
-### Build with Verbose Output
+### Inspect the Container Build
 
-To print the values for base image, Dockerfile, GPU type, and output image name, use ```--verbose```.
-
-For example, on an x86_64 system with dGPU, the default build command will print the following values when using the ```--verbose``` option.
+Use `--dryrun --verbose` to resolve the base image, Dockerfile, GPU type,
+build arguments, and output tags without building an image:
 
 ```bash
-user@ubuntu-20-04:/media/data/github/holohub$ ./holohub build-container --verbose
-Build (HOLOHUB_ROOT:/media/data/github/holohub)...
-Build (gpu_type_type:dgpu)...
-Build (base_img:nvcr.io/nvidia/clara-holoscan/holoscan:v0.6.0-dgpu)...
-Build (docker_file_path:/media/data/github/holohub/Dockerfile)...
-Build (img:holohub:ngc-v0.6.0-dgpu)...
-....
+./holohub build-container --dryrun --verbose
 ```
+
+The preview prints the exact `docker build` command. Values depend on the
+wrapper's configured SDK version, detected GPU type, selected CUDA major
+version, current branch, and commit.
 
 ## Advanced Launch Options (Container)
 
@@ -199,15 +192,26 @@ HoloHub automatically forwards X11 and Wayland displays when `DISPLAY` or
 
 ### Local SDK Path
 
-If you have an installation of the Holoscan SDK which is not in a standard path, you may want to provide the root directory of your Holoscan SDK installation.
+To build against a Holoscan SDK source/build tree on the host, use
+`--local-sdk-root`:
 
 ```bash
-  ./holohub build --configure-args="-Dholoscan_DIR=/path/to/holoscan/install/lib/cmake/holoscan"
+./holohub build <project> \
+  --local-sdk-root /path/to/holoscan-sdk
+```
+
+If a nonstandard SDK install is already visible inside the selected container
+or native environment, pass its CMake package directory explicitly:
+
+```bash
+./holohub build <project> \
+  --configure-args="-Dholoscan_DIR=/path/to/holoscan/install/lib/cmake/holoscan"
 ```
 
 ### Building a Specific Application
 
-By default HoloHub builds all the sample applications that are maintained with the SDK. You can build specific applications by the name of the directory.
+`./holohub build` requires a discovered project name and builds that project
+plus its declared dependencies. Use `./holohub list` to see valid names.
 
 ```bash
   ./holohub build <application>
@@ -219,27 +223,39 @@ For example:
   ./holohub build endoscopy_tool_tracking
 ```
 
-Note that CMake will build the application in the directory specified. If there are multiple languages, the script will attempt to build all of them.
+If a project has multiple language implementations, the CLI reports its
+selection and defaults to Python when available. Pass `--language cpp` or
+`--language python` to select an implementation explicitly.
 
-### Building application or operator manually
+### Building an application or operator manually
 
-If you prefer to build applications and operator manually you can follow the steps below.
+Prefer entering the project's development container before invoking CMake
+directly. This keeps host dependencies and generated files aligned with the
+standard CLI build environment:
 
 ```bash
-# Export cuda (in case it's not already in the path)
-export PATH=$PATH:/usr/local/cuda/bin
+./holohub run-container <project>
+```
 
-# Configure HoloHub with CMake
-cmake -S <path_to_holohub_source>            # Source directory
-      -B build                               # Build directory
-      -DPython3_EXECUTABLE=/usr/bin/python3  # Specifies the python executable for CMake to find the correct version
-      -DHOLOHUB_DATA_DIR=$(pwd)/data         # Specifies the data directory
-      -DAPP_<name_of_the_application>=1      # Specified the application to build
+Inside the container, configure and build with commands such as:
 
+```bash
+# Export CUDA if it is not already in PATH.
+export PATH="$PATH:/usr/local/cuda/bin"
+
+# Configure HoloHub with CMake (example application)
+cmake -S /workspace/holohub \
+  -B build \
+  -DPython3_EXECUTABLE=/usr/bin/python3 \
+  -DHOLOHUB_DATA_DIR="$(pwd)/data" \
+  -DAPP_endoscopy_tool_tracking=ON
 
 # Build the application(s)
 cmake --build build
 ```
+
+Direct host CMake builds are the native-build path and require the host setup
+described above.
 
 ## Additional Build Notes
 
@@ -247,8 +263,10 @@ While not all applications requires building HoloHub, the current build system a
 
 You can refer to the README of each application/operator if you prefer to build/run them manually.
 
-The `./holohub` script creates a `data` subdirectory to store the downloaded HoloHub data.
-This directory is noted `HOLOHUB_DATA_DIR/holohub_data_dir` in the documentation, READMEs and metadata files.
+The CLI creates a `data` subdirectory for downloaded HoloHub data. CMake uses
+`HOLOHUB_DATA_DIR`; application metadata refers to the same location through
+the `<holohub_data_dir>` placeholder. At runtime, the CLI also exports
+`HOLOSCAN_CLI_DATA_PATH` and `HOLOSCAN_INPUT_PATH`.
 
 ## Advanced Options for Running Applications
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -13,12 +13,13 @@ A **Holoscan Module** is a library project that extends the Holoscan SDK API.
 Run the following command to initialize a new module adhering to HoloHub conventions
 from the provided cookiecutter template. The template will prompt for several project
 details (name, project languages, description) before creating the new project directory
-on your local system.
+on your local system. Pass the unprefixed module name; the template creates a
+`holoscan-<name>` repository directory.
 
 ```bash
 pip install cookiecutter
 
-./holohub create <my_module> --template modules/template
+./holohub create my-module --template modules/template
 ```
 
 The generated project is a self-contained git repository with its own operators/,

--- a/modules/template/{{cookiecutter.module_repo_name}}/pkg/{{cookiecutter.module_repo_name}}/README.md
+++ b/modules/template/{{cookiecutter.module_repo_name}}/pkg/{{cookiecutter.module_repo_name}}/README.md
@@ -15,8 +15,10 @@ This directory defines the Debian package for `{{ cookiecutter.module_repo_name 
 - **`package` key** — marks this directory as a HoloHub *package* project. The CLI
   discovers it via the recursive `HOLOSCAN_CLI_SEARCH_PATH` scan from the module root,
   which makes it appear under the `PACKAGES` section of `./holohub list`.
-- **`package.dockerfile`** — path (relative to the module root) to the container
-  image used by `./holohub run --build` for container-based package builds.
+- **`package.dockerfile`** — declares a Dockerfile path (relative to the module
+  root) for this package-project record. When packaging this generated module
+  by name, `./holohub package` instead selects the root `module` record and its
+  `module.dockerfile`.
 
 Looking for Python packaging? Review the project [pyproject.toml](../../pyproject.toml)
 for configuration.

--- a/operators/dds/README.md
+++ b/operators/dds/README.md
@@ -36,5 +36,6 @@ variables are set (which can be done using the RTI `setenv` script) and use the
 following:
 
 ```sh
-./holohub run --docker-opts "-v $NDDSHOME:/opt/dds -e NDDSHOME=/opt/dds -e CONNEXTDDS_ARCH=$CONNEXTDDS_ARCH"
+./holohub run-container dds_video \
+  --docker-opts "-v $NDDSHOME:/opt/dds -e NDDSHOME=/opt/dds -e CONNEXTDDS_ARCH=$CONNEXTDDS_ARCH"
 ```

--- a/operators/st2110_source/BUILD.md
+++ b/operators/st2110_source/BUILD.md
@@ -25,7 +25,7 @@ This document provides instructions for building the ST2110 Source operator on N
 ./holohub build st2110_source
 
 # Build with Python bindings
-./holohub build st2110_source --configure-args "-DHOLOHUB_BUILD_PYTHON=ON"
+./holohub build st2110_source --configure-args="-DHOLOHUB_BUILD_PYTHON=ON"
 ```
 
 ## Detailed Build Instructions
@@ -54,7 +54,7 @@ cd /path/to/holohub
 ./holohub build st2110_source
 
 # Build with Python bindings
-./holohub build st2110_source --configure-args "-DHOLOHUB_BUILD_PYTHON=ON"
+./holohub build st2110_source --configure-args="-DHOLOHUB_BUILD_PYTHON=ON"
 ```
 
 #### Option B: Direct CMake build (For development)

--- a/operators/st2110_source/README.md
+++ b/operators/st2110_source/README.md
@@ -172,7 +172,7 @@ To build the operator:
 To build with Python bindings:
 
 ```bash
-./holohub build st2110_source --configure-args "-DHOLOHUB_BUILD_PYTHON=ON"
+./holohub build st2110_source --configure-args="-DHOLOHUB_BUILD_PYTHON=ON"
 ```
 
 ## Network Configuration

--- a/tutorials/cuda_mps/README.md
+++ b/tutorials/cuda_mps/README.md
@@ -232,14 +232,15 @@ echo $LD_LIBRARY_PATH
 /usr/local/cuda-12.6/compat/lib:/usr/local/cuda-12.6/compat:/usr/local/cuda-12.6/lib64:
 ```
 
-**2. Be sure to pass `-v /tmp/nvidia-mps:/tmp/nvidia-mps  -v /tmp/nvidia-log:/tmp/nvidia-log -v
-/usr/local/cuda-12.6:/usr/local/cuda-12.6` to `./holohub run` command to ensure that the container is
-connected to the MPS control and server**
+**2. Use `--mps` so the container shares the host MPS control and log
+directories. If the required CUDA installation is not already present in the
+image, mount it explicitly with `--docker-opts`.**
 
 Example:
 
 ```bash
-./holohub run --img holohub:v2.1 --docker-opts="-v /tmp/nvidia-mps:/tmp/nvidia-mps  -v /tmp/nvidia-log:/tmp/nvidia-log -v /usr/local/cuda-12.6:/usr/local/cuda-12.6"
+./holohub run-container model_benchmarking --as-root --mps \
+  --docker-opts "-v /usr/local/cuda-12.6:/usr/local/cuda-12.6"
 ```
 
 **3. Inside the container, be sure to set the following environment variables:**

--- a/tutorials/high_performance_networking/README.md
+++ b/tutorials/high_performance_networking/README.md
@@ -2303,11 +2303,14 @@ bench_tx: # (31)!
     5. Run your application like so:
 
         ```bash
-        ./holohub run --img holohub:my_app --docker-opts "-u 0 --privileged" --bash -c "./build/my_app/applications/my_app my_app_config.yaml"
+        ./holohub run-container my_app --img holohub:my_app \
+          --docker-opts "-u 0 --privileged" -- \
+          "./build/my_app/applications/my_app my_app_config.yaml"
         ```
 
         or, if you have set up a shortcut to run your application with its config file through its `metadata.json` (see other apps for examples):
 
         ```bash
-        ./holohub run --no-local-build --container_args " -u 0 --privileged"
+        ./holohub run my_app --no-local-build --img holohub:my_app \
+          --docker-opts "-u 0 --privileged"
         ```

--- a/tutorials/holoscan-modules/create-a-module/README.md
+++ b/tutorials/holoscan-modules/create-a-module/README.md
@@ -126,10 +126,11 @@ local Python environment:
 
 ### 3.2 Scaffold with `./holohub create`
 
-From your HoloHub clone:
+From your HoloHub clone, pass the unprefixed module name; the template creates
+the `holoscan-<name>` repository directory:
 
 ```bash
-./holohub create holoscan-my-sensor \
+./holohub create my-sensor \
     --template modules/template \
     --directory ~/repos
 ```
@@ -158,7 +159,7 @@ The CLI will further derive some names using these rules:
 *Advanced Users and AI Agents:* For non-interactive use, pass values directly:
 
 ```bash
-./holohub create holoscan-my-sensor \
+./holohub create my-sensor \
     --template modules/template \
     --directory $HOME \
     --interactive false \
@@ -190,7 +191,7 @@ Git repository initialised. Push to a remote when ready:
   git push -u origin main
 
 Register your module at https://nvidia-holoscan.github.io/ when ready.
-Successfully created new project: holoscan-my-sensor
+Successfully created new project: my-sensor
 Directory: /home/myuser/holoscan-my-sensor
 
 Possible next steps:
@@ -562,7 +563,7 @@ Fast lookup for repeat use:
 
 | Step | Command | Key file or output |
 | --- | --- | --- |
-| Scaffold | `./holohub create <repo> --template modules/template --directory <dir>` | `<dir>/<repo>/` |
+| Scaffold | `./holohub create <name> --template modules/template --directory <dir>` | `<dir>/holoscan-<name>/` |
 | Build | `./holohub build <app> --local` | `build/` |
 | Test | `./holohub test` | `ctest` + `pytest` output |
 | Dev import | `./holohub install --dev` | `.pth` shim in site-packages |

--- a/tutorials/holoscan-modules/use-a-module/README.md
+++ b/tutorials/holoscan-modules/use-a-module/README.md
@@ -120,12 +120,10 @@ dependency.
 ### 4.1 (Optional) Scaffold a HoloHub subproject
 
 If you don't already have a subproject, you can use the HoloHub CLI to create one.
-Pick the template that matches the type of project you want to build, then fill in
-the interactive prompts with your project details.
+The application template produces metadata ready for a module dependency.
 
 ```bash
 ./holohub create my_app --template applications/template
-./holohub create my_op  --template operators/template
 ```
 
 The scaffolded subproject ships a `metadata.json` ready for you to add a

--- a/utilities/cli/README.md
+++ b/utilities/cli/README.md
@@ -9,25 +9,29 @@ The Python implementation that used to live under this directory
 one of its downstream consumers alongside Isaac OS and the I4H Workflows
 repos.
 
-For the canonical command, option, and environment-variable reference, run
-`holoscan --help` (or `holoscan env-info` for the full env-var surface), or
-visit the [holoscan-cli](https://github.com/nvidia-holoscan/holoscan-cli)
-repository — that is now the single source of truth and stays current as
-the CLI evolves. The historical `cli_reference.md` in this directory
-documents the old in-tree CLI and is no longer authoritative.
+For the canonical HoloHub command and option reference, run
+`./holohub --help` or `./holohub <command> --help`. Run
+`./holohub env-info` for the effective package, interpreter, paths, and
+environment variables. The standalone
+[holoscan-cli](https://github.com/nvidia-holoscan/holoscan-cli) repository is
+the source of truth for parser and runtime implementation. The local CLI
+reference is a curated HoloHub wrapper guide. Treat current help as
+authoritative for accepted command-line syntax and the selected holoscan-cli
+source as authoritative for runtime behavior.
 
 This directory keeps the user-facing CLI documentation:
 
 | Document                                | Description                                                                                                                  |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| [CLI Reference](cli_reference.md)       | HoloHub-oriented command examples, modes, and environment variables.                                                         |
 | [CLI Developer Guide](cli_dev_guide.md) | Workflow tips, implementation invariants, and extension guide. For the canonical source layout, see the holoscan-cli repo.   |
 
 ## Quick Start
 
 ```bash
 ./holohub <command> [options] [arguments]
-./holohub -h | --help                    # List all commands
-./holohub <command> -h | --help          # Options for a specific command
+./holohub --help                         # List all commands
+./holohub <command> --help               # Options for a specific command
 ./holohub list                           # List available projects
 ```
 
@@ -119,9 +123,10 @@ through Docker build args or environment variables.
 
 ```bash
 HOLOSCAN_CLI_SOURCE=/path/to/holoscan-cli \
-  pytest -q utilities/cli/tests/test_holoscan_cli_consolidation.py
+  python -m pytest -q -o addopts='' --noconftest \
+  utilities/cli/tests/test_holoscan_cli_consolidation.py
 ```
 
-That single test exercises the wrapper -> install -> delegate path and
-asserts that `holoscan list` / `modes` / `run --dryrun` work against this
-repo.
+That test exercises both the direct Python package entry point and the
+wrapper -> install -> delegate path against this repository, including
+project discovery and a wrapper-driven `run --dryrun`.

--- a/utilities/cli/cli_dev_guide.md
+++ b/utilities/cli/cli_dev_guide.md
@@ -13,7 +13,13 @@ For command/flag docs, see the [CLI Reference](cli_reference.md).
 
 ## Agent Safety Rules
 
-1. Always `./holohub <cmd> --dryrun --verbose` before running any command for real.
+1. Preview mutating commands with the flags they support:
+   - `build`, `run`, `build-container`, `run-container`, `install`, `test`,
+     and `package`: use `--dryrun --verbose`.
+   - `create`, `lint`, `setup`, and `clear-cache`: use `--dryrun`; they do not
+     accept `--verbose`.
+   - `list`, `modes`, `env-info`, `env-check`, `status`, and `version` are
+     read-only diagnostics and accept neither preview flag.
 2. Never `./holohub build --local` or `./holohub run --local` without explicit user approval — they run directly in the host workspace, may modify files there, and require host dependencies to already be installed (no automatic package installation).
 3. Never hardcode repo names, command names, or path prefixes — the CLI is reused across repos via env vars.
 4. Check the project's README and `metadata.json` for architecture/platform (e.g. x86_64, aarch64, IGX, Thor, DGX Spark) requirements before building.  The project may not support all platforms, do not suggest building on platforms that are not supported unless the user explicitly asks for it.
@@ -21,15 +27,23 @@ For command/flag docs, see the [CLI Reference](cli_reference.md).
 
 ## Mental Model
 
-The CLI is a **container-first** build system. Every `build`, `run`, `install`, and `test` command builds a Docker image and then re-invokes itself with `--local` inside that container. The only host-side commands are `docker build` and `docker run`; cmake, python, and application processes execute inside the container where dependencies are guaranteed to exist.
+The CLI is a **container-first** build system. In normal container mode,
+`build`, `run`, `install`, and `package` resolve the project on the host, build
+or reuse its Docker image, and then re-invoke the CLI with `--local` inside
+that container. `test` uses the same image setup but launches CTest directly.
+The host handles wrapper bootstrap, metadata resolution, and Docker
+orchestration; cmake, python, packaging, testing, and application processes
+execute inside the container. `--local`, the `--no-*-build` flags, and
+`HOLOSCAN_CLI_ALWAYS_BUILD=false` intentionally alter that flow.
 
 When a user asks how to customize a build or run — change the build directory, add cmake flags, use a different build type — the answer is `./holohub run-container <app>` first, then run commands inside (see [Why this matters](#why-this-matters) for examples).
 
 ## Implementation Invariants
 
-1. Container re-enters local: `build`/`run`/`install` in container mode build an
-   image, then run the CLI with `--local` inside it. Local-mode changes affect
-   both host and container execution.
+1. Container re-entry: `build`/`run`/`install`/`package` in container mode
+   build or reuse an image, then run the CLI with `--local` inside it. `test`
+   launches its CTest command directly in the selected image. Local-mode
+   changes affect both host and re-entered container execution.
 2. CLI flags override modes: resolution is `resolve_mode` -> `validate_mode` ->
    `get_effective_build_config`/`get_effective_run_config`. Most flags override
    mode values; `--run-args` is appended to the argument list passed to
@@ -46,23 +60,29 @@ When a user asks how to customize a build or run — change the build directory,
 
 ## Execution Model
 
-`build`, `run`, `install`, and `test` follow a two-phase container pattern by default (without `--local`):
+`build`, `run`, `install`, `test`, and `package` follow a two-phase container
+pattern by default (without `--local`):
 
 ### Phase 1 — Container setup (runs on host)
 
-1. Build a Docker image with project dependencies (`docker build`). Skip with `--no-docker-build`.
+1. Build a Docker image with project dependencies (`docker build`), unless
+   `--no-docker-build` or `HOLOSCAN_CLI_ALWAYS_BUILD=false` skips that step.
 2. Launch a container (`docker run`) with the repo bind-mounted at `/workspace/<name>` (`HOLOSCAN_CLI_WORKSPACE_NAME`, default `holohub`) and `HOLOSCAN_CLI_BUILD_LOCAL=1` set in the environment.
 
 ### Phase 2 — Build / run (runs inside the container)
 
-The container re-invokes the CLI with `--local` appended. For example, `./holohub build myapp` on the host becomes `./holohub build myapp --local` inside the container. The local handler runs the underlying tools:
+For `build`, `run`, `install`, and `package`, the container re-invokes the CLI
+with `--local` appended. For example, `./holohub build myapp` on the host
+becomes `./holohub build myapp --local` inside the container. `test` launches
+its CTest command directly in the container.
 
 | Command   | What runs inside the container                                                 |
 | --------- | ------------------------------------------------------------------------------ |
 | `build`   | `cmake -B build/<app> -S . -DAPP_<app>=ON [opts] && cmake --build build/<app>` |
 | `run`     | Same cmake build, then the mode's `run.command` with placeholders expanded     |
 | `install` | Same cmake build, then `cmake --install build/<app>`                           |
-| `test`    | CTest via a CTest script                                                       |
+| `package` | Module configure/build plus requested CPack and/or wheel generation            |
+| `test`    | CTest via the configured CTest script                                          |
 
 The cmake flag `-DAPP_<app>=ON` selects a single project (operators use `-DOP_<name>=ON`, extensions use `-DEXT_<name>=ON`). The build directory `build/<app>/` isolates per-project artifacts; this path is `HOLOSCAN_CLI_BUILD_PARENT_DIR/<app>` (default parent varies by repo; `<repo_root>/build` in HoloHub). Because the repo is bind-mounted, artifacts persist on the host after the container exits.
 
@@ -70,7 +90,12 @@ The cmake flag `-DAPP_<app>=ON` selects a single project (operators use `-DOP_<n
 
 ### Why this matters
 
-By default (without `--local` or relevant environment variables) every cmake, python, and application command executes **inside the container**, not on the host. To run those commands manually — customize the build directory, add cmake flags, or debug a failure — enter the container first, then run whatever you need:
+By default (without `--local`) cmake, python, packaging, and application
+commands execute **inside the container**, not on the host. Build-skip controls
+can reuse existing image or project artifacts, but do not move those commands
+to the host. To run commands manually — customize the build directory, add
+cmake flags, or debug a failure — enter the container first, then run whatever
+you need:
 
 ```bash
 # 1. Enter the container (builds the image if needed, then opens an interactive shell):
@@ -98,7 +123,9 @@ Use `--dryrun --local` on the host to see the exact cmake commands the CLI would
 
 ### Inspect before running
 
-`--dryrun` prints every command (prefixed `[dryrun]`) without executing anything. It works with every CLI command.
+For commands that support it, `--dryrun` prints external commands (prefixed
+`[dryrun]`) without executing them. Read-only diagnostics do not need a
+preview mode.
 
 Add `--local` to bypass the Docker layer and see the underlying cmake / app commands directly. Without `--local`, you see the `docker build` + `docker run` wrapper instead.
 
@@ -108,7 +135,9 @@ Add `--local` to bypass the Docker layer and see the underlying cmake / app comm
 ./holohub build <app> [mode] --dryrun              # docker build + docker run wrapping the local build
 ```
 
-`--verbose` adds env variable dumps, path mappings, and Docker launch details. In local mode, `--dryrun` already implies the same env output as `--verbose`.
+For container/build commands that support it, `--verbose` adds environment
+variables, path mappings, and Docker launch details. In local mode,
+`--dryrun` already implies the same environment output as `--verbose`.
 
 ### Test
 
@@ -152,9 +181,9 @@ Check for existing images first: `docker images | grep <project>`.
 
 | Flag / Env                                                     | Effect                                                                                                            |
 | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `--no-docker-build`                                            | Reuse existing image — default during dev. Rebuild only when Dockerfile, base image, or `--extra-scripts` change. |
+| `--no-docker-build`                                            | Reuse an existing image during iteration. Rebuild when the Dockerfile, base image, or `--extra-scripts` change.   |
 | `--no-local-build`                                             | Skip cmake — for re-runs with different args or Python-only changes.                                              |
-| `HOLOSCAN_CLI_ALWAYS_BUILD=false`                              | Disable both build phases globally.                                                                               |
+| `HOLOSCAN_CLI_ALWAYS_BUILD=false`                              | With `run`, reuse both image and project artifacts; other container commands skip only the image build.           |
 | `HOLOSCAN_CLI_ENABLE_SCCACHE=true` + `--extra-scripts sccache` | Compiler cache at `~/.cache/sccache`.                                                                             |
 
 ### Debug inside the container
@@ -198,14 +227,17 @@ Everything after `--` is joined into a single string and executed via `bash -c`,
 ### Project configuration
 
 - Each project's `metadata.json` drives automatic discovery, language selection, dependency tracking, Dockerfile resolution, run command templates, and mode definitions.
-- `metadata.json` modes must be self-contained (Docker opts, run opts, env vars).
+- Application `metadata.json` files may define either a top-level `run` or
+  `modes`, but not both. Every mode requires `description` and `run`; two or
+  more modes also require `default_mode`.
 - `CMakeLists.txt` must guard inclusion behind `APP_<name>=ON` (or `OP_`/`EXT_`/`PKG_`).
 - Dockerfiles resolve by walking up parent dirs — siblings share a common-ancestor Dockerfile.
 
 **Metadata references** (for downstream repos without local access to HoloHub examples):
 
 - [Base project schema](../metadata/project.schema.json) — all valid fields, types, and constraints
-- [CLI Reference > Modes](cli_reference.md#modes) — mode fields, path placeholders, build/run config
+- [CLI Reference > Modes](cli_reference.md#application-modes) — mode fields,
+  path placeholders, and build/run configuration
 - Examples: [simple app](https://raw.githubusercontent.com/nvidia-holoscan/holohub/main/applications/endoscopy_tool_tracking/python/metadata.json), [multi-mode with docker opts](https://raw.githubusercontent.com/nvidia-holoscan/holohub/main/applications/isaac_sim_holoscan_bridge/metadata.json), [multi-mode with build deps](https://raw.githubusercontent.com/nvidia-holoscan/holohub/main/applications/ai_surgical_video/python/metadata.json)
 
 ## Extending the CLI

--- a/utilities/cli/cli_reference.md
+++ b/utilities/cli/cli_reference.md
@@ -2,8 +2,9 @@
 
 > ⚠️ **Wrapper reference.** This file documents HoloHub's `./holohub`
 > wrapper usage around the standalone `holoscan-cli` package. For the
-> authoritative parser and runtime environment-variable list, run
-> `./holohub --help` / `./holohub env-info`, or see the
+> accepted command syntax, run `./holohub --help` or
+> `./holohub <command> --help`; use `./holohub env-info` to inspect the
+> effective runtime environment. The implementation lives in the
 > [holoscan-cli](https://github.com/nvidia-holoscan/holoscan-cli)
 > repository.
 
@@ -22,8 +23,8 @@ Run the CLI from the repository root:
 **Getting help:**
 
 ```bash
-./holohub -h | --help                    # List all commands
-./holohub <command> -h | --help          # Options for a specific command
+./holohub --help                         # List all commands
+./holohub <command> --help               # Options for a specific command
 ./holohub run myapp --verbose --dryrun   # Debug: print without executing
 ./holohub list                           # List available projects
 ```
@@ -41,7 +42,7 @@ Run the CLI from the repository root:
 
 | Command                                     | Description                                                                |
 | ------------------------------------------- | -------------------------------------------------------------------------- |
-| [create](#create)                           | Create a new Holoscan application from a template                          |
+| [create](#create)                           | Create an application or external module from a template                   |
 | [build-container](#build-container)         | Build the development container image                                      |
 | [run-container](#run-container)             | Build and launch the development container                                 |
 | [build](#build)                             | Build a project (container or local)                                       |
@@ -54,8 +55,10 @@ Run the CLI from the repository root:
 | [env-info](#env-info)                       | Display environment debugging information                                  |
 | [env-check](#env-check)                     | Run system health checks (GPU, CUDA, Docker, SDK, disk, display, devices)  |
 | [install](#install)                         | Install a built project                                                    |
+| [package](#package)                         | Build Holoscan Module distribution artifacts                               |
 | [test](#test)                               | Run tests for a project                                                    |
 | [clear-cache](#clear-cache)                 | Clear cache folders (build, data, install)                                 |
+| [version](#version)                         | Display the installed holoscan-cli package version                         |
 | [autocompletion_list](#autocompletion-list) | List targets for autocompletion (used internally)                          |
 
 ---
@@ -64,9 +67,20 @@ Run the CLI from the repository root:
 
 Many commands inherit **container build** and/or **container run** options. They are listed here once; see each command section for applicability.
 
+### Preview Support
+
+Preview mutating commands with the flags they actually support:
+
+| Commands | Preview flags |
+| --- | --- |
+| `build`, `run`, `build-container`, `run-container`, `install`, `test`, `package` | `--dryrun --verbose` |
+| `create`, `lint`, `setup`, `clear-cache` | `--dryrun` |
+| `list`, `modes`, `env-info`, `env-check`, `status`, `version` | Read-only; no preview flags |
+
 ### Container Build Options
 
-Used by: `build-container`, `run-container`, `build`, `run`, `install`, `test`.
+Used by: `build-container`, `run-container`, `build`, `run`, `install`,
+`test`, and `package`.
 
 | Option                   | Description                                                                                                                                           |
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -74,13 +88,13 @@ Used by: `build-container`, `run-container`, `build`, `run`, `install`, `test`.
 | `--docker-file`          | Path to Dockerfile to use                                                                                                                             |
 | `--img`                  | Fully qualified output container image name                                                                                                           |
 | `--no-cache`             | Do not use cache when building the image                                                                                                              |
-| `--cuda <version>`       | CUDA major version (for example `12`, `13`). Default: `12`                                                                                            |
-| `--build-args`           | Extra arguments to `docker build` (for example `--build-args '--network=host'`)                                                                       |
+| `--cuda <version>`       | Override the CUDA major version (for example `12`, `13`). If omitted, select it from the driver, falling back to `13` when detection is unavailable.  |
+| `--build-args`           | Extra arguments to `docker build` (for example `--build-args='--network=host'`)                                                                       |
 | `--extra-scripts <name>` | Run named setup scripts as Docker layers (search in `HOLOSCAN_CLI_SETUP_SCRIPTS_DIR`). Can be repeated. Use `./holohub setup --list-scripts` to list. |
 
 ### Container Run Options
 
-Used by: `run-container`, `build`, `run`, `install`.
+Used by: `run-container`, `build`, `run`, `install`, and `package`.
 
 | Option                    | Description                                                                   |
 | ------------------------- | ----------------------------------------------------------------------------- |
@@ -91,10 +105,14 @@ Used by: `run-container`, `build`, `run`, `install`.
 | `--init`                  | Use tini entry point                                                          |
 | `--persistent`            | Do not delete container after it exits                                        |
 | `--add-volume <path>`     | Mount path at `/workspace/volumes`. Can be repeated                           |
-| `--as-root`               | With `run`, build as the user and run the application phase as root           |
+| `--as-root`               | `run`: app as root; other listed commands: container as root                  |
 | `--nsys-location <path>`  | Nsight Systems installation path on host                                      |
 | `--mps`                   | Mount CUDA MPS host directories into container (if MPS enabled on host)       |
 | `--enable-x11`            | Deprecated; X11/Wayland forwarding is auto-detected                           |
+
+With `run`, the build phase remains under the invoking user and only the
+application runs as root. With `run-container`, `build`, `install`, and
+`package`, `--as-root` launches the development container as root.
 
 ---
 
@@ -102,7 +120,8 @@ Used by: `run-container`, `build`, `run`, `install`.
 
 ### Create
 
-Create a new Holoscan-based application from a template (for example, cookiecutter).
+Create a HoloHub application or external Holoscan Module from a cookiecutter
+template.
 
 **Usage:**
 
@@ -121,8 +140,8 @@ Create a new Holoscan-based application from a template (for example, cookiecutt
 | Option                | Default                                  | Description                                 |
 | --------------------- | ---------------------------------------- | ------------------------------------------- |
 | `--template <path>`   | `applications/template`                  | Path to template directory                  |
-| `--language`          | `python` (if both implementations exist) | `cpp` or `python`                           |
-| `--directory <path>`  | `applications`                           | Directory to create the project in          |
+| `--language`          | `cpp`                                    | `cpp` or `python`                           |
+| `--directory <path>`  | `applications`                           | Module templates prompt when omitted        |
 | `--context key=value` | —                                        | Cookiecutter context; can be repeated       |
 | `-i`, `--interactive` | true                                     | Interactive mode; use `-i False` to disable |
 | `--dryrun`            | —                                        | Print commands without executing            |
@@ -254,7 +273,7 @@ Build a project. By default builds inside the container; use `--local` to build 
 | `--parallel <n>`         | Number of parallel build jobs                                                       |
 | `--pkg-generator`        | `DEB` (default) or other cpack generator                                            |
 | `--language`             | `cpp` or `python`                                                                   |
-| `--benchmark`            | Build for Holoscan Flow Benchmarking (applications only)                            |
+| `--benchmark`            | Build for Holoscan Flow Benchmarking (applications and benchmarks)                  |
 | `--no-docker-build`      | Skip building the container                                                         |
 | `--verbose`              | Extra output                                                                        |
 | `--dryrun`               | Print commands without executing                                                    |
@@ -538,14 +557,14 @@ Build and install a project (container or local). Installs built artifacts (for 
 **Usage:**
 
 ```bash
-./holohub install <project> [mode] [options]
+./holohub install [project] [mode] [options]
 ```
 
 **Arguments:**
 
 | Argument  | Description                          |
 | --------- | ------------------------------------ |
-| `project` | Project to install                   |
+| `project` | Project; optional with `--dev`       |
 | `mode`    | (Optional) Mode from `metadata.json` |
 
 **Options:** All [container build](#container-build-options) and [container run](#container-run-options) options, plus:
@@ -553,6 +572,9 @@ Build and install a project (container or local). Installs built artifacts (for 
 | Option                   | Description                             |
 | ------------------------ | --------------------------------------- |
 | `--local`                | Install locally instead of in container |
+| `--dev`                  | Install staged module development hooks |
+| `--uninstall`            | Remove installed development hooks      |
+| `--build-dir <path>`     | Select staged-hook build directory      |
 | `--build-type`           | `debug`, `release`, or `rel-debug`      |
 | `--build-with <list>`    | Semicolon-separated operators           |
 | `--configure-args <arg>` | Extra CMake options; can be repeated    |
@@ -567,6 +589,43 @@ Build and install a project (container or local). Installs built artifacts (for 
 ```bash
 ./holohub install myapp
 ./holohub install myapp --local --build-type release
+./holohub install --dev --build-dir build/my_module
+```
+
+---
+
+### Package
+
+Build Holoscan Module distribution artifacts. This command packages modules
+as DEB and/or Python wheel artifacts; it is not the legacy HAP/MAP application
+packager retired in holoscan-cli 4.3.0.
+
+**Usage:**
+
+```bash
+./holohub package [project] [options]
+```
+
+When `project` is omitted, the command reads module metadata from
+`./metadata.json` in the current directory.
+
+**Options:** All [container build](#container-build-options) and
+[container run](#container-run-options) options, plus:
+
+| Option | Description |
+| --- | --- |
+| `--local` | Package locally instead of in a container |
+| `--build-type` | `debug`, `release`, or `rel-debug` |
+| `--pkg-generator <list>` | Comma-separated generators such as `DEB,WHEEL` |
+| `--language` | `cpp` or `python` |
+| `--no-docker-build` | Reuse an existing container image |
+| `--verbose` | Print additional build details |
+| `--dryrun` | Print commands without executing them |
+
+**Example:**
+
+```bash
+./holohub package holoscan-my-sensor --pkg-generator DEB,WHEEL
 ```
 
 ---
@@ -594,7 +653,7 @@ Run tests for a project (for example CTest in container or locally).
 | `--local`                                       | Test locally instead of in container                            |
 | `--coverage`                                    | Enable code coverage (adds coverage flags, runs ctest_coverage) |
 | `--language`                                    | `cpp` or `python`                                               |
-| `--clear-cache`                                 | Clear cache before running                                      |
+| `--clear-cache`                                 | Clear build and install caches before running                   |
 | `--ctest-script <path>`                         | CTest script to use                                             |
 | `--cmake-options <opt>`                         | CMake options; can be repeated                                  |
 | `--ctest-options <opt>`                         | CTest options; can be repeated                                  |
@@ -635,6 +694,8 @@ Clear cache directories (build, data, install).
 | `--dryrun`  | Print commands without executing |
 
 If none of `--build`, `--data`, `--install` are given, all are cleared. Use `--dryrun` to preview what would be deleted.
+The command refuses to remove `/`, the user's home directory, the repository
+root, their ancestors, or candidates outside the configured cache roots.
 
 **Examples:**
 
@@ -642,6 +703,18 @@ If none of `--build`, `--data`, `--install` are given, all are cleared. Use `--d
 ./holohub clear-cache
 ./holohub clear-cache --build
 ```
+
+---
+
+### Version
+
+Display the installed `holoscan-cli` package version selected by the wrapper.
+
+```bash
+./holohub version
+```
+
+This command is read-only and has no command-specific options.
 
 ---
 
@@ -699,7 +772,7 @@ Each mode is defined under the `modes` key in `metadata.json`:
 
 ```json
 {
-  "metadata": {
+  "application": {
     "default_mode": "mode_name",
     "modes": {
       "mode_name": { }
@@ -742,7 +815,7 @@ Each mode is defined under the `modes` key in `metadata.json`:
 
 ```json
 {
-  "metadata": {
+  "application": {
     "default_mode": "standard",
     "modes": {
       "standard": {
@@ -814,7 +887,7 @@ for selection order, safety boundaries, and managed-venv maintenance.
 | `VIRTUAL_ENV` | Uses the active environment's `bin/python` when no explicit interpreter is set. |
 | `HOLOSCAN_CLI_VENV` | Wrapper-managed environment; defaults to `${XDG_DATA_HOME:-$HOME/.local/share}/holoscan-cli/venv`. |
 | `HOLOSCAN_CLI_SOURCE` | Local holoscan-cli checkout used in preference to a package requirement. |
-| `HOLOSCAN_CLI_INSTALL_ARGS` | Whitespace-separated pip tokens; defaults to the NVIDIA pre-release index and floating `holoscan-cli>4.2.0`. Shell quotes are not parsed. |
+| `HOLOSCAN_CLI_INSTALL_ARGS` | Whitespace-separated pip options and requirements. HoloHub defaults to the NVIDIA pre-release index; the wrapper also applies its exact committed pin. Shell quotes are not parsed. |
 | `HOLOSCAN_CLI_PINNED_VERSION` | One exact package version to install and verify. An explicitly empty value means floating. Ignored with `HOLOSCAN_CLI_SOURCE`. |
 | `PIP_BREAK_SYSTEM_PACKAGES` | PEP 668 pip control only; defaults to `1` after root system scope is selected and never selects that scope. |
 
@@ -822,8 +895,8 @@ for selection order, safety boundaries, and managed-venv maintenance.
 
 | Variable                      | Purpose                                                                                                          |
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `HOLOSCAN_CLI_BUILD_LOCAL`    | Force local mode (like `--local`); skips container build steps and runs on the host directly                     |
-| `HOLOSCAN_CLI_ALWAYS_BUILD`   | Defaults to `true`. Set to `false` to allow skipping builds with `--no-local-build` / `--no-docker-build`        |
+| `HOLOSCAN_CLI_BUILD_LOCAL`    | Force local execution (like `--local`); containers set it during CLI re-entry                                    |
+| `HOLOSCAN_CLI_ALWAYS_BUILD`   | Defaults to `true`; `false` skips both run builds, but only image builds for other container commands            |
 | `HOLOSCAN_CLI_ENABLE_SCCACHE` | Defaults to `false`. Set to `true` to enable sccache for builds; use with `--extra-scripts sccache` in container |
 
 ### Paths and Directories
@@ -864,13 +937,17 @@ for selection order, safety boundaries, and managed-venv maintenance.
 | `CMAKE_BUILD_TYPE`           | Default CMake build type when not set on CLI      |
 | `CMAKE_BUILD_PARALLEL_LEVEL` | Default parallel build jobs                       |
 
+`HOLOSCAN_CLI_IN_CONTAINER_CMD` selects the command used when container
+workflows recurse into the CLI; HoloHub sets it to the mounted wrapper.
+
 ---
 
 ## Appendix
 
 ### Bash Autocompletion
 
-Autocompletion is usually installed during `./holohub setup`. It completes project names and command names.
+`./holohub setup` installs the repository's Bash completion script when
+`/etc/bash_completion.d` is available. You can also install it manually.
 
 ```bash
 ./holohub <TAB><TAB>       # List commands


### PR DESCRIPTION
## Summary

Refreshes HoloHub documentation to match the standalone `holoscan-cli` wrapper that `./holohub` now delegates to. Touches ~33 docs across the repo (READMEs, `AGENTS.md`, developer guide, and the `utilities/cli/` reference + dev guide).

## What changed

- **Command/flag standardization** — kebab-case flags throughout (`--as-root`, `--docker-opts`, `--local-sdk-root`, `--base-img`, `--extra-scripts`), `--configure-args=`/`--run-args=` equals form, and `--no-build` → `--no-docker-build --no-local-build`.
- **Execution model docs** — container-first two-phase model, per-command preview-flag support (`--dryrun` / `--dryrun --verbose` / read-only), and the new `package` and `version` commands documented in the CLI reference, developer guide, and dev guide.
- **Legacy packager notes** — application READMEs that used the old HAP/MAP packager now carry an `> [!IMPORTANT]` note that it requires `holoscan-cli` ≤ 4.2.0 and that current `./holohub package` builds Holoscan Module artifacts.
- **`applications/iio` migration** — converted the last README still using the retired `./dev_container` / `./run` scripts to `./holohub run`/`build`.

## Notes

- Docs-only change; no code or behavior changes.
- Applied a small consistency/cleanup pass: fixed a lone space-form `--run-args` example and a repeated-word phrasing in the developer guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated HoloHub CLI guidance and examples to use current command syntax, including hyphenated flags and consistent usage patterns.
  * Expanded container workflow documentation for build/run/install/package behavior, including preview support via `--dryrun`/`--verbose` and updated environment-variable semantics.
  * Clarified packaging changes: legacy helper requirements (Holoscan CLI 4.2.0 or earlier) and the shift to Holoscan Module artifact packaging.
  * Refreshed project/module creation instructions (explicit project names, unprefixed module names) and updated multiple application/operator/tutorial command examples and safety notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->