### PR TITLE
Update NGC CLI to 4.34.10

### DIFF
--- a/applications/video_streaming/Dockerfile
+++ b/applications/video_streaming/Dockerfile
@@ -62,10 +62,10 @@ ENV PKG_CONFIG_PATH="/usr/local/ssl/lib64/pkgconfig:${PKG_CONFIG_PATH}"
 
 # Install NGC CLI following official instructions
 WORKDIR /tmp/ngc-install
-RUN wget --no-check-certificate --content-disposition https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/3.151.0/files/ngccli_linux.zip -O ngccli_linux.zip && \
+RUN wget --content-disposition https://api.ngc.nvidia.com/v2/resources/nvidia/ngc-apps/ngc_cli/versions/4.34.10/files/ngccli_linux.zip -O ngccli_linux.zip && \
+    # Verify SHA256 before extraction
+    echo "58bc4d7b6901551a095ce5a43a0065b1c22d5eaf1a164d40029ee3fda11ccd47 ngccli_linux.zip" | sha256sum --check && \
     unzip ngccli_linux.zip && \
-    # Verify SHA256
-    echo "834aeebcdfee2f6db61744dbae5f976c4e3a7a4a9aa99d23dd1ed2928a2abd60 ngccli_linux.zip" | sha256sum --check && \
     # Make NGC CLI executable and add to path
     chmod u+x ngc-cli/ngc && \
     # Install to system path


### PR DESCRIPTION
Updates the video streaming Dockerfile to use NGC CLI 4.34.10 and its published checksum.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bundled NGC CLI to version 4.34.10.
  * Enabled certificate verification and SHA256 checksum validation during download to improve installation security and integrity.
  * Updated the verified checksum to match the new CLI version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->