### PR TITLE
Fix critical ChromaDB vulnerability in EHR Query LLM

### DIFF
--- a/applications/ehr_query_llm/lmm/requirements.txt
+++ b/applications/ehr_query_llm/lmm/requirements.txt
@@ -7,7 +7,7 @@ flask==3.1.3
 websockets==12.0
 asyncio==3.4.3
 pyzmq~=26.0
-chromadb==1.5.9
+chromadb==0.6.3
 langchain==1.3.9
 langchain-community==0.3.31
 langchain-core==1.3.3


### PR DESCRIPTION
## Summary

- Pin ChromaDB to `0.6.3`, the newest published release outside the vulnerable range.
- Address [GHSA-f4j7-r4q5-qw2c](https://github.com/advisories/GHSA-f4j7-r4q5-qw2c) / CVE-2026-45829.

## Rationale

ChromaDB `1.5.9` is affected by a critical pre-authentication code injection vulnerability. Upstream has not published a patched release, so this restores the repository's previous `0.6.3` pin with no application code changes.

## Validation

- ChromaDB `0.6.3` resolves with `langchain-community==0.3.31`.
- Full repository lint suite passes locally.
- All pull request checks pass, including lint, Docker builds, DCO, compliance, and CodeQL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ChromaDB dependency to version 0.6.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->