### PR TITLE
feat: add 'hide' attribute to documentation index files

### DIFF
--- a/doc/website/docs/applications/index.md
+++ b/doc/website/docs/applications/index.md
@@ -4,4 +4,6 @@ title: Holoscan Applications
 description: >-
   Browse HoloHub Holoscan applications — reference pipelines for real-time AI
   sensor processing across healthcare, robotics, computer vision, and streaming.
+hide:
+  - path
 ---

--- a/doc/website/docs/benchmarks/index.md
+++ b/doc/website/docs/benchmarks/index.md
@@ -4,4 +4,6 @@ title: Holoscan Benchmarks
 description: >-
   Measure Holoscan performance with HoloHub benchmarks — tools and examples for
   evaluating real-time AI sensor processing pipelines.
+hide:
+  - path
 ---

--- a/doc/website/docs/modules/index.md
+++ b/doc/website/docs/modules/index.md
@@ -4,4 +4,6 @@ title: Holoscan Modules
 description: >-
   Browse HoloHub Holoscan modules — packaged operators, assets, and metadata
   for distributing and reusing Holoscan ecosystem components.
+hide:
+  - path
 ---

--- a/doc/website/docs/operators/index.md
+++ b/doc/website/docs/operators/index.md
@@ -4,4 +4,6 @@ title: Holoscan Operators
 description: >-
   Browse HoloHub Holoscan operators — reusable building blocks for data
   ingestion, inference, visualization, and sensor processing pipelines.
+hide:
+  - path
 ---

--- a/doc/website/docs/tutorials/index.md
+++ b/doc/website/docs/tutorials/index.md
@@ -4,4 +4,6 @@ title: Holoscan Tutorials
 description: >-
   Learn Holoscan with HoloHub tutorials — step-by-step guides for building,
   packaging, and deploying Holoscan applications and modules.
+hide:
+  - path
 ---


### PR DESCRIPTION
This commit introduces a 'hide' attribute with a value of 'path' to the index files of various documentation sections, including applications, benchmarks, modules, operators, and tutorials. This change enhances the organization and visibility of the documentation by controlling the display of specific paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved documentation navigation by hiding internal page paths on the Applications, Benchmarks, Modules, Operators, and Tutorials landing pages.
  - Provides cleaner, more user-friendly URLs and page presentation across the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->