### PR TITLE
Harden changed-file URL checks

### DIFF
--- a/.github/workflows/check_urls.yml
+++ b/.github/workflows/check_urls.yml
@@ -4,11 +4,30 @@ on:
   push:
     branches: [main]
   pull_request:
+
+permissions:
+  contents: read
+
 jobs:
-  check-urls:
+  test-changed-file-handling:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Lychee for changed-file tests
+      uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2
+      with:
+        args: --version
+        checkbox: false
+        failIfEmpty: false
+        jobSummary: false
+
+    - name: Test changed-file handling
+      run: bash .github/workflows/scripts/test_check_urls_changed_files.sh
+
+  check-urls:
+    needs: test-changed-file-handling
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
@@ -17,55 +36,77 @@ jobs:
     - name: Get changed files in the PR
       if: github.event_name == 'pull_request'
       id: changed-files
-      run: |
-        # Get changed files using git diff
-        if git diff --name-only --diff-filter=d origin/${{ github.base_ref }}..HEAD | grep -E '\.(md|html|rst)$' > changed_files.txt; then
-          if [ -s changed_files.txt ]; then
-            echo "any_changed=true" >> $GITHUB_OUTPUT
-            echo "changed_files_list=$(cat changed_files.txt | sed 's|^|'"'"'${{ github.workspace }}/|; s|$|'"'"'|' | tr '\n' ' ')" >> $GITHUB_OUTPUT
-          else
-            echo "any_changed=false" >> $GITHUB_OUTPUT
-          fi
-        else
-          echo "any_changed=false" >> $GITHUB_OUTPUT
-        fi
+      env:
+        BASE_REF: ${{ github.base_ref }}
+        WORKSPACE: ${{ github.workspace }}
+      run: bash .github/workflows/scripts/get_changed_doc_files.sh
 
-    - name: Echo changed files in the PR
-      if: github.event_name == 'pull_request' && steps.changed-files.outputs.any_changed == 'true'
+    - name: Report changed documentation files
+      if: github.event_name == 'pull_request'
+      env:
+        ANY_CHANGED: ${{ steps.changed-files.outputs.any_changed }}
+        CHANGED_FILE_COUNT: ${{ steps.changed-files.outputs.changed_file_count }}
       run: |
-        echo "Files being checked: ${{ steps.changed-files.outputs.changed_files_list }}"
+        if [[ ! "${ANY_CHANGED}" =~ ^(true|false)$ ]] || [[ ! "${CHANGED_FILE_COUNT}" =~ ^[0-9]+$ ]]; then
+          echo "::error::Changed-file collection did not produce valid outputs."
+          exit 1
+        fi
+        echo "Checking ${CHANGED_FILE_COUNT} changed documentation file(s)"
+        while IFS= read -r file; do
+          printf '  %q\n' "${file}"
+        done < "${RUNNER_TEMP}/changed_doc_files.expected.txt"
+
+    - name: Install Lychee for the changed-file check
+      if: github.event_name == 'pull_request' && steps.changed-files.outputs.any_changed == 'true'
+      uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2
+      with:
+        args: --version
+        checkbox: false
+        failIfEmpty: false
+        jobSummary: false
 
     - name: URL checker (PR - changed files only)
       if: github.event_name == 'pull_request' && steps.changed-files.outputs.any_changed == 'true'
