### PR TITLE
Fix deployed operator API references

### DIFF
--- a/.github/workflows/gh-pages-docs-deploy.yml
+++ b/.github/workflows/gh-pages-docs-deploy.yml
@@ -18,6 +18,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y doxygen
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/doc/website/scripts/generate_api_docs.py
+++ b/doc/website/scripts/generate_api_docs.py
@@ -193,10 +193,13 @@ def run_doxygen_and_parse(website_dir: Path) -> dict:
         logger.error(f"Doxyfile not found at {doxyfile}")
         return {}
 
-    # Check for doxygen
+    # C++ API references are a required part of the generated operator pages.
+    # Failing the build prevents publishing a partially generated site when the
+    # build environment is missing this system dependency.
     if not shutil.which("doxygen"):
-        logger.warning("Doxygen not found in PATH. Skipping C++ API doc generation.")
-        return {}
+        raise RuntimeError(
+            "Doxygen is required to generate C++ API references but was not found in PATH."
+        )
 
     xml_output_dir = website_dir / "_build" / "doxygen" / "xml"
 

--- a/doc/website/tests/test_generate_api_docs.py
+++ b/doc/website/tests/test_generate_api_docs.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from generate_api_docs import run_doxygen_and_parse
+
+
+class RunDoxygenAndParseTest(unittest.TestCase):
+    def test_missing_doxygen_stops_api_reference_generation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            website_dir = Path(temp_dir)
+            (website_dir / "Doxyfile").touch()
+
+            with patch("generate_api_docs.shutil.which", return_value=None), self.assertRaisesRegex(
+                RuntimeError, "Doxygen is required"
+            ):
+                run_doxygen_and_parse(website_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- install Doxygen in GitHub Pages CI so deployed operator C++ API references are generated
- fail documentation builds when Doxygen is unavailable
- add regression coverage for missing Doxygen

## Validation
- documentation website build
- focused unit test
- repository lint

Fix #1477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation builds now install Doxygen automatically during deployment.
  * API documentation generation reports a clear error when Doxygen is unavailable instead of silently producing incomplete results.

* **Tests**
  * Added coverage to verify the expected error is raised when Doxygen cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->