### PR TITLE
Fix pipeline visualization magic enum include

### DIFF
--- a/applications/pipeline_visualization/cpp/nats_logger.cpp
+++ b/applications/pipeline_visualization/cpp/nats_logger.cpp
@@ -26,7 +26,7 @@
 
 #include <nats.h>
 
-#include <magic_enum.hpp>
+#include <magic_enum/magic_enum.hpp>
 #include <stdexcept>
 
 #include <flatbuffers/message_generated.h>


### PR DESCRIPTION
Updates the pipeline visualization logger to use the SDK's nested `magic_enum` header path, restoring the C++ and Python builds.

Validation:

- `./holohub build pipeline_visualization --language cpp --configure-args=-DBUILD_TESTING=OFF`
- `./holohub build pipeline_visualization --language python --configure-args=-DBUILD_TESTING=OFF`
- Full HoloHub lint

AI-assisted: Created with Codex/GPT at the user's request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the enum library include path to improve compatibility with the current package layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->