-      id: lychee-pr
-      uses: lycheeverse/lychee-action@v2
-      with:
-        workingDirectory: .github/workflows
-        args: >-
-          --accept=200,403,429
-          --verbose
-          --no-progress
-          --root-dir=${{ github.workspace }}
-          --exclude='${{ github.workspace }}/doc/website/overrides/'
-          --remap='(file://.*)/holoscan-sdk/(.*) https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/$2'
-          ${{ steps.changed-files.outputs.changed_files_list }}
-        fail: true
-        failIfEmpty: false
-        jobSummary: true
+      working-directory: .github/workflows
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        manifest="${RUNNER_TEMP}/changed_doc_files.txt"
+        expected="${RUNNER_TEMP}/changed_doc_files.expected.txt"
+        expanded_inputs="${RUNNER_TEMP}/expanded_changed_doc_files.txt"
+        diagnostics="${RUNNER_TEMP}/expanded_changed_doc_files.stderr"
+        lychee_args=(--files-from "${manifest}")
+
+        if ! lychee --dump-inputs "${lychee_args[@]}" > "${expanded_inputs}" 2> "${diagnostics}"; then
+          echo "::error::Lychee could not expand the changed-file manifest."
+          sed 's/^/  /' "${diagnostics}" >&2
+          exit 1
+        fi
+        if ! LC_ALL=C diff -u --label expected --label expanded \
+          <(LC_ALL=C sort -- "${expected}") <(LC_ALL=C sort -- "${expanded_inputs}"); then
+          echo "::error::Lychee expanded $(wc -l < "${expanded_inputs}") inputs; expected $(wc -l < "${expected}")."
+          exit 1
+        fi
+
+        report="${RUNNER_TEMP}/lychee-pr.md"
+        status=0
+        lychee --format markdown --mode task --output "${report}" "${lychee_args[@]}" || status=$?
+        if [[ ! -f "${report}" ]]; then
+          echo "::error::Lychee did not produce a report."
+          exit 1
+        fi
+        cat -- "${report}"
+        cat -- "${report}" > "${GITHUB_STEP_SUMMARY}"
+        exit "${status}"
 
     - name: URL checker (all files)
       if: github.event_name == 'push'
       id: lychee-main
-      uses: lycheeverse/lychee-action@v2
+      uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2
       with:
         workingDirectory: .github/workflows
         args: >-
-          --accept=200,403,429
-          --verbose
-          --no-progress
-          --root-dir=${{ github.workspace }}
-          --exclude='${{ github.workspace }}/doc/website/overrides/'
-          --remap='(file://.*)/holoscan-sdk/(.*) https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/$2'
           '${{ github.workspace }}/**/*.md'
           '${{ github.workspace }}/**/*.html'
           '${{ github.workspace }}/**/*.rst'

--- a/.github/workflows/check_urls.yml
+++ b/.github/workflows/check_urls.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      with:
+        persist-credentials: false
 
     - name: Install Lychee for changed-file tests
       uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2
@@ -32,6 +34,7 @@ jobs:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Get changed files in the PR
       if: github.event_name == 'pull_request'
@@ -107,9 +110,9 @@ jobs:
       with:
         workingDirectory: .github/workflows
         args: >-
-          '${{ github.workspace }}/**/*.md'
-          '${{ github.workspace }}/**/*.html'
-          '${{ github.workspace }}/**/*.rst'
+          '${{ github.workspace }}/**/*.[mM][dD]'
+          '${{ github.workspace }}/**/*.[hH][tT][mM][lL]'
+          '${{ github.workspace }}/**/*.[rR][sS][tT]'
         fail: true
         failIfEmpty: false
         jobSummary: true

--- a/.github/workflows/check_urls.yml
+++ b/.github/workflows/check_urls.yml
@@ -12,7 +12,7 @@ jobs:
   test-changed-file-handling:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
     - name: Install Lychee for changed-file tests
       uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8  # v2
@@ -29,7 +29,7 @@ jobs:
     needs: test-changed-file-handling
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/lychee.toml
+++ b/.github/workflows/lychee.toml
@@ -17,7 +17,6 @@ verbose = "info"
 no_progress = true
 accept = ["200", "403", "429"]
 hidden = true
-glob_ignore_case = true
 root_dir = "../.."
 exclude = ['^file://.*/doc/website/overrides/']
 remap = ["(file://.*)/holoscan-sdk/(.*) https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/$2"]

--- a/.github/workflows/lychee.toml
+++ b/.github/workflows/lychee.toml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+verbose = "info"
+no_progress = true
+accept = ["200", "403", "429"]
+hidden = true
+glob_ignore_case = true
+root_dir = "../.."
+exclude = ['^file://.*/doc/website/overrides/']
+remap = ["(file://.*)/holoscan-sdk/(.*) https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/$2"]

