### PR TITLE
docs: fix nvidia_nim_chat README project name and requirements path

### DIFF
--- a/applications/nvidia_nim/nvidia_nim_chat/README.md
+++ b/applications/nvidia_nim/nvidia_nim_chat/README.md
@@ -38,7 +38,7 @@ To run the sample application with Docker, you must first build and run a Docker
 
 ```bash
 # Build and run the Docker images from the root directory of Holohub
-./holohub run-container nvidia_nim
+./holohub run-container nvidia_nim_chat
 ```
 
 Continue to the [Start the Application](#start-the-application) section once inside the Docker container.
@@ -53,7 +53,7 @@ python3 -m venv .venv
 source .venv/bin/activate
 
 # install the required packages
-pip install -r applications/nvidia_nim/chat/requirements.txt
+pip install -r applications/nvidia_nim/nvidia_nim_chat/requirements.txt
 ```
 
 ### Start the Application


### PR DESCRIPTION
Closes #1692

The `chat` -> `nvidia_nim_chat` rename left two stale references in this README, so both documented setup paths fail for new users. `./holohub run-container nvidia_nim` exits `[FATAL] Project 'nvidia_nim' not found`, and the pip step points at the deleted `applications/nvidia_nim/chat/` directory.

Changes:
- Line 41: `run-container nvidia_nim` -> `run-container nvidia_nim_chat`
- Line 56: `nvidia_nim/chat/requirements.txt` -> `nvidia_nim/nvidia_nim_chat/requirements.txt`

Verified `./holohub list` reports `nvidia_nim_chat` and that the new requirements path exists. This brings the chat README in line with its nvclip and imaging siblings, which already use full project names.

Test: `./holohub run-container nvidia_nim_chat`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated NVIDIA NIM README commands to use the correct `nvidia_nim_chat` application path and identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->