### PR TITLE
App: document imx274_gpu_resident HSB 2.5.x requirement

### DIFF
--- a/applications/imx274_gpu_resident/README.md
+++ b/applications/imx274_gpu_resident/README.md
@@ -59,8 +59,9 @@ For step-by-step instructions for building and running the application, refer to
 
 - NVIDIA IGX Orin w/ Ampere or later discrete GPUs (e.g. RTX A6000, RTX Ada
   6000, etc.)
-- Holoscan SDK 4.0.0 or later
-- Holoscan Sensor Bridge (HSB) 2.5.0 or later
+- Holoscan SDK 4.0.0 or later, built against Holoscan Sensor Bridge (HSB) 2.5.x
+- Holoscan Sensor Bridge (HSB) 2.5.x (2.6.0 and later are not supported yet, see
+  [HSB version compatibility](#hsb-version-compatibility))
 - [Lattice CPNX100-ETH-SENSOR-BRIDGE board](https://www.latticesemi.com/en/Products/DevelopmentBoardsAndKits/lattice-nvidia-edge-ai)
 - IMX274 Camera
 - ConntectX SmartNIC Transceivers and adapters
@@ -69,6 +70,18 @@ For step-by-step instructions for building and running the application, refer to
 - (Optional) [NVIDIA DOCA SDK 3.2.1+](https://docs.nvidia.com/doca/sdk/doca-developer-guide/index.html) with GPUNetIO support
 
 Hardware details available in [Holoscan Sensor Bridge](https://docs.nvidia.com/holoscan/sensor-bridge/latest/index.html).
+
+### HSB Version Compatibility
+
+This application and its GPU-resident HSB operators are written against the HSB
+2.5.x API and must be built in a container whose base image bundles HSB 2.5.x,
+such as `nvcr.io/nvidia/clara-holoscan/holoscan:v4.0.0-cuda12-dgpu`.
+
+Holoscan SDK 4.4.0 container images bundle **HSB 2.6.0**, which is not API
+compatible with this application. Building on top of a Holoscan SDK 4.4.0 base
+image fails at configure or compile time (see [Known Issues](#known-issues) and
+the known HSB compatibility issue). Use a Holoscan SDK
+base image that bundles HSB 2.5.x until this application is updated for HSB 2.6.
 
 ### NVIDIA Driver Version
 
@@ -157,6 +170,10 @@ From the **HoloHub repository root**:
 ```
 
 The Holoscan `v4.0.0-cuda12-dgpu` container image is built on top of a Holoscan container that **already includes HSB** (e.g. installed at `/opt/nvidia/hololink`).
+
+**Note:** Pass a base image that bundles HSB 2.5.x. Overriding the base image
+with a Holoscan SDK 4.4.0 image (`--base-img nvcr.io/.../holoscan:v4.4.0.0-cuda12-dgpu`)
+is not supported; see [HSB version compatibility](#hsb-version-compatibility).
 
 **Note:** You can pull the base image before building, e.g.
 `docker pull nvcr.io/nvidia/clara-holoscan/holoscan:v4.0.0-cuda12-dgpu`
@@ -308,3 +325,9 @@ The graphs below illustrate the latency comparison between the CPU-driven (vanil
   then Ctrl+C signal may not reach the application, and the application may not
   shutdown gracefully with all the measurements being printed.
 - Pressing Ctrl+C for the DOCA GPUNetIO version does not show any measurement outputs at the end.
+- Building against HSB 2.6.0 (bundled in Holoscan SDK 4.4.0
+  container images) fails. The build stops either in CMake configuration with
+  `The imported target "hololink::emulation_host" references the file
+  "/opt/nvidia/hololink/lib/libemulation_host.a" but this file does not exist`,
+  or later with HSB API compatibility errors. Build with a base image that
+  bundles HSB 2.5.x instead.

--- a/applications/imx274_gpu_resident/README.md
+++ b/applications/imx274_gpu_resident/README.md
@@ -59,6 +59,7 @@ For step-by-step instructions for building and running the application, refer to
 
 - NVIDIA IGX Orin w/ Ampere or later discrete GPUs (e.g. RTX A6000, RTX Ada
   6000, etc.)
+- IGX Thor is not supported
 - Holoscan SDK 4.0.0 or later, built against Holoscan Sensor Bridge (HSB) 2.5.x
 - Holoscan Sensor Bridge (HSB) 2.5.x (2.6.0 and later are not supported yet, see
   [HSB version compatibility](#hsb-version-compatibility))

--- a/applications/imx274_gpu_resident/README.md
+++ b/applications/imx274_gpu_resident/README.md
@@ -45,12 +45,15 @@ Before getting started, make sure to review the [Requirements](#requirements) se
 You can simply run application with the following command from the repository root:
 
 ```bash
-./holohub run imx274_gpu_resident
+./holohub run imx274_gpu_resident --base-img nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda12-dgpu
 # or
-./holohub run imx274_gpu_resident doca
+./holohub run imx274_gpu_resident doca --base-img nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda12-dgpu
 ```
 
 This will build and launch the development container, build the operators and build and run the application.
+The `--base-img` option is required: the default HoloHub base image is a Holoscan SDK 4.4.0 or later
+container that bundles HSB 2.6.0, which this application does not support yet (see
+[HSB version compatibility](#hsb-version-compatibility)).
 For more details on using the Holohub CLI, see the [Holohub CLI Reference Guide](../../utilities/cli/cli_reference.md).
 
 For step-by-step instructions for building and running the application, refer to the [Detailed Build and Run Instructions](#detailed-build-and-run-instructions).
@@ -75,13 +78,15 @@ Hardware details available in [Holoscan Sensor Bridge](https://docs.nvidia.com/h
 ### HSB Version Compatibility
 
 This application and its GPU-resident HSB operators are written against the HSB
-2.5.x API and must be built in a container whose base image bundles HSB 2.5.x,
-such as `nvcr.io/nvidia/clara-holoscan/holoscan:v4.0.0-cuda12-dgpu`.
+2.5.x API and must be built in a container whose base image bundles HSB 2.5.x.
+Holoscan SDK 4.0.0 through 4.3.0 discrete GPU container images bundle HSB 2.5.0;
+`nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda12-dgpu` is the latest compatible
+base image.
 
-Holoscan SDK 4.4.0 container images bundle **HSB 2.6.0**, which is not API
-compatible with this application. Building on top of a Holoscan SDK 4.4.0 base
+Holoscan SDK 4.4.0 and later container images bundle **HSB 2.6.0**, which is not API
+compatible with this application. Building on top of a Holoscan SDK 4.4.0 or later base
 image fails at configure or compile time (see [Known Issues](#known-issues) and
-the known HSB compatibility issue). Use a Holoscan SDK
+the known HSB compatibility issue). Pass `--base-img` with a Holoscan SDK
 base image that bundles HSB 2.5.x until this application is updated for HSB 2.6.
 
 ### NVIDIA Driver Version
@@ -165,19 +170,19 @@ Ensure you are in the HoloHub repository root for all commands below.
 From the **HoloHub repository root**:
 
 ```bash
-./holohub build-container imx274_gpu_resident
+./holohub build-container imx274_gpu_resident --base-img nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda12-dgpu
 # or
-./holohub build-container imx274_gpu_resident doca
+./holohub build-container imx274_gpu_resident doca --base-img nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda12-dgpu
 ```
 
-The Holoscan `v4.0.0-cuda12-dgpu` container image is built on top of a Holoscan container that **already includes HSB** (e.g. installed at `/opt/nvidia/hololink`).
+The Holoscan `v4.3.0-cuda12-dgpu` container image **already includes HSB 2.5.0** (installed at `/opt/nvidia/hololink`).
 
-**Note:** Pass a base image that bundles HSB 2.5.x. Overriding the base image
-with a Holoscan SDK 4.4.0 image (`--base-img nvcr.io/nvidia/clara-holoscan/holoscan:v4.4.0-cuda12-dgpu`)
-is not supported; see [HSB version compatibility](#hsb-version-compatibility).
+**Note:** Always pass a base image that bundles HSB 2.5.x. The default HoloHub base image and
+Holoscan SDK 4.4.0 or later images (e.g. `nvcr.io/nvidia/clara-holoscan/holoscan:v4.4.0-cuda12-dgpu`)
+bundle HSB 2.6.0 and are not supported; see [HSB version compatibility](#hsb-version-compatibility).
 
 **Note:** You can pull the base image before building, e.g.
-`docker pull nvcr.io/nvidia/clara-holoscan/holoscan:v4.0.0-cuda12-dgpu`
+`docker pull nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda12-dgpu`
 
 ##### Verify the Image
 
@@ -326,8 +331,8 @@ The graphs below illustrate the latency comparison between the CPU-driven (vanil
   then Ctrl+C signal may not reach the application, and the application may not
   shutdown gracefully with all the measurements being printed.
 - Pressing Ctrl+C for the DOCA GPUNetIO version does not show any measurement outputs at the end.
-- Building against HSB 2.6.0 (bundled in Holoscan SDK 4.4.0
-  container images) fails. The build stops either in CMake configuration with
+- Building against HSB 2.6.0 (bundled in Holoscan SDK 4.4.0 and later
+  container images, including the default HoloHub base image) fails. The build stops either in CMake configuration with
   `The imported target "hololink::emulation_host" references the file
   "/opt/nvidia/hololink/lib/libemulation_host.a" but this file does not exist`,
   or later with HSB API compatibility errors. Build with a base image that

--- a/applications/imx274_gpu_resident/README.md
+++ b/applications/imx274_gpu_resident/README.md
@@ -172,7 +172,7 @@ From the **HoloHub repository root**:
 The Holoscan `v4.0.0-cuda12-dgpu` container image is built on top of a Holoscan container that **already includes HSB** (e.g. installed at `/opt/nvidia/hololink`).
 
 **Note:** Pass a base image that bundles HSB 2.5.x. Overriding the base image
-with a Holoscan SDK 4.4.0 image (`--base-img nvcr.io/.../holoscan:v4.4.0.0-cuda12-dgpu`)
+with a Holoscan SDK 4.4.0 image (`--base-img nvcr.io/.../holoscan:v4.4.0-cuda12-dgpu`)
 is not supported; see [HSB version compatibility](#hsb-version-compatibility).
 
 **Note:** You can pull the base image before building, e.g.

--- a/applications/imx274_gpu_resident/README.md
+++ b/applications/imx274_gpu_resident/README.md
@@ -206,9 +206,9 @@ This uses the application's configured Docker options for HSB (privileged mode, 
 After launching the container with the command above, you can build the application:
 
 ```bash
-./holohub build imx274_gpu_resident
+./holohub build imx274_gpu_resident --base-img nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda12-dgpu
 # or, if building with DOCA GPUNetIO support:
-./holohub build imx274_gpu_resident doca
+./holohub build imx274_gpu_resident doca --base-img nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda12-dgpu
 ```
 
 ##### List Buildable Components

--- a/applications/imx274_gpu_resident/README.md
+++ b/applications/imx274_gpu_resident/README.md
@@ -173,7 +173,7 @@ From the **HoloHub repository root**:
 The Holoscan `v4.0.0-cuda12-dgpu` container image is built on top of a Holoscan container that **already includes HSB** (e.g. installed at `/opt/nvidia/hololink`).
 
 **Note:** Pass a base image that bundles HSB 2.5.x. Overriding the base image
-with a Holoscan SDK 4.4.0 image (`--base-img nvcr.io/.../holoscan:v4.4.0-cuda12-dgpu`)
+with a Holoscan SDK 4.4.0 image (`--base-img nvcr.io/nvidia/clara-holoscan/holoscan:v4.4.0-cuda12-dgpu`)
 is not supported; see [HSB version compatibility](#hsb-version-compatibility).
 
 **Note:** You can pull the base image before building, e.g.

--- a/operators/hsb_roce_receiver_doca_gpunetio/README.md
+++ b/operators/hsb_roce_receiver_doca_gpunetio/README.md
@@ -25,7 +25,8 @@ The `DocaRoceReceiverOp` is a GPU-resident Holoscan operator that:
 
 - Holoscan SDK 4.0.0 or later
 - [NVIDIA DOCA SDK 3.2.1+](https://docs.nvidia.com/doca/sdk/doca-developer-guide/index.html) with GPUNetIO support
-- Holoscan Sensor Bridge (HSB) 2.5.0 or later
+- Holoscan Sensor Bridge (HSB) 2.5.x (2.6.0 and later are not supported yet, see
+  the known HSB compatibility issue)
 - CUDA-capable GPU with GPUDirect RDMA support (Ampere or later, e.g. RTX A6000)
 - aarch64 platform (e.g. IGX Orin)
 - RoCE-capable NIC (e.g., ConnectX)

--- a/operators/hsb_roce_receiver_doca_gpunetio/README.md
+++ b/operators/hsb_roce_receiver_doca_gpunetio/README.md
@@ -26,7 +26,7 @@ The `DocaRoceReceiverOp` is a GPU-resident Holoscan operator that:
 - Holoscan SDK 4.0.0 or later
 - [NVIDIA DOCA SDK 3.2.1+](https://docs.nvidia.com/doca/sdk/doca-developer-guide/index.html) with GPUNetIO support
 - Holoscan Sensor Bridge (HSB) 2.5.x (2.6.0 and later are not supported yet, see
-  the known HSB compatibility issue)
+  the [known HSB compatibility issue](../../applications/imx274_gpu_resident/README.md#hsb-version-compatibility))
 - CUDA-capable GPU with GPUDirect RDMA support (Ampere or later, e.g. RTX A6000)
 - aarch64 platform (e.g. IGX Orin)
 - RoCE-capable NIC (e.g., ConnectX)

--- a/operators/hsb_roce_receiver_doca_gpunetio/README.md
+++ b/operators/hsb_roce_receiver_doca_gpunetio/README.md
@@ -70,13 +70,13 @@ This operator is built as part of the HoloHub build system when the `doca` mode
 is selected:
 
 ```bash
-./holohub build imx274_gpu_resident doca
+./holohub build imx274_gpu_resident doca --base-img nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda12-dgpu
 ```
 
 Or enable the operator explicitly:
 
 ```bash
-./holohub build imx274_gpu_resident --build-with hsb_roce_receiver_doca_gpunetio
+./holohub build imx274_gpu_resident --build-with hsb_roce_receiver_doca_gpunetio --base-img nvcr.io/nvidia/clara-holoscan/holoscan:v4.3.0-cuda12-dgpu
 ```
 
 ## Dependencies

--- a/operators/hsb_roce_receiver_nmd/README.md
+++ b/operators/hsb_roce_receiver_nmd/README.md
@@ -18,7 +18,8 @@ The `RoceReceiverOp` is a Holoscan operator that:
 ## Requirements
 
 - Holoscan SDK 4.0.0 or later
-- Holoscan Sensor Bridge ("Hololink") library installed and available
+- Holoscan Sensor Bridge ("Hololink") 2.5.x library installed and available
+  (2.6.0 and later are not supported yet; see the known HSB compatibility issue)
 - CUDA-capable GPU with GPUDirect RDMA support
 - libibverbs (InfiniBand Verbs library)
 - RoCE-capable NIC (e.g., ConnectX)

--- a/operators/hsb_roce_receiver_nmd/README.md
+++ b/operators/hsb_roce_receiver_nmd/README.md
@@ -19,7 +19,7 @@ The `RoceReceiverOp` is a Holoscan operator that:
 
 - Holoscan SDK 4.0.0 or later
 - Holoscan Sensor Bridge ("Hololink") 2.5.x library installed and available
-  (2.6.0 and later are not supported yet; see the known HSB compatibility issue)
+  (2.6.0 and later are not supported yet; see the [known HSB compatibility issue](../../applications/imx274_gpu_resident/README.md#hsb-version-compatibility))
 - CUDA-capable GPU with GPUDirect RDMA support
 - libibverbs (InfiniBand Verbs library)
 - RoCE-capable NIC (e.g., ConnectX)


### PR DESCRIPTION
Document HSB version support requirement for the IMX274 GPU Resident HoloHub sample application.

The demo application and operator APIs require HSB 2.5.0 and are not updated to support later versions.

Internal tracking: 6359158

Assisted-by: Devin AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated build and run instructions to use Holoscan SDK 4.3.0 discrete-GPU images compatible with HSB 2.5.x.
  * Clarified that IGX Thor and HSB 2.6.0 are unsupported for these applications and operators.
  * Expanded known-issue guidance for SDK 4.4.0 and later, including default HoloHub images.
  * Added links to centralized HSB and Hololink compatibility guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->