### PR TITLE
Fix Florence model download

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Projects live under `applications/`, `benchmarks/`, `operators/`, `gxf_extension
 ## Boundaries
 
 - **Always** run `./holohub run-container -- "./holohub lint --install-dependencies; ./holohub lint"` before committing
+- **Always** sign every commit with the Developer Certificate of Origin using `git commit -s`, and verify the resulting commit contains a `Signed-off-by` trailer before pushing
 - **Always** preview mutating CLI commands with `--dryrun` before running them for real; add `--verbose` where supported. Read-only diagnostics (`list`, `modes`, `env-info`, `env-check`, `status`, `version`) need no preview. See the [CLI Reference](utilities/cli/cli_reference.md#preview-support) for per-command support.
 - **Ask first** before changing `metadata.json` schemas, shared Dockerfiles, or CMake registration macros (`add_holohub_application`, `add_holohub_operator`, etc.)
 - **Never** delete `build/`, `data/`, or `install/` directories without asking

--- a/applications/florence-2-vision/Dockerfile
+++ b/applications/florence-2-vision/Dockerfile
@@ -44,7 +44,7 @@ RUN python3 -m pip install --no-cache-dir setuptools && \
 
 # Download the Florence-2 model
 RUN hf download microsoft/Florence-2-large-ft \
-    --local-dir /workspace/volumes/models/microsoft/Florence-2-large-ft --cache-dir /workspace/volumes/models/microsoft/Florence-2-large-ft
+    --local-dir /workspace/volumes/models/microsoft/Florence-2-large-ft
 
 # Build/install flash-attention 2 (NOTE: on Arm64 this will take between 1-1.5 hours)
 # MAX_JOBS is set to 4 to avoid running out of memory


### PR DESCRIPTION
Removes the incompatible `--cache-dir` option from the Florence-2 model download while retaining `--local-dir`. Also documents the required DCO sign-off in `AGENTS.md`.

Validation: full HoloHub lint.

AI-assisted: Created with Codex/GPT at the user's request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Florence-2 model setup to use a simplified local download configuration.
  * Added contributor guidance requiring signed commits with a verified sign-off record.
  * No user-facing API or feature changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->