--- a/.github/workflows/scripts/get_changed_doc_files.sh
+++ b/.github/workflows/scripts/get_changed_doc_files.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+: "${BASE_REF:?BASE_REF must be set}"
+: "${WORKSPACE:?WORKSPACE must be set}"
+: "${RUNNER_TEMP:?RUNNER_TEMP must be set}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set}"
+
+manifest="${RUNNER_TEMP}/changed_doc_files.txt"
+expected_paths="${RUNNER_TEMP}/changed_doc_files.expected.txt"
+diff_list="${RUNNER_TEMP}/changed_files.z"
+: > "${manifest}"
+: > "${expected_paths}"
+
+if ! git diff -z --name-only --diff-filter=d "origin/${BASE_REF}...HEAD" -- > "${diff_list}"; then
+  printf -v quoted_ref '%q' "${BASE_REF}"
+  echo "::error::Could not diff against origin/${quoted_ref}; refusing to skip the link check."
+  exit 1
+fi
+
+changed_file_count=0
+while IFS= read -r -d '' file; do
+  case "${file##*.}" in
+    [mM][dD]|[hH][tT][mM][lL]|[rR][sS][tT]) ;;
+    *) continue ;;
+  esac
+
+  # Lychee's --files-from format is line-delimited, and its Markdown report
+  # renders input names verbatim. Reject line breaks before writing or logging
+  # the filename so it cannot create a forged workflow command.
+  if [[ "${file}" == *$'\n'* || "${file}" == *$'\r'* ]]; then
+    printf -v quoted_file '%q' "${file}"
+    echo "::error::Documentation filename contains an unsupported line break: ${quoted_file}"
+    exit 1
+  fi
+
+  # --files-from still treats each line as a glob pattern. Encode Lychee's
+  # glob metacharacters as literal character classes, matching Rust glob's
+  # Pattern::escape behavior while leaving spaces unchanged.
+  path="${WORKSPACE}/${file}"
+  glob_escaped=""
+  for ((index = 0; index < ${#path}; index++)); do
+    character="${path:index:1}"
+    case "${character}" in
+      '?'|'*'|'['|']') glob_escaped+="[${character}]" ;;
+      *) glob_escaped+="${character}" ;;
+    esac
+  done
+  printf '%s\n' "${glob_escaped}" >> "${manifest}"
+  printf '%s\n' "${path}" >> "${expected_paths}"
+  changed_file_count=$((changed_file_count + 1))
+done < "${diff_list}"
+
+if [[ "${changed_file_count}" -gt 0 ]]; then
+  echo "any_changed=true" >> "${GITHUB_OUTPUT}"
+else
+  echo "any_changed=false" >> "${GITHUB_OUTPUT}"
+fi
+echo "changed_file_count=${changed_file_count}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/scripts/test_check_urls_changed_files.sh
+++ b/.github/workflows/scripts/test_check_urls_changed_files.sh
@@ -244,7 +244,7 @@ test_reports_no_changed_documents() {
   fi
 }
 
-test_config_expands_hidden_glob_paths() {
+test_config_preserves_manifest_case_and_expands_hidden_paths() {
   local case_dir="${test_tmp}/lychee-config"
   local actual="${case_dir}/actual"
   local config_dir
@@ -254,12 +254,13 @@ test_config_expands_hidden_glob_paths() {
   local manifest="${case_dir}/manifest"
 
   if [[ -z "${lychee_bin}" ]] || [[ ! -r "${lychee_config}" ]]; then
-    fail "Lychee config expands hidden and case-insensitive glob paths"
+    fail "Lychee config preserves manifest case and expands hidden paths"
     return
   fi
   config_dir="$(cd "$(dirname "${lychee_config}")" && pwd)"
   mkdir -p "${case_dir}/.github" "${case_dir}/docs"
   : > "${case_dir}/.github/guide.md"
+  : > "${case_dir}/docs/.HIDDEN[1].md"
   : > "${case_dir}/docs/.hidden[1].md"
   : > "${case_dir}/docs/normal.md"
   : > "${case_dir}/docs/UPPER.MD"
@@ -271,6 +272,7 @@ test_config_expands_hidden_glob_paths() {
     "${case_dir}/docs/normal.md" > "${expected}"
   printf '%s\n' \
     "${case_dir}/.github/guide.md" \
+    "${case_dir}/docs/.HIDDEN[1].md" \
     "${case_dir}/docs/.hidden[1].md" \
     "${case_dir}/docs/normal.md" \
     "${case_dir}/docs/UPPER.MD" > "${glob_expected}"
@@ -279,11 +281,11 @@ test_config_expands_hidden_glob_paths() {
       --files-from "${manifest}") > "${actual}" 2> "${case_dir}/diagnostics" ||
     ! cmp -s <(LC_ALL=C sort "${expected}") <(LC_ALL=C sort "${actual}") ||
     ! (cd "${config_dir}" && "${lychee_bin}" --dump-inputs \
-      "${case_dir}/**/*.md") > "${glob_actual}" 2>> "${case_dir}/diagnostics" ||
+      "${case_dir}/**/*.[mM][dD]") > "${glob_actual}" 2>> "${case_dir}/diagnostics" ||
     ! cmp -s <(LC_ALL=C sort "${glob_expected}") <(LC_ALL=C sort "${glob_actual}"); then
-    fail "Lychee config expands hidden and case-insensitive glob paths"
+    fail "Lychee config preserves manifest case and expands hidden paths"
   else
-    pass "Lychee config expands hidden and case-insensitive glob paths"
+    pass "Lychee config preserves manifest case and expands hidden paths"
   fi
 }
 
@@ -317,7 +319,7 @@ test_fails_when_git_diff_fails
 test_rejects_line_breaks_before_emitting_paths
 test_handles_large_changed_file_sets_outside_action_inputs
 test_reports_no_changed_documents
-test_config_expands_hidden_glob_paths
+test_config_preserves_manifest_case_and_expands_hidden_paths
 test_config_excludes_only_local_override_files
 
 exit "${failures}"

--- a/.github/workflows/scripts/test_check_urls_changed_files.sh
+++ b/.github/workflows/scripts/test_check_urls_changed_files.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+collector="${1:-.github/workflows/scripts/get_changed_doc_files.sh}"
+lychee_config="${2:-.github/workflows/lychee.toml}"
+lychee_bin="$(command -v "${LYCHEE:-lychee}" || true)"
+test_tmp="$(mktemp -d)"
+trap 'rm -rf -- "${test_tmp}"' EXIT
+
+if [[ ! -r "${collector}" ]]; then
+  echo "not ok - collector is readable: ${collector}" >&2
+  exit 1
+fi
+
+failures=0
+
+fail() {
+  echo "not ok - $1" >&2
+  failures=$((failures + 1))
+}
+
+pass() {
+  echo "ok - $1"
+}
+
+# The collector runs as its own Bash process. Exporting this function gives it
+# a deterministic git stub while still exercising its real argv construction.
+git() {
+  printf '%s\0' "$@" > "${GIT_ARGS_FILE}"
+  if [[ "${GIT_EXIT_STATUS}" -ne 0 ]]; then
+    return "${GIT_EXIT_STATUS}"
+  fi
+  command cat -- "${GIT_PATHS_FILE}"
+}
+export -f git
+
+run_collector() {
+  local case_name="$1"
+  local git_status="$2"
+  shift 2
+
+  LAST_CASE_DIR="${test_tmp}/${case_name}"
+  mkdir -p "${LAST_CASE_DIR}"
+  printf '%s\0' "$@" > "${LAST_CASE_DIR}/git-paths"
+  : > "${LAST_CASE_DIR}/github-output"
+
+  set +e
+  BASE_REF="main" \
+    WORKSPACE="/workspace" \
+    RUNNER_TEMP="${LAST_CASE_DIR}" \
+    CHANGED_DOCS_MANIFEST="${LAST_CASE_DIR}/ambient-manifest" \
+    CHANGED_DOCS_EXPECTED="${LAST_CASE_DIR}/ambient-expected-paths" \
+    GITHUB_OUTPUT="${LAST_CASE_DIR}/github-output" \
+    GIT_ARGS_FILE="${LAST_CASE_DIR}/git-args" \
+    GIT_PATHS_FILE="${LAST_CASE_DIR}/git-paths" \
+    GIT_EXIT_STATUS="${git_status}" \
+    bash "${collector}" > "${LAST_CASE_DIR}/log" 2>&1
+  LAST_STATUS=$?
+  set -e
+}
+
+assert_git_argv() {
+  local label="$1"
+  local -a actual=()
+  local -a expected=(
+    diff
+    -z
+    --name-only
+    --diff-filter=d
+    origin/main...HEAD
+    --
+  )
+  local index
+
+  mapfile -d '' -t actual < "${LAST_CASE_DIR}/git-args"
+  if [[ "${#actual[@]}" -ne "${#expected[@]}" ]]; then
+    fail "${label}"
+    return
+  fi
+  for index in "${!expected[@]}"; do
+    if [[ "${actual[index]}" != "${expected[index]}" ]]; then
+      fail "${label}"
+      return
+    fi
+  done
+  pass "${label}"
+}
+
+test_selects_and_escapes_documentation_paths() {
+  local malicious_path="docs/evil\$(printf injected > ${test_tmp}/INJECTED).md"
+  local -a changed_paths=(
+    "applications/template/{{cookiecutter.project_slug}}/README.md"
+    "docs/with space.html"
+    "docs/ümlaut.rst"
+    "docs/uppercase.MD"
+    "docs/uppercase.HTML"
+    "docs/uppercase.RsT"
+    "${malicious_path}"
+    "docs/.hidden[1].md"
+    "docs/report*.md"
+    "docs/report?.rst"
+    "docs/literal]end.html"
+    "docs/argument--mode-task.md"
+    "docs/not-documentation.txt"
+  )
+  local expected_manifest="${test_tmp}/expected-manifest"
+  local expected_paths="${test_tmp}/expected-paths"
+
+  run_collector selection 0 "${changed_paths[@]}"
+
+  printf '%s\n' \
+    "/workspace/applications/template/{{cookiecutter.project_slug}}/README.md" \
+    "/workspace/docs/with space.html" \
+    "/workspace/docs/ümlaut.rst" \
+    "/workspace/docs/uppercase.MD" \
+    "/workspace/docs/uppercase.HTML" \
+    "/workspace/docs/uppercase.RsT" \
+    "/workspace/${malicious_path}" \
+    "/workspace/docs/.hidden[[]1[]].md" \
+    "/workspace/docs/report[*].md" \
+    "/workspace/docs/report[?].rst" \
+    "/workspace/docs/literal[]]end.html" \
+    "/workspace/docs/argument--mode-task.md" > "${expected_manifest}"
+  printf '%s\n' \
+    "/workspace/applications/template/{{cookiecutter.project_slug}}/README.md" \
+    "/workspace/docs/with space.html" \
+    "/workspace/docs/ümlaut.rst" \
+    "/workspace/docs/uppercase.MD" \
+    "/workspace/docs/uppercase.HTML" \
+    "/workspace/docs/uppercase.RsT" \
+    "/workspace/${malicious_path}" \
+    "/workspace/docs/.hidden[1].md" \
+    "/workspace/docs/report*.md" \
+    "/workspace/docs/report?.rst" \
+    "/workspace/docs/literal]end.html" \
+    "/workspace/docs/argument--mode-task.md" > "${expected_paths}"
+
+  if [[ "${LAST_STATUS}" -ne 0 ]] ||
+    ! cmp -s "${expected_manifest}" "${LAST_CASE_DIR}/changed_doc_files.txt" ||
+    ! cmp -s "${expected_paths}" "${LAST_CASE_DIR}/changed_doc_files.expected.txt" ||
+    [[ -e "${LAST_CASE_DIR}/ambient-manifest" ]] ||
+    [[ -e "${LAST_CASE_DIR}/ambient-expected-paths" ]] ||
+    ! grep -qx 'any_changed=true' "${LAST_CASE_DIR}/github-output" ||
+    ! grep -qx 'changed_file_count=12' "${LAST_CASE_DIR}/github-output" ||
+    grep -q '^changed_files_list=' "${LAST_CASE_DIR}/github-output" ||
+    [[ -e "${test_tmp}/INJECTED" ]]; then
+    fail "selects each documentation extension without evaluating filename bytes"
+  else
+    pass "selects each documentation extension without evaluating filename bytes"
+  fi
+
+  assert_git_argv "uses a NUL diff, excludes deletions, and diffs from the merge base"
+}
+
+test_fails_when_git_diff_fails() {
+  run_collector diff-failure 42
+
+  if [[ "${LAST_STATUS}" -eq 0 ]] || [[ -s "${LAST_CASE_DIR}/github-output" ]]; then
+    fail "fails closed when git diff fails"
+  else
+    pass "fails closed when git diff fails"
+  fi
+}
+
+test_rejects_line_breaks_before_emitting_paths() {
+  local newline_path=$'docs/x\n::error file=README.md,line=1::pwned.md'
+  local carriage_return_path=$'docs/x\r::error file=README.md,line=1::pwned.rst'
+  local case_name
+  local path
+
+  for case_name in newline carriage-return; do
+    if [[ "${case_name}" == newline ]]; then
+      path="${newline_path}"
+    else
+      path="${carriage_return_path}"
+    fi
+    run_collector "${case_name}" 0 "${path}"
+
+    if [[ "${LAST_STATUS}" -eq 0 ]] ||
+      [[ ! -f "${LAST_CASE_DIR}/changed_doc_files.txt" ]] ||
+      [[ -s "${LAST_CASE_DIR}/changed_doc_files.txt" ]] ||
+      [[ ! -f "${LAST_CASE_DIR}/changed_doc_files.expected.txt" ]] ||
+      [[ -s "${LAST_CASE_DIR}/changed_doc_files.expected.txt" ]] ||
+      [[ -s "${LAST_CASE_DIR}/github-output" ]] ||
+      grep -q '^::error file=README.md,line=1::' "${LAST_CASE_DIR}/log"; then
+      fail "rejects ${case_name} filenames before emitting their bytes"
+    else
+      pass "rejects ${case_name} filenames before emitting their bytes"
+    fi
+  done
+}
+
+test_handles_large_changed_file_sets_outside_action_inputs() {
+  local -a changed_paths=()
+  local index
+  local name
+
+  for ((index = 0; index < 600; index++)); do
+    printf -v name 'docs/%04d-%0235d.md' "${index}" 0
+    changed_paths+=("${name}")
+  done
+  run_collector large-list 0 "${changed_paths[@]}"
+
+  if [[ "${LAST_STATUS}" -ne 0 ]] ||
+    [[ "$(wc -l < "${LAST_CASE_DIR}/changed_doc_files.txt")" -ne 600 ]] ||
+    [[ ! -f "${LAST_CASE_DIR}/changed_doc_files.expected.txt" ]] ||
+    [[ "$(wc -l < "${LAST_CASE_DIR}/changed_doc_files.expected.txt")" -ne 600 ]] ||
+    [[ "$(wc -c < "${LAST_CASE_DIR}/github-output")" -ge 1024 ]] ||
+    grep -q '^changed_files_list=' "${LAST_CASE_DIR}/github-output"; then
+    fail "keeps large filename lists in the manifest"
+  else
+    pass "keeps large filename lists in the manifest"
+  fi
+}
+
+test_reports_no_changed_documents() {
+  run_collector no-docs 0 "src/code.cpp" "images/logo.png" "notes.txt"
+
+  if [[ "${LAST_STATUS}" -ne 0 ]] ||
+    [[ -s "${LAST_CASE_DIR}/changed_doc_files.txt" ]] ||
+    [[ ! -f "${LAST_CASE_DIR}/changed_doc_files.expected.txt" ]] ||
+    [[ -s "${LAST_CASE_DIR}/changed_doc_files.expected.txt" ]] ||
+    ! grep -qx 'any_changed=false' "${LAST_CASE_DIR}/github-output" ||
+    ! grep -qx 'changed_file_count=0' "${LAST_CASE_DIR}/github-output"; then
+    fail "reports an empty documentation manifest"
+  else
+    pass "reports an empty documentation manifest"
+  fi
+}
+
+test_config_expands_hidden_glob_paths() {
+  local case_dir="${test_tmp}/lychee-config"
+  local actual="${case_dir}/actual"
+  local config_dir
+  local expected="${case_dir}/expected"
+  local glob_actual="${case_dir}/glob-actual"
+  local glob_expected="${case_dir}/glob-expected"
+  local manifest="${case_dir}/manifest"
+
+  if [[ -z "${lychee_bin}" ]] || [[ ! -r "${lychee_config}" ]]; then
+    fail "Lychee config expands hidden and case-insensitive glob paths"
+    return
+  fi
+  config_dir="$(cd "$(dirname "${lychee_config}")" && pwd)"
+  mkdir -p "${case_dir}/.github" "${case_dir}/docs"
+  : > "${case_dir}/.github/guide.md"
+  : > "${case_dir}/docs/.hidden[1].md"
+  : > "${case_dir}/docs/normal.md"
+  : > "${case_dir}/docs/UPPER.MD"
+  printf '%s\n' \
+    "${case_dir}/docs/.hidden[[]1[]].md" \
+    "${case_dir}/docs/normal.md" > "${manifest}"
+  printf '%s\n' \
+    "${case_dir}/docs/.hidden[1].md" \
+    "${case_dir}/docs/normal.md" > "${expected}"
+  printf '%s\n' \
+    "${case_dir}/.github/guide.md" \
+    "${case_dir}/docs/.hidden[1].md" \
+    "${case_dir}/docs/normal.md" \
+    "${case_dir}/docs/UPPER.MD" > "${glob_expected}"
+
+  if ! (cd "${config_dir}" && "${lychee_bin}" --dump-inputs \
+      --files-from "${manifest}") > "${actual}" 2> "${case_dir}/diagnostics" ||
+    ! cmp -s <(LC_ALL=C sort "${expected}") <(LC_ALL=C sort "${actual}") ||
+    ! (cd "${config_dir}" && "${lychee_bin}" --dump-inputs \
+      "${case_dir}/**/*.md") > "${glob_actual}" 2>> "${case_dir}/diagnostics" ||
+    ! cmp -s <(LC_ALL=C sort "${glob_expected}") <(LC_ALL=C sort "${glob_actual}"); then
+    fail "Lychee config expands hidden and case-insensitive glob paths"
+  else
+    pass "Lychee config expands hidden and case-insensitive glob paths"
+  fi
+}
+
+test_config_excludes_only_local_override_files() {
+  local case_dir="${test_tmp}/lychee-excludes"
+  local config_dir
+  local output="${case_dir}/output"
+
+  if [[ -z "${lychee_bin}" ]] || [[ ! -r "${lychee_config}" ]]; then
+    fail "Lychee config excludes only local website overrides"
+    return
+  fi
+  config_dir="$(cd "$(dirname "${lychee_config}")" && pwd)"
+  mkdir -p "${case_dir}"
+  printf '%s\n' \
+    '[local](file:///workspace/holohub/doc/website/overrides/missing.html)' \
+    '[remote](https://openai.com/doc/website/overrides/page)' > "${case_dir}/links.md"
+
+  if ! (cd "${config_dir}" && "${lychee_bin}" --dump \
+      "${case_dir}/links.md") > "${output}" 2> "${case_dir}/diagnostics" ||
+    ! grep -Eq '^file:///workspace/holohub/doc/website/overrides/missing\.html .* \[excluded\]$' "${output}" ||
+    grep -Eq '^https://openai\.com/doc/website/overrides/page .* \[excluded\]$' "${output}"; then
+    fail "Lychee config excludes only local website overrides"
+  else
+    pass "Lychee config excludes only local website overrides"
+  fi
+}
+
+test_selects_and_escapes_documentation_paths
+test_fails_when_git_diff_fails
+test_rejects_line_breaks_before_emitting_paths
+test_handles_large_changed_file_sets_outside_action_inputs
+test_reports_no_changed_documents
+test_config_expands_hidden_glob_paths
+test_config_excludes_only_local_override_files
+
+exit "${failures}"


### PR DESCRIPTION
## Summary

- Make PR URL checks NUL-safe and fail closed for malformed or unexpanded paths.
- Centralize Lychee settings and include hidden and uppercase documentation.
- Add regression coverage for adversarial filenames and changed-file selection.

## Testing

- `./holohub run-container -- "./holohub lint --install-dependencies; ./holohub lint"`
- Changed-file regression suite against Lychee 0.24.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation link checks for pull requests, including special characters and empty change sets.
  * Added clearer validation and error reporting when changed-document checks cannot be completed.
* **New Features**
  * Link-check results now include expanded reports in workflow summaries.
  * Added support for configurable accepted statuses, hidden files, and local SDK link mapping.
* **Tests**
  * Added comprehensive coverage for changed-document detection, filename handling, large file lists, and link-check configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->