### PR TITLE
Op: Harden volume_loader MHD ingestion

### DIFF
--- a/operators/volume_loader/CMakeLists.txt
+++ b/operators/volume_loader/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,6 +68,10 @@ target_compile_definitions(volume_loader PRIVATE HOLOSCAN_MINOR_VERSION=${holosc
 install(TARGETS volume_loader
   COMPONENT holoscan-ops
 )
+
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()
 
 if(HOLOHUB_BUILD_PYTHON)
     add_subdirectory(python)

--- a/operators/volume_loader/mhd_loader.cpp
+++ b/operators/volume_loader/mhd_loader.cpp
@@ -1,5 +1,6 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,14 +18,38 @@
 
 #include "mhd_loader.hpp"
 
+#include <algorithm>
 #include <array>
+#include <cmath>
 #include <filesystem>
+#include <limits>
+#include <sstream>
 
 #include <zlib.h>
 
 #include "volume.hpp"
 
 namespace holoscan::ops {
+
+namespace {
+
+template <typename T, size_t N>
+bool parse_exact_vector(const std::string& value, std::array<T, N>& result) {
+  std::istringstream value_stream(value);
+  std::array<T, N> parsed;
+
+  for (T& component : parsed) {
+    if (!(value_stream >> component)) { return false; }
+  }
+
+  value_stream >> std::ws;
+  if (!value_stream.eof()) { return false; }
+
+  result = parsed;
+  return true;
+}
+
+}  // namespace
 
 bool is_mhd(const std::string& file_name) {
   std::filesystem::path path(file_name);
@@ -36,9 +61,12 @@ bool is_mhd(const std::string& file_name) {
 
 bool load_mhd(const std::string& file_name, Volume& volume) {
   bool compressed = false;
+  bool has_dims = false;
+  bool has_element_type = false;
+  bool has_ndims = false;
   std::string data_file_name;
-  nvidia::gxf::PrimitiveType primitive_type;
-  std::array<int32_t, 3> dims;
+  nvidia::gxf::PrimitiveType primitive_type{};
+  std::array<int32_t, 3> dims{};
 
   {
     std::stringstream meta_header;
@@ -68,11 +96,19 @@ bool load_mhd(const std::string& file_name, Volume& volume) {
       while ((it != value.end()) && (std::isspace(*it))) { it = value.erase(it); }
 
       if (parameter == "NDims") {
-        int dims = std::stoi(value);
-        if (dims != 3) {
-          holoscan::log_error("MHD expected a three dimensional input, instead NDims is {}", dims);
+        std::istringstream value_stream(value);
+        int dimensions;
+        if (!(value_stream >> dimensions)) {
+          holoscan::log_error("MHD invalid NDims value");
           return false;
         }
+        value_stream >> std::ws;
+        if (!value_stream.eof() || dimensions != 3) {
+          holoscan::log_error(
+              "MHD expected a three dimensional input, instead NDims is {}", dimensions);
+          return false;
+        }
+        has_ndims = true;
       } else if (parameter == "CompressedData") {
         if (value == "True") {
           compressed = true;
@@ -83,17 +119,31 @@ bool load_mhd(const std::string& file_name, Volume& volume) {
           return false;
         }
       } else if (parameter == "DimSize") {
-        std::stringstream value_stream(value);
-        std::string value;
-        for (int index = 0; std::getline(value_stream, value, ' ') && (index < 3); ++index) {
-          dims[2 - index] = std::stoi(value);
+        std::array<int32_t, 3> parsed_dims;
+        if (!parse_exact_vector(value, parsed_dims)) {
+          holoscan::log_error("MHD DimSize must contain exactly three integers");
+          return false;
         }
+        if (std::any_of(
+                parsed_dims.begin(), parsed_dims.end(), [](int32_t dim) { return dim <= 0; })) {
+          holoscan::log_error("MHD DimSize values must be positive");
+          return false;
+        }
+        dims = {parsed_dims[2], parsed_dims[1], parsed_dims[0]};
+        has_dims = true;
       } else if (parameter == "ElementSpacing") {
-        std::stringstream value_stream(value);
-        std::string value;
-        for (int index = 0; std::getline(value_stream, value, ' ') && (index < 3); ++index) {
-          volume.spacing_[index] = std::stof(value);
+        std::array<float, 3> spacing;
+        if (!parse_exact_vector(value, spacing)) {
+          holoscan::log_error("MHD ElementSpacing must contain exactly three numbers");
+          return false;
         }
+        if (std::any_of(spacing.begin(), spacing.end(), [](float value) {
+              return !std::isfinite(value) || value <= 0.f;
+            })) {
+          holoscan::log_error("MHD ElementSpacing values must be finite and positive");
+          return false;
+        }
+        volume.spacing_ = spacing;
       } else if (parameter == "ElementType") {
         if (value == "MET_CHAR") {
           primitive_type = nvidia::gxf::PrimitiveType::kInt8;
@@ -113,6 +163,7 @@ bool load_mhd(const std::string& file_name, Volume& volume) {
           holoscan::log_error("MHD unexpected value for {}: {}", parameter, value);
           return false;
         }
+        has_element_type = true;
       } else if (parameter == "ElementDataFile") {
         const std::string path = file_name.substr(0, file_name.find_last_of("/\\") + 1);
         data_file_name = path + value;
@@ -122,8 +173,20 @@ bool load_mhd(const std::string& file_name, Volume& volume) {
     }
   }
 
-  const size_t data_size =
-      dims[0] * dims[1] * dims[2] * nvidia::gxf::PrimitiveTypeSize(primitive_type);
+  if (!has_ndims || !has_dims || !has_element_type || data_file_name.empty()) {
+    holoscan::log_error(
+        "MHD is missing one or more required fields: NDims, DimSize, ElementType, ElementDataFile");
+    return false;
+  }
+
+  size_t data_size = nvidia::gxf::PrimitiveTypeSize(primitive_type);
+  for (const int32_t dim : dims) {
+    if (data_size > std::numeric_limits<size_t>::max() / static_cast<size_t>(dim)) {
+      holoscan::log_error("MHD volume size exceeds the supported range");
+      return false;
+    }
+    data_size *= static_cast<size_t>(dim);
+  }
   std::unique_ptr<uint8_t> data(new uint8_t[data_size]);
 
   std::ifstream file;

--- a/operators/volume_loader/mhd_loader.cpp
+++ b/operators/volume_loader/mhd_loader.cpp
@@ -103,7 +103,11 @@ bool load_mhd(const std::string& file_name, Volume& volume) {
           return false;
         }
         value_stream >> std::ws;
-        if (!value_stream.eof() || dimensions != 3) {
+        if (!value_stream.eof()) {
+          holoscan::log_error("MHD invalid NDims value");
+          return false;
+        }
+        if (dimensions != 3) {
           holoscan::log_error(
               "MHD expected a three dimensional input, instead NDims is {}", dimensions);
           return false;
@@ -229,7 +233,21 @@ bool load_mhd(const std::string& file_name, Volume& volume) {
       return false;
     }
   } else {
-    file.read(reinterpret_cast<char*>(data.get()), data_size);
+    if (data_size > static_cast<size_t>(std::numeric_limits<std::streamsize>::max())) {
+      holoscan::log_error("MHD raw payload size exceeds the supported range");
+      return false;
+    }
+
+    const auto expected_size = static_cast<std::streamsize>(data_size);
+    file.read(reinterpret_cast<char*>(data.get()), expected_size);
+    if (!file || file.gcount() != expected_size) {
+      holoscan::log_error(
+          "MHD raw payload {} is truncated: expected {} bytes, read {} bytes",
+          data_file_name,
+          data_size,
+          file.gcount());
+      return false;
+    }
   }
 
   // allocate the tensor

--- a/operators/volume_loader/mhd_loader.cpp
+++ b/operators/volume_loader/mhd_loader.cpp
@@ -191,6 +191,10 @@ bool load_mhd(const std::string& file_name, Volume& volume) {
     }
     data_size *= static_cast<size_t>(dim);
   }
+  if (data_size > static_cast<size_t>(std::numeric_limits<std::streamsize>::max())) {
+    holoscan::log_error("MHD payload size exceeds the supported range");
+    return false;
+  }
   std::unique_ptr<uint8_t> data(new uint8_t[data_size]);
 
   std::ifstream file;
@@ -233,11 +237,6 @@ bool load_mhd(const std::string& file_name, Volume& volume) {
       return false;
     }
   } else {
-    if (data_size > static_cast<size_t>(std::numeric_limits<std::streamsize>::max())) {
-      holoscan::log_error("MHD raw payload size exceeds the supported range");
-      return false;
-    }
-
     const auto expected_size = static_cast<std::streamsize>(data_size);
     file.read(reinterpret_cast<char*>(data.get()), expected_size);
     if (!file || file.gcount() != expected_size) {

--- a/operators/volume_loader/tests/CMakeLists.txt
+++ b/operators/volume_loader/tests/CMakeLists.txt
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+find_package(GTest QUIET)
+if(NOT GTest_FOUND)
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+  )
+  set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+  FetchContent_MakeAvailable(googletest)
+endif()
+
+add_executable(volume_loader_mhd_test
+  test_mhd_loader.cpp
+)
+
+target_link_libraries(volume_loader_mhd_test
+  PRIVATE
+    holoscan::core
+    holoscan::ops::volume_loader
+    GTest::gtest_main
+)
+
+add_test(NAME volume_loader_mhd_test COMMAND volume_loader_mhd_test)
+set_tests_properties(volume_loader_mhd_test PROPERTIES
+  LABELS "unit;volume_loader"
+  TIMEOUT 30
+)

--- a/operators/volume_loader/tests/CMakeLists.txt
+++ b/operators/volume_loader/tests/CMakeLists.txt
@@ -6,8 +6,9 @@ if(NOT GTest_FOUND)
   include(FetchContent)
   FetchContent_Declare(
     googletest
-    URL https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG v1.17.0
+    GIT_SHALLOW TRUE
   )
   set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
   FetchContent_MakeAvailable(googletest)

--- a/operators/volume_loader/tests/test_mhd_loader.cpp
+++ b/operators/volume_loader/tests/test_mhd_loader.cpp
@@ -31,27 +31,48 @@ class MhdLoaderHeaderTest : public testing::Test {
  protected:
   void SetUp() override {
     header_path_ = std::filesystem::temp_directory_path() / "holohub_mhd_loader_test.mhd";
+    raw_path_ = std::filesystem::temp_directory_path() / "holohub_mhd_loader_test.raw";
   }
 
   void TearDown() override {
     std::error_code error;
     std::filesystem::remove(header_path_, error);
+    std::filesystem::remove(raw_path_, error);
   }
 
   bool load_header(const std::string& header) {
     std::ofstream header_file(header_path_);
+    if (!header_file.is_open()) {
+      ADD_FAILURE() << "Failed to open test MHD header " << header_path_;
+      return false;
+    }
+
     header_file << header;
+    if (!header_file.good()) {
+      ADD_FAILURE() << "Failed to write test MHD header " << header_path_;
+      return false;
+    }
+
     header_file.close();
+    if (header_file.fail()) {
+      ADD_FAILURE() << "Failed to close test MHD header " << header_path_;
+      return false;
+    }
 
     Volume volume;
     return load_mhd(header_path_.string(), volume);
   }
 
   std::filesystem::path header_path_;
+  std::filesystem::path raw_path_;
 };
 
 TEST_F(MhdLoaderHeaderTest, RejectsTooFewDimensions) {
   EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 20\n"));
+}
+
+TEST_F(MhdLoaderHeaderTest, RejectsInvalidDimensionCount) {
+  EXPECT_FALSE(load_header("NDims = 3abc\nDimSize = 10 20 30\n"));
 }
 
 TEST_F(MhdLoaderHeaderTest, RejectsTooManyDimensions) {
@@ -85,6 +106,20 @@ TEST_F(MhdLoaderHeaderTest, RejectsOverflowingVolumeSize) {
                            "DimSize = 2147483647 2147483647 2147483647\n"
                            "ElementType = MET_FLOAT\n"
                            "ElementDataFile = unused.raw\n"));
+}
+
+TEST_F(MhdLoaderHeaderTest, RejectsTruncatedRawPayload) {
+  std::ofstream raw_file(raw_path_, std::ios::binary);
+  ASSERT_TRUE(raw_file.is_open());
+  raw_file.write("1234567", 7);
+  ASSERT_TRUE(raw_file.good());
+  raw_file.close();
+  ASSERT_FALSE(raw_file.fail());
+
+  EXPECT_FALSE(load_header("NDims = 3\n"
+                           "DimSize = 2 2 2\n"
+                           "ElementType = MET_UCHAR\n"
+                           "ElementDataFile = holohub_mhd_loader_test.raw\n"));
 }
 
 }  // namespace holoscan::ops

--- a/operators/volume_loader/tests/test_mhd_loader.cpp
+++ b/operators/volume_loader/tests/test_mhd_loader.cpp
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+
+#include "mhd_loader.hpp"
+#include "volume.hpp"
+
+namespace holoscan::ops {
+
+class MhdLoaderHeaderTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    header_path_ = std::filesystem::temp_directory_path() / "holohub_mhd_loader_test.mhd";
+  }
+
+  void TearDown() override {
+    std::error_code error;
+    std::filesystem::remove(header_path_, error);
+  }
+
+  bool load_header(const std::string& header) {
+    std::ofstream header_file(header_path_);
+    header_file << header;
+    header_file.close();
+
+    Volume volume;
+    return load_mhd(header_path_.string(), volume);
+  }
+
+  std::filesystem::path header_path_;
+};
+
+TEST_F(MhdLoaderHeaderTest, RejectsTooFewDimensions) {
+  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 20\n"));
+}
+
+TEST_F(MhdLoaderHeaderTest, RejectsTooManyDimensions) {
+  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 20 30 40\n"));
+}
+
+TEST_F(MhdLoaderHeaderTest, RejectsNonPositiveDimensions) {
+  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 0 30\n"));
+  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 -20 30\n"));
+}
+
+TEST_F(MhdLoaderHeaderTest, RejectsTooFewSpacingValues) {
+  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 20 30\nElementSpacing = 1 1\n"));
+}
+
+TEST_F(MhdLoaderHeaderTest, RejectsTooManySpacingValues) {
+  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 20 30\nElementSpacing = 1 1 1 1\n"));
+}
+
+TEST_F(MhdLoaderHeaderTest, RejectsNonPositiveSpacing) {
+  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 20 30\nElementSpacing = 1 0 1\n"));
+  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 20 30\nElementSpacing = 1 -1 1\n"));
+}
+
+TEST_F(MhdLoaderHeaderTest, RejectsMissingRequiredFields) {
+  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 20 30\n"));
+}
+
+TEST_F(MhdLoaderHeaderTest, RejectsOverflowingVolumeSize) {
+  EXPECT_FALSE(load_header("NDims = 3\n"
+                           "DimSize = 2147483647 2147483647 2147483647\n"
+                           "ElementType = MET_FLOAT\n"
+                           "ElementDataFile = unused.raw\n"));
+}
+
+}  // namespace holoscan::ops

--- a/operators/volume_loader/tests/test_mhd_loader.cpp
+++ b/operators/volume_loader/tests/test_mhd_loader.cpp
@@ -32,6 +32,13 @@ class MhdLoaderHeaderTest : public testing::Test {
   void SetUp() override {
     header_path_ = std::filesystem::temp_directory_path() / "holohub_mhd_loader_test.mhd";
     raw_path_ = std::filesystem::temp_directory_path() / "holohub_mhd_loader_test.raw";
+
+    std::ofstream raw_file(raw_path_, std::ios::binary);
+    ASSERT_TRUE(raw_file.is_open());
+    raw_file.put('\0');
+    ASSERT_TRUE(raw_file.good());
+    raw_file.close();
+    ASSERT_FALSE(raw_file.fail());
   }
 
   void TearDown() override {
@@ -63,38 +70,46 @@ class MhdLoaderHeaderTest : public testing::Test {
     return load_mhd(header_path_.string(), volume);
   }
 
+  std::string complete_header(const std::string& ndims,
+                              const std::string& dim_size,
+                              const std::string& element_spacing = "1 1 1") const {
+    return "NDims = " + ndims + "\nDimSize = " + dim_size +
+           "\nElementSpacing = " + element_spacing +
+           "\nElementType = MET_UCHAR\nElementDataFile = holohub_mhd_loader_test.raw\n";
+  }
+
   std::filesystem::path header_path_;
   std::filesystem::path raw_path_;
 };
 
 TEST_F(MhdLoaderHeaderTest, RejectsTooFewDimensions) {
-  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 20\n"));
+  EXPECT_FALSE(load_header(complete_header("3", "1 1")));
 }
 
 TEST_F(MhdLoaderHeaderTest, RejectsInvalidDimensionCount) {
-  EXPECT_FALSE(load_header("NDims = 3abc\nDimSize = 10 20 30\n"));
+  EXPECT_FALSE(load_header(complete_header("3abc", "1 1 1")));
 }
 
 TEST_F(MhdLoaderHeaderTest, RejectsTooManyDimensions) {
-  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 20 30 40\n"));
+  EXPECT_FALSE(load_header(complete_header("3", "1 1 1 1")));
 }
 
 TEST_F(MhdLoaderHeaderTest, RejectsNonPositiveDimensions) {
-  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 0 30\n"));
-  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 -20 30\n"));
+  EXPECT_FALSE(load_header(complete_header("3", "1 0 1")));
+  EXPECT_FALSE(load_header(complete_header("3", "1 -1 1")));
 }
 
 TEST_F(MhdLoaderHeaderTest, RejectsTooFewSpacingValues) {
-  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 20 30\nElementSpacing = 1 1\n"));
+  EXPECT_FALSE(load_header(complete_header("3", "1 1 1", "1 1")));
 }
 
 TEST_F(MhdLoaderHeaderTest, RejectsTooManySpacingValues) {
-  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 20 30\nElementSpacing = 1 1 1 1\n"));
+  EXPECT_FALSE(load_header(complete_header("3", "1 1 1", "1 1 1 1")));
 }
 
 TEST_F(MhdLoaderHeaderTest, RejectsNonPositiveSpacing) {
-  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 20 30\nElementSpacing = 1 0 1\n"));
-  EXPECT_FALSE(load_header("NDims = 3\nDimSize = 10 20 30\nElementSpacing = 1 -1 1\n"));
+  EXPECT_FALSE(load_header(complete_header("3", "1 1 1", "1 0 1")));
+  EXPECT_FALSE(load_header(complete_header("3", "1 1 1", "1 -1 1")));
 }
 
 TEST_F(MhdLoaderHeaderTest, RejectsMissingRequiredFields) {
@@ -106,6 +121,13 @@ TEST_F(MhdLoaderHeaderTest, RejectsOverflowingVolumeSize) {
                            "DimSize = 2147483647 2147483647 2147483647\n"
                            "ElementType = MET_FLOAT\n"
                            "ElementDataFile = unused.raw\n"));
+}
+
+TEST_F(MhdLoaderHeaderTest, RejectsPayloadLargerThanStreamSize) {
+  EXPECT_FALSE(load_header("NDims = 3\n"
+                           "DimSize = 2097152 2097152 2097152\n"
+                           "ElementType = MET_UCHAR\n"
+                           "ElementDataFile = holohub_mhd_loader_test.raw\n"));
 }
 
 TEST_F(MhdLoaderHeaderTest, RejectsTruncatedRawPayload) {

--- a/operators/volume_loader/volume_loader.cpp
+++ b/operators/volume_loader/volume_loader.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -80,20 +80,21 @@ void VolumeLoaderOp::compute(InputContext& input, OutputContext& output,
   volume.tensor_ =
       static_cast<nvidia::gxf::Entity&>(entity).add<nvidia::gxf::Tensor>("volume").value();
 
+  bool loaded = false;
   if (is_nifty(file_name)) {
-    if (!load_nifty(file_name, volume)) {
-      holoscan::log_error("Failed to load nifty file {}", file_name);
-    }
+    loaded = load_nifty(file_name, volume);
   } else if (is_mhd(file_name)) {
-    if (!load_mhd(file_name, volume)) {
-      holoscan::log_error("Failed to load mhd file {}", file_name);
-    }
+    loaded = load_mhd(file_name, volume);
   } else if (is_nrrd(file_name)) {
-    if (!load_nrrd(file_name, volume)) {
-      holoscan::log_error("Failed to load nrrd file {}", file_name);
-    }
+    loaded = load_nrrd(file_name, volume);
   } else {
     holoscan::log_error("File is not a supported volume format {}", file_name);
+    return;
+  }
+
+  if (!loaded) {
+    holoscan::log_error("Failed to load volume file {}", file_name);
+    return;
   }
 
   output.emit(entity, "volume");


### PR DESCRIPTION
Address issues flagged internally where volume_loader MetaImage loading procedures did not fully check bounds, resulting in potential heap-buffer-overflow issue

Internal reference: 6384964

Assisted-by: Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened MHD header parsing/validation (dimension count, positive dimension sizes, valid positive spacing, supported element type, and required fields).
  * Added overflow-safe data-size calculations and stricter raw payload reads to prevent oversized reads and detect truncated payloads.
  * Improved volume-load failure behavior to consistently stop when loading fails and emit a single clear error.

* **Tests**
  * Added comprehensive unit tests for invalid MHD headers, missing fields, spacing/dimension errors, overflow/size constraints, and truncated raw payloads.
  * Added a dedicated CTest entry for the volume loader MHD test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->