### PR TITLE
fix(cli): preserve HoloHub create template default

### DIFF
--- a/holohub
+++ b/holohub
@@ -26,6 +26,7 @@
 #   HOLOSCAN_CLI_PINNED_VERSION  Exact package version; empty enables floating mode.
 #   HOLOSCAN_CLI_PYTHON_BIN      Caller-owned interpreter.
 #   HOLOSCAN_CLI_VENV            Wrapper-managed venv location.
+#   HOLOSCAN_CLI_CREATE_TEMPLATE Default template used by `./holohub create`.
 #   HOLOSCAN_CLI_CTEST_SCRIPT    CTest script used by `./holohub test`.
 #   HOLOSCAN_CLI_IN_CONTAINER_CMD  In-container CLI entry (default: this wrapper).
 
@@ -54,6 +55,7 @@ export HOLOSCAN_CLI_VENV="${HOLOSCAN_CLI_VENV:-}"
 
 # The standalone CLI has no SDK-image default; HoloHub owns this project default.
 export HOLOSCAN_CLI_BASE_SDK_VERSION="${HOLOSCAN_CLI_BASE_SDK_VERSION:-4.5.0}"
+export HOLOSCAN_CLI_CREATE_TEMPLATE="${HOLOSCAN_CLI_CREATE_TEMPLATE:-applications/template}"
 export HOLOSCAN_CLI_CTEST_SCRIPT="${HOLOSCAN_CLI_CTEST_SCRIPT:-utilities/testing/holohub.container.ctest}"
 
 _holoscan_cli_version() {

--- a/utilities/cli/cli_reference.md
+++ b/utilities/cli/cli_reference.md
@@ -962,6 +962,7 @@ for selection order, safety boundaries, and managed-venv maintenance.
 | `HOLOSCAN_CLI_ROOT`              | HoloHub repo root                                                                    |
 | `HOLOSCAN_CLI_BUILD_PARENT_DIR`  | `<HOLOSCAN_CLI_ROOT>/build`                                                          |
 | `HOLOSCAN_CLI_DATA_DIR`          | `<HOLOSCAN_CLI_ROOT>/data`                                                           |
+| `HOLOSCAN_CLI_CREATE_TEMPLATE`   | `applications/template`, the default template used by `./holohub create`             |
 | `HOLOSCAN_CLI_SETUP_SCRIPTS_DIR` | `<HOLOSCAN_CLI_ROOT>/utilities/setup`                                                |
 | `HOLOSCAN_CLI_PATH_PREFIX`       | `holohub_` (prefix for path placeholders in metadata)                                |
 | `HOLOSCAN_CLI_DEFAULT_HSDK_DIR`  | `/opt/nvidia/holoscan`                                                               |


### PR DESCRIPTION
## Summary

- Keep `./holohub create` application-first by defaulting `HOLOSCAN_CLI_CREATE_TEMPLATE` to `applications/template`.
- Document the HoloHub wrapper default and its environment override.

## Context

nvidia-holoscan/holoscan-cli#225 makes direct `holoscan create` default to the packaged standalone Module template. The HoloHub wrapper retains its in-tree application workflow by explicitly selecting the project template.

## Validation

- `bash -n holohub`
- CLI consolidation suite: 17 passed
- `./holohub create ci-template-probe --dryrun -i False` selects `applications/template` and would register the application
- HoloHub container lint: all hooks passed

AI-assisted: Created with Codex/GPT at the user request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `HOLOSCAN_CLI_CREATE_TEMPLATE` setting to customize the template used by `./holohub create`.
  * The default template is now `applications/template` when no override is provided.

* **Documentation**
  * Documented the new environment variable and its default value in the CLI reